### PR TITLE
feat: add URL normalization utilities to prevent double slashes

### DIFF
--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -1,5 +1,6 @@
 use crate::api::ModelsResponse;
 use crate::core::builtin_providers::find_builtin_provider;
+use crate::utils::url::construct_api_url;
 
 pub async fn fetch_models(
     client: &reqwest::Client,
@@ -7,8 +8,9 @@ pub async fn fetch_models(
     api_key: &str,
     provider_name: &str,
 ) -> Result<ModelsResponse, Box<dyn std::error::Error>> {
+    let models_url = construct_api_url(base_url, "models");
     let mut request = client
-        .get(format!("{base_url}/models"))
+        .get(models_url)
         .header("Content-Type", "application/json");
 
     // Handle provider-specific authentication headers

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,5 +1,6 @@
 use crate::core::builtin_providers::load_builtin_providers;
 use crate::core::config::{suggest_provider_id, Config, CustomProvider};
+use crate::utils::url::normalize_base_url;
 use keyring::Entry;
 use ratatui::crossterm::{
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
@@ -251,6 +252,9 @@ impl AuthManager {
             return Err("Base URL cannot be empty".into());
         }
 
+        // Normalize the base URL to remove trailing slashes
+        let normalized_base_url = normalize_base_url(base_url);
+
         let auth_mode = None; // Default to openai mode for now
 
         print!("Enter your API token for {display_name} (press F2 to reveal last 4 chars): ");
@@ -266,7 +270,7 @@ impl AuthManager {
         let custom_provider = CustomProvider::new(
             final_id.clone(),
             display_name.to_string(),
-            base_url.to_string(),
+            normalized_base_url.clone(),
             auth_mode,
         );
 
@@ -274,7 +278,7 @@ impl AuthManager {
         self.store_token(&final_id, &token)?;
 
         println!(
-            "✓ Custom provider '{display_name}' (ID: {final_id}) configured with URL: {base_url}"
+            "✓ Custom provider '{display_name}' (ID: {final_id}) configured with URL: {normalized_base_url}"
         );
 
         Ok(())

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -6,6 +6,7 @@ use crate::core::message::Message;
 use crate::core::text_wrapping::{TextWrapper, WrapConfig};
 use crate::utils::logging::LoggingState;
 use crate::utils::scroll::ScrollCalculator;
+use crate::utils::url::construct_api_url;
 use ratatui::text::Line;
 use reqwest::Client;
 use std::{collections::VecDeque, time::Instant};
@@ -228,7 +229,7 @@ Please either:
 
         // Note: We use the OpenAI API format for all providers including Anthropic
         // This is known to work well with Anthropic's models
-        let api_endpoint = format!("{base_url}/chat/completions");
+        let api_endpoint = construct_api_url(&base_url, "chat/completions");
         eprintln!("🌐 API endpoint: {api_endpoint}");
 
         if let Some(ref log_path) = log_file {

--- a/src/ui/chat_loop.rs
+++ b/src/ui/chat_loop.rs
@@ -9,6 +9,7 @@ use crate::commands::CommandResult;
 use crate::core::app::App;
 use crate::ui::renderer::ui;
 use crate::utils::editor::handle_external_editor;
+use crate::utils::url::construct_api_url;
 use futures_util::StreamExt;
 use ratatui::crossterm::{
     event::{
@@ -151,8 +152,9 @@ pub async fn run_chat(
                                         // Use tokio::select! to race between the HTTP request and cancellation
                                         tokio::select! {
                                                 _ = async {
+                                                    let chat_url = construct_api_url(&base_url, "chat/completions");
                                                     match client
-                                                        .post(format!("{base_url}/chat/completions"))
+                                                        .post(chat_url)
                                                         .header("Authorization", format!("Bearer {api_key}"))
                                                         .header("Content-Type", "application/json")
                                                         .json(&request)
@@ -333,8 +335,9 @@ pub async fn run_chat(
                                 // Use tokio::select! to race between the HTTP request and cancellation
                                 tokio::select! {
                                             _ = async {
+                                                let chat_url = construct_api_url(&base_url, "chat/completions");
                                                 match client
-                                                    .post(format!("{base_url}/chat/completions"))
+                                                    .post(chat_url)
                                                     .header("Authorization", format!("Bearer {api_key}"))
                                                     .header("Content-Type", "application/json")
                                                     .json(&request)
@@ -514,8 +517,9 @@ pub async fn run_chat(
                                     // Use tokio::select! to race between the HTTP request and cancellation
                                     tokio::select! {
                                         _ = async {
+                                            let chat_url = construct_api_url(&base_url, "chat/completions");
                                             match client
-                                                .post(format!("{base_url}/chat/completions"))
+                                                .post(chat_url)
                                                 .header("Authorization", format!("Bearer {api_key}"))
                                                 .header("Content-Type", "application/json")
                                                 .json(&request)

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod editor;
 pub mod logging;
 pub mod scroll;
+pub mod url;

--- a/src/utils/url.rs
+++ b/src/utils/url.rs
@@ -1,0 +1,136 @@
+//! URL utilities for consistent URL handling
+//!
+//! This module provides utilities for normalizing URLs to prevent issues
+//! with trailing slashes when constructing API endpoints.
+
+/// Normalize a base URL by removing trailing slashes
+///
+/// This ensures consistent URL construction when appending endpoints,
+/// preventing double slashes in the final URLs.
+///
+/// # Examples
+///
+/// ```
+/// use chabeau::utils::url::normalize_base_url;
+///
+/// assert_eq!(normalize_base_url("https://api.example.com/v1"), "https://api.example.com/v1");
+/// assert_eq!(normalize_base_url("https://api.example.com/v1/"), "https://api.example.com/v1");
+/// assert_eq!(normalize_base_url("https://api.example.com/v1///"), "https://api.example.com/v1");
+/// ```
+pub fn normalize_base_url(base_url: &str) -> String {
+    base_url.trim_end_matches('/').to_string()
+}
+
+/// Construct a complete API endpoint URL from a base URL and endpoint path
+///
+/// This function normalizes the base URL and safely appends the endpoint,
+/// ensuring there are no double slashes in the result.
+///
+/// # Examples
+///
+/// ```
+/// use chabeau::utils::url::construct_api_url;
+///
+/// assert_eq!(
+///     construct_api_url("https://api.example.com/v1", "chat/completions"),
+///     "https://api.example.com/v1/chat/completions"
+/// );
+/// assert_eq!(
+///     construct_api_url("https://api.example.com/v1/", "chat/completions"),
+///     "https://api.example.com/v1/chat/completions"
+/// );
+/// ```
+pub fn construct_api_url(base_url: &str, endpoint: &str) -> String {
+    let normalized_base = normalize_base_url(base_url);
+    let endpoint = endpoint.trim_start_matches('/');
+    format!("{}/{}", normalized_base, endpoint)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_base_url() {
+        // No trailing slash - should remain unchanged
+        assert_eq!(
+            normalize_base_url("https://api.example.com/v1"),
+            "https://api.example.com/v1"
+        );
+
+        // Single trailing slash - should be removed
+        assert_eq!(
+            normalize_base_url("https://api.example.com/v1/"),
+            "https://api.example.com/v1"
+        );
+
+        // Multiple trailing slashes - should all be removed
+        assert_eq!(
+            normalize_base_url("https://api.example.com/v1///"),
+            "https://api.example.com/v1"
+        );
+
+        // Root URL with trailing slash
+        assert_eq!(
+            normalize_base_url("https://api.example.com/"),
+            "https://api.example.com"
+        );
+
+        // Root URL without trailing slash
+        assert_eq!(
+            normalize_base_url("https://api.example.com"),
+            "https://api.example.com"
+        );
+
+        // Empty string
+        assert_eq!(normalize_base_url(""), "");
+
+        // Just slashes
+        assert_eq!(normalize_base_url("///"), "");
+    }
+
+    #[test]
+    fn test_construct_api_url() {
+        // Normal case - no trailing slash on base URL
+        assert_eq!(
+            construct_api_url("https://api.example.com/v1", "chat/completions"),
+            "https://api.example.com/v1/chat/completions"
+        );
+
+        // Base URL with trailing slash
+        assert_eq!(
+            construct_api_url("https://api.example.com/v1/", "chat/completions"),
+            "https://api.example.com/v1/chat/completions"
+        );
+
+        // Endpoint with leading slash
+        assert_eq!(
+            construct_api_url("https://api.example.com/v1", "/chat/completions"),
+            "https://api.example.com/v1/chat/completions"
+        );
+
+        // Both base URL with trailing slash and endpoint with leading slash
+        assert_eq!(
+            construct_api_url("https://api.example.com/v1/", "/chat/completions"),
+            "https://api.example.com/v1/chat/completions"
+        );
+
+        // Multiple trailing slashes on base URL
+        assert_eq!(
+            construct_api_url("https://api.example.com/v1///", "models"),
+            "https://api.example.com/v1/models"
+        );
+
+        // Multiple leading slashes on endpoint
+        assert_eq!(
+            construct_api_url("https://api.example.com/v1", "///models"),
+            "https://api.example.com/v1/models"
+        );
+
+        // Test with models endpoint
+        assert_eq!(
+            construct_api_url("https://api.openai.com/v1/", "models"),
+            "https://api.openai.com/v1/models"
+        );
+    }
+}


### PR DESCRIPTION
- Add `utils::url` module with `normalize_base_url()` and `construct_api_url()` functions
- Update all API endpoint construction to use centralized URL utilities
- Normalize custom provider URLs during authentication setup
- Add comprehensive tests for URL handling edge cases

This prevents API request failures caused by malformed URLs when base URLs contain trailing slashes, ensuring consistent URL construction across built-in and custom providers.