### PR TITLE
fix: prevent system messages from being sent to API

### DIFF
--- a/src/core/text_wrapping.rs
+++ b/src/core/text_wrapping.rs
@@ -73,7 +73,12 @@ impl TextWrapper {
 
                         // Handle very long words
                         if word_len > config.width {
-                            Self::handle_long_word(&mut result, &current_word, &mut current_line_len, config.width);
+                            Self::handle_long_word(
+                                &mut result,
+                                &current_word,
+                                &mut current_line_len,
+                                config.width,
+                            );
                         } else {
                             // Normal word that fits
                             result.push_str(&current_word);
@@ -112,7 +117,12 @@ impl TextWrapper {
 
                 // Handle very long words
                 if word_len > config.width {
-                    Self::handle_long_word(&mut result, &current_word, &mut current_line_len, config.width);
+                    Self::handle_long_word(
+                        &mut result,
+                        &current_word,
+                        &mut current_line_len,
+                        config.width,
+                    );
                 } else {
                     // Normal word that fits
                     result.push_str(&current_word);
@@ -125,7 +135,12 @@ impl TextWrapper {
     }
 
     /// Handle words that are longer than the line width by breaking them
-    fn handle_long_word(result: &mut String, word: &str, current_line_len: &mut usize, width: usize) {
+    fn handle_long_word(
+        result: &mut String,
+        word: &str,
+        current_line_len: &mut usize,
+        width: usize,
+    ) {
         let mut remaining_word = word;
         while !remaining_word.is_empty() {
             let chars_to_take = width.saturating_sub(*current_line_len);
@@ -176,7 +191,11 @@ impl TextWrapper {
     }
 
     /// Calculate cursor position within wrapped text
-    pub fn calculate_cursor_position_in_wrapped_text(text: &str, cursor_position: usize, config: &WrapConfig) -> (usize, usize) {
+    pub fn calculate_cursor_position_in_wrapped_text(
+        text: &str,
+        cursor_position: usize,
+        config: &WrapConfig,
+    ) -> (usize, usize) {
         let cursor_position = cursor_position.min(text.chars().count());
 
         // Get text before cursor

--- a/src/ui/chat_loop.rs
+++ b/src/ui/chat_loop.rs
@@ -681,7 +681,8 @@ pub async fn run_chat(
                                 // Update input scroll to keep cursor visible
                                 let input_area_height =
                                     app_guard.calculate_input_area_height(terminal_size.width);
-                                app_guard.update_input_scroll(input_area_height, terminal_size.width);
+                                app_guard
+                                    .update_input_scroll(input_area_height, terminal_size.width);
                             } else {
                                 // Up Arrow: Scroll chat history up
                                 app_guard.auto_scroll = false;
@@ -701,7 +702,8 @@ pub async fn run_chat(
                                 // Update input scroll to keep cursor visible
                                 let input_area_height =
                                     app_guard.calculate_input_area_height(terminal_size.width);
-                                app_guard.update_input_scroll(input_area_height, terminal_size.width);
+                                app_guard
+                                    .update_input_scroll(input_area_height, terminal_size.width);
                             } else {
                                 // Down Arrow: Scroll chat history down
                                 app_guard.auto_scroll = false;
@@ -712,8 +714,10 @@ pub async fn run_chat(
                                     .height
                                     .saturating_sub(input_area_height + 2) // Dynamic input area + borders
                                     .saturating_sub(1); // 1 for title
-                                let max_scroll = app_guard
-                                    .calculate_max_scroll_offset(available_height, terminal_size.width);
+                                let max_scroll = app_guard.calculate_max_scroll_offset(
+                                    available_height,
+                                    terminal_size.width,
+                                );
                                 app_guard.scroll_offset =
                                     (app_guard.scroll_offset.saturating_add(1)).min(max_scroll);
                             }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -5,7 +5,7 @@ use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
-    widgets::{Block, Borders, Paragraph, Wrap, Widget},
+    widgets::{Block, Borders, Paragraph, Widget, Wrap},
     Frame,
 };
 
@@ -134,7 +134,11 @@ impl<'a> InputWidget<'a> {
 
         // Use TextWrapper to calculate cursor position
         let config = WrapConfig::new(text_area.width as usize);
-        let (line, col) = TextWrapper::calculate_cursor_position_in_wrapped_text(self.text, cursor_position, &config);
+        let (line, col) = TextWrapper::calculate_cursor_position_in_wrapped_text(
+            self.text,
+            cursor_position,
+            &config,
+        );
 
         // Apply scroll offset
         let visible_line = (line as u16).saturating_sub(self.scroll_offset);


### PR DESCRIPTION
System messages (like /help responses and error messages) were being included in API requests alongside user and assistant messages. This caused unnecessary API calls and potential information leakage.

- Add filtering in add_user_message() to exclude system messages from API calls
- Add filtering in prepare_retry() to exclude system messages during retries
- Add unit tests to verify system messages are properly excluded
- System messages continue to display correctly in the UI

Fixes issue where commands like /help and editor errors were sent to external APIs instead of being local-only system responses.