### PR TITLE
Support for reproducible builds; clean version info without git repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
+---
 name: Rust build and test
 
-on:
+'on':
   push:
   pull_request:
 
@@ -12,26 +13,87 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Cache cargo registry
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
 
-    - name: Build
-      run: cargo build --verbose
+      - name: Build
+        run: cargo build --verbose
 
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Run tests
+        run: cargo test --verbose
+
+  reproducible-builds:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-repro-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-repro-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - name: Test reproducible builds
+        run: |
+          echo "Testing SOURCE_DATE_EPOCH reproducibility..."
+          SOURCE_DATE_EPOCH=1640995200 cargo run -- --version | \
+            tee version_source_date.txt
+          if grep -q "2022-01-01T00:00:00" version_source_date.txt; then
+            echo "✅ SOURCE_DATE_EPOCH working"
+          else
+            echo "❌ SOURCE_DATE_EPOCH failed"; exit 1
+          fi
+
+          echo "Testing VERGEN_IDEMPOTENT reproducibility..."
+          VERGEN_IDEMPOTENT=1 cargo run -- --version | \
+            tee version_idempotent.txt
+          if ! grep -q "Build timestamp:" version_idempotent.txt && \
+             grep -q "Distribution build" version_idempotent.txt; then
+            echo "✅ VERGEN_IDEMPOTENT working"
+          else
+            echo "❌ VERGEN_IDEMPOTENT failed"; exit 1
+          fi
+
+      - name: Test no-git scenario
+        run: |
+          echo "Testing package maintainer scenario (no git)..."
+          # Safely hide .git directory to simulate source tarball
+          mv .git .git.backup
+          VERGEN_IDEMPOTENT=1 cargo run -- --version | \
+            tee version_no_git.txt
+          # Restore .git directory for GitHub cleanup
+          mv .git.backup .git
+
+          if grep -q "Distribution build" version_no_git.txt && \
+             ! grep -q "Git commit:" version_no_git.txt; then
+            echo "✅ No-git build working"
+          else
+            echo "❌ No-git build failed"; exit 1
+          fi
+          echo "All reproducibility tests passed! 🎉"

--- a/build.rs
+++ b/build.rs
@@ -1,47 +1,54 @@
 use vergen::{BuildBuilder, CargoBuilder, Emitter, RustcBuilder};
 use vergen_git2::Git2Builder;
 
+macro_rules! emit_instructions {
+    ($build:expr, $cargo:expr, $rustc:expr $(, $git2:expr)?) => {
+        {
+            let mut emitter = Emitter::default();
+            emitter.add_instructions($build)?;
+            emitter.add_instructions($cargo)?;
+            emitter.add_instructions($rustc)?;
+            $(emitter.add_instructions($git2)?;)?
+            emitter.emit()?;
+        }
+    };
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let build = BuildBuilder::all_build()?;
+    // Check for reproducible build environment variables
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+    println!("cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT");
+
+    // Configure build instructions - respect reproducible build settings
+    let build = if std::env::var_os("VERGEN_IDEMPOTENT").is_some() {
+        // For reproducible builds, only include non-temporal information
+        BuildBuilder::default().build_date(false).build_timestamp(false).build()?
+    } else {
+        // Normal builds include timestamps (vergen will respect SOURCE_DATE_EPOCH)
+        BuildBuilder::all_build()?
+    };
     let cargo = CargoBuilder::all_cargo()?;
     let rustc = RustcBuilder::all_rustc()?;
 
-    // Try to configure git2, but don't fail if git is not available (e.g., crates.io builds)
-    let git2_result = Git2Builder::default()
-        .branch(true)
-        .commit_author_email(true)
-        .commit_author_name(true)
-        .commit_count(true)
-        .commit_message(true)
-        .commit_timestamp(true)
-        .describe(true, true, None) // enable describe, include tags, no match pattern
-        .sha(true)
-        .build();
-
-    // Only add git instructions if git is available
-    if let Ok(git2) = git2_result {
-        Emitter::default()
-            .add_instructions(&build)?
-            .add_instructions(&cargo)?
-            .add_instructions(&rustc)?
-            .add_instructions(&git2)?
-            .emit()?;
+    // Get git instructions if we're in a git repository and not in idempotent mode
+    if std::path::Path::new(".git").exists() && std::env::var_os("VERGEN_IDEMPOTENT").is_none() {
+        if let Ok(git2) = Git2Builder::default()
+            .branch(true)
+            .commit_author_email(true)
+            .commit_author_name(true)
+            .commit_count(true)
+            .commit_message(true)
+            .commit_timestamp(true)
+            .describe(true, true, None)
+            .sha(true)
+            .build()
+        {
+            emit_instructions!(&build, &cargo, &rustc, &git2);
+        } else {
+            emit_instructions!(&build, &cargo, &rustc);
+        }
     } else {
-        // Set fallback values when git is not available
-        println!("cargo:rustc-env=VERGEN_GIT_BRANCH=unknown");
-        println!("cargo:rustc-env=VERGEN_GIT_COMMIT_AUTHOR_EMAIL=unknown");
-        println!("cargo:rustc-env=VERGEN_GIT_COMMIT_AUTHOR_NAME=unknown");
-        println!("cargo:rustc-env=VERGEN_GIT_COMMIT_COUNT=0");
-        println!("cargo:rustc-env=VERGEN_GIT_COMMIT_MESSAGE=unknown");
-        println!("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP=unknown");
-        println!("cargo:rustc-env=VERGEN_GIT_DESCRIBE=unknown");
-        println!("cargo:rustc-env=VERGEN_GIT_SHA=unknown");
-
-        Emitter::default()
-            .add_instructions(&build)?
-            .add_instructions(&cargo)?
-            .add_instructions(&rustc)?
-            .emit()?;
+        emit_instructions!(&build, &cargo, &rustc);
     }
 
     Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,12 +23,13 @@ use crate::ui::chat_loop::run_chat;
 fn print_version_info() {
     println!("chabeau {}", env!("CARGO_PKG_VERSION"));
 
-    let git_describe = env!("VERGEN_GIT_DESCRIBE");
-    let git_sha = env!("VERGEN_GIT_SHA");
-    let git_branch = env!("VERGEN_GIT_BRANCH");
+    // Use option_env! to handle missing git environment variables
+    let git_describe = option_env!("VERGEN_GIT_DESCRIBE").unwrap_or("unknown");
+    let git_sha = option_env!("VERGEN_GIT_SHA").unwrap_or("unknown");
+    let git_branch = option_env!("VERGEN_GIT_BRANCH").unwrap_or("unknown");
 
-    // Check if git information is available (vergen sets to "VERGEN_IDEMPOTENT_OUTPUT" when git is not available)
-    let has_git_info = !git_describe.starts_with("VERGEN_") && git_describe != "unknown";
+    // Check if git information is available
+    let has_git_info = git_describe != "unknown" && !git_describe.starts_with("VERGEN_");
 
     // Determine build type
     let build_type = if !has_git_info {
@@ -53,7 +54,9 @@ fn print_version_info() {
         }
     }
 
-    println!("Build timestamp: {}", env!("VERGEN_BUILD_TIMESTAMP"));
+    if let Some(timestamp) = option_env!("VERGEN_BUILD_TIMESTAMP") {
+        println!("Build timestamp: {}", timestamp);
+    }
     println!("Rust version: {}", env!("VERGEN_RUSTC_SEMVER"));
     println!("Target triple: {}", env!("VERGEN_CARGO_TARGET_TRIPLE"));
     println!("Build profile: {}", if cfg!(debug_assertions) { "debug" } else { "release" });

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,19 +27,24 @@ fn print_version_info() {
     let git_sha = env!("VERGEN_GIT_SHA");
     let git_branch = env!("VERGEN_GIT_BRANCH");
 
+    // Check if git information is available (vergen sets to "VERGEN_IDEMPOTENT_OUTPUT" when git is not available)
+    let has_git_info = !git_describe.starts_with("VERGEN_") && git_describe != "unknown";
+
     // Determine build type
-    let build_type = match git_describe {
-        "unknown" => "Distribution build",
-        desc if desc.starts_with('v') && !desc.contains('-') && !desc.contains("dirty") => "Release build",
-        _ => "Development build",
+    let build_type = if !has_git_info {
+        "Distribution build"
+    } else if git_describe.starts_with('v') && !git_describe.contains('-') && !git_describe.contains("dirty") {
+        "Release build"
+    } else {
+        "Development build"
     };
     println!("{}", build_type);
 
     // Show git information if available
-    if git_sha != "unknown" {
+    if has_git_info {
         println!("Git commit: {}", &git_sha[..7.min(git_sha.len())]);
 
-        if !git_branch.is_empty() && git_branch != "unknown" {
+        if !git_branch.is_empty() && !git_branch.starts_with("VERGEN_") {
             println!("Git branch: {}", git_branch);
         }
 


### PR DESCRIPTION
- Fixes version info lookup when we're not in a Git repo
- Respects conventions for build reproducibility and idempotency