### PR TITLE
refactor(tests): centralize test message utilities 

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -176,7 +176,7 @@ fn handle_dump_result(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test_utils::create_test_app;
+    use crate::utils::test_utils::{create_test_app, create_test_message};
     use std::fs;
     use std::io::Read;
     use tempfile::tempdir;
@@ -187,18 +187,11 @@ mod tests {
         let mut app = create_test_app();
 
         // Add messages
-        app.messages.push_back(crate::core::message::Message {
-            role: "user".to_string(),
-            content: "Hello".to_string(),
-        });
-        app.messages.push_back(crate::core::message::Message {
-            role: "assistant".to_string(),
-            content: "Hi there!".to_string(),
-        });
-        app.messages.push_back(crate::core::message::Message {
-            role: "system".to_string(),
-            content: "System message".to_string(),
-        });
+        app.messages.push_back(create_test_message("user", "Hello"));
+        app.messages
+            .push_back(create_test_message("assistant", "Hi there!"));
+        app.messages
+            .push_back(create_test_message("system", "System message"));
 
         // Create a temporary directory for testing
         let temp_dir = tempdir().unwrap();
@@ -229,14 +222,9 @@ mod tests {
         let mut app = create_test_app();
 
         // Add messages
-        app.messages.push_back(crate::core::message::Message {
-            role: "user".to_string(),
-            content: "Hello".to_string(),
-        });
-        app.messages.push_back(crate::core::message::Message {
-            role: "assistant".to_string(),
-            content: "Hi there!".to_string(),
-        });
+        app.messages.push_back(create_test_message("user", "Hello"));
+        app.messages
+            .push_back(create_test_message("assistant", "Hi there!"));
 
         // Create a temporary directory for testing
         let temp_dir = tempdir().unwrap();
@@ -265,10 +253,8 @@ mod tests {
         let mut app = create_test_app();
 
         // Add a message to test dumping
-        app.messages.push_back(crate::core::message::Message {
-            role: "user".to_string(),
-            content: "Test message".to_string(),
-        });
+        app.messages
+            .push_back(create_test_message("user", "Test message"));
 
         // Create a temporary directory for testing
         let temp_dir = tempdir().unwrap();

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -797,7 +797,7 @@ Please either:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test_utils::create_test_app;
+    use crate::utils::test_utils::{create_test_app, create_test_message};
 
     #[test]
     fn test_system_messages_excluded_from_api() {
@@ -805,10 +805,7 @@ mod tests {
         let mut app = create_test_app();
 
         // Add a user message
-        app.messages.push_back(Message {
-            role: "user".to_string(),
-            content: "Hello".to_string(),
-        });
+        app.messages.push_back(create_test_message("user", "Hello"));
 
         // Add a system message (like from /help command)
         app.add_system_message(
@@ -816,10 +813,8 @@ mod tests {
         );
 
         // Add an assistant message
-        app.messages.push_back(Message {
-            role: "assistant".to_string(),
-            content: "Hi there!".to_string(),
-        });
+        app.messages
+            .push_back(create_test_message("assistant", "Hi there!"));
 
         // Add another system message
         app.add_system_message("Another system message".to_string());

--- a/src/utils/scroll.rs
+++ b/src/utils/scroll.rs
@@ -210,26 +210,8 @@ impl ScrollCalculator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::test_utils::{create_test_message, create_test_messages};
     use std::collections::VecDeque;
-
-    fn create_test_message(role: &str, content: &str) -> Message {
-        Message {
-            role: role.to_string(),
-            content: content.to_string(),
-        }
-    }
-
-    fn create_test_messages() -> VecDeque<Message> {
-        let mut messages = VecDeque::new();
-        messages.push_back(create_test_message("user", "Hello"));
-        messages.push_back(create_test_message("assistant", "Hi there!"));
-        messages.push_back(create_test_message("user", "How are you?"));
-        messages.push_back(create_test_message(
-            "assistant",
-            "I'm doing well, thank you for asking!",
-        ));
-        messages
-    }
 
     #[test]
     fn test_build_display_lines_basic() {

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 use crate::core::app::App;
 #[cfg(test)]
+use crate::core::message::Message;
+#[cfg(test)]
 use crate::utils::logging::LoggingState;
 #[cfg(test)]
 use std::collections::VecDeque;
@@ -31,4 +33,25 @@ pub fn create_test_app() -> App {
         retrying_message_index: None,
         input_scroll_offset: 0,
     }
+}
+
+#[cfg(test)]
+pub fn create_test_message(role: &str, content: &str) -> Message {
+    Message {
+        role: role.to_string(),
+        content: content.to_string(),
+    }
+}
+
+#[cfg(test)]
+pub fn create_test_messages() -> VecDeque<Message> {
+    let mut messages = VecDeque::new();
+    messages.push_back(create_test_message("user", "Hello"));
+    messages.push_back(create_test_message("assistant", "Hi there!"));
+    messages.push_back(create_test_message("user", "How are you?"));
+    messages.push_back(create_test_message(
+        "assistant",
+        "I'm doing well, thank you for asking!",
+    ));
+    messages
 }


### PR DESCRIPTION
Move create_test_message() and create_test_messages() to shared test_utils.rs module to eliminate duplication across scroll.rs, app.rs, and commands/mod.rs. Refactor config tests to properly initialize structs and move test module to end of file to resolve clippy warnings.