### PR TITLE
feat(ui): tui-textarea input; fix cursor + keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "tui-textarea",
  "vergen",
  "vergen-git2",
 ]
@@ -2237,6 +2238,17 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tokio-util = "0.7.15"
 keyring = { version = "3.0", features = ["sync-secret-service", "windows-native", "apple-native"] }
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3.20"
+tui-textarea = "0.7"
 
 [build-dependencies]
 vergen = { version = "9.0", features = ["build", "cargo", "rustc", "si"] }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Chabeau is not a coding agent, nor does it aspire to be one. Instead, it brings 
 ## Features
 
 - Full-screen terminal UI with real-time streaming responses
+- Robust multi-line input powered by `tui-textarea` (IME-friendly)
 - Multiple OpenAI-compatible providers (OpenAI, OpenRouter, Poe, Anthropic, Venice AI, Groq, Mistral, Cerebras, custom)
 - Secure API key storage in system keyring with config-based provider management
 - Message retry and external editor support
@@ -131,8 +132,8 @@ export EDITOR="code --wait" # VS Code with wait
   - **Cyan/Bold**: Your messages
   - **White**: Assistant responses
   - **Gray**: System messages
-- **Input Area**: Message composition (yellow highlight)
-- **Title Bar**: Version, provider, model, logging status
+- **Input Area**: Message composition with soft-wrap and IME support (powered by `tui-textarea`)
+- **Title Bar**: Version, provider, model, logging status, and a pulsing streaming indicator
 
 ## Architecture
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -101,24 +101,24 @@ impl AuthManager {
                             .find_provider_by_name(default_provider)
                             .map(|p| p.display_name.clone())
                             .unwrap_or_else(|| default_provider.clone());
-                        return Ok((
+                        Ok((
                             api_key,
                             base_url,
                             default_provider.to_lowercase(),
                             display_name,
-                        ));
+                        ))
                     } else {
-                        return Err(format!("No authentication found for default provider '{default_provider}'. Run 'chabeau auth' to set up authentication.").into());
+                        Err(format!("No authentication found for default provider '{default_provider}'. Run 'chabeau auth' to set up authentication.").into())
                     }
                 } else {
                     // Try to find any available authentication
                     if let Some((provider, api_key)) = self.find_first_available_auth() {
-                        return Ok((
+                        Ok((
                             api_key,
                             provider.base_url,
                             provider.name.to_lowercase(),
                             provider.display_name,
-                        ));
+                        ))
                     } else {
                         // Fall back to environment variables
                         let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| {
@@ -134,27 +134,25 @@ Please either:
                         let base_url = std::env::var("OPENAI_BASE_URL")
                             .unwrap_or_else(|_| "https://api.openai.com/v1".to_string());
 
-                        return Ok((
+                        Ok((
                             api_key,
                             base_url,
                             "openai".to_string(),
                             "OpenAI".to_string(),
-                        ));
+                        ))
                     }
                 }
             } else {
                 // User specified a provider - normalize to lowercase for consistent config lookup
                 let normalized_provider_name = provider_name.to_lowercase();
-                if let Some((base_url, api_key)) =
-                    self.get_auth_for_provider(provider_name)?
-                {
+                if let Some((base_url, api_key)) = self.get_auth_for_provider(provider_name)? {
                     let display_name = self
                         .find_provider_by_name(provider_name)
                         .map(|p| p.display_name.clone())
                         .unwrap_or_else(|| provider_name.to_string());
-                    return Ok((api_key, base_url, normalized_provider_name, display_name));
+                    Ok((api_key, base_url, normalized_provider_name, display_name))
                 } else {
-                    return Err(format!("No authentication found for provider '{provider_name}'. Run 'chabeau auth' to set up authentication.").into());
+                    Err(format!("No authentication found for provider '{provider_name}'. Run 'chabeau auth' to set up authentication.").into())
                 }
             }
         } else if let Some(ref provider_name) = config.default_provider {
@@ -164,24 +162,24 @@ Please either:
                     .find_provider_by_name(provider_name)
                     .map(|p| p.display_name.clone())
                     .unwrap_or_else(|| provider_name.clone());
-                return Ok((
+                Ok((
                     api_key,
                     base_url,
                     provider_name.to_lowercase(),
                     display_name,
-                ));
+                ))
             } else {
-                return Err(format!("No authentication found for default provider '{provider_name}'. Run 'chabeau auth' to set up authentication.").into());
+                Err(format!("No authentication found for default provider '{provider_name}'. Run 'chabeau auth' to set up authentication.").into())
             }
         } else {
             // Try to find any available authentication
             if let Some((provider, api_key)) = self.find_first_available_auth() {
-                return Ok((
+                Ok((
                     api_key,
                     provider.base_url,
                     provider.name.to_lowercase(),
                     provider.display_name,
-                ));
+                ))
             } else {
                 // Fall back to environment variables
                 let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| {
@@ -197,12 +195,12 @@ Please either:
                 let base_url = std::env::var("OPENAI_BASE_URL")
                     .unwrap_or_else(|_| "https://api.openai.com/v1".to_string());
 
-                return Ok((
+                Ok((
                     api_key,
                     base_url,
                     "openai".to_string(),
                     "OpenAI".to_string(),
-                ));
+                ))
             }
         }
     }

--- a/src/cli/model_list.rs
+++ b/src/cli/model_list.rs
@@ -13,10 +13,8 @@ pub async fn list_models(provider: Option<String>) -> Result<(), Box<dyn Error>>
     let config = Config::load()?;
 
     // Use the shared authentication resolution function
-    let (api_key, base_url, _, provider_name) = auth_manager.resolve_authentication(
-        provider.as_deref(),
-        &config,
-    )?;
+    let (api_key, base_url, _, provider_name) =
+        auth_manager.resolve_authentication(provider.as_deref(), &config)?;
 
     println!("🤖 Available Models for {provider_name}");
     println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");

--- a/src/cli/pick_default_model.rs
+++ b/src/cli/pick_default_model.rs
@@ -61,10 +61,8 @@ pub async fn pick_default_model(provider: Option<String>) -> Result<(), Box<dyn 
     };
 
     // Use the shared authentication resolution function
-    let (api_key, base_url, _, display_name) = auth_manager.resolve_authentication(
-        Some(&provider_name),
-        &config,
-    )?;
+    let (api_key, base_url, _, display_name) =
+        auth_manager.resolve_authentication(Some(&provider_name), &config)?;
 
     println!("🤖 Available Models for {display_name}");
     println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -1,6 +1,0 @@
-//! Shared constants used across the application
-
-/// Space reserved for streaming indicator + margin in input areas
-/// This must be consistently used in both UI rendering and text calculations
-/// to prevent horizontal scrolling issues.
-pub const INDICATOR_SPACE: u16 = 4;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,5 @@
 pub mod app;
 pub mod builtin_providers;
 pub mod config;
-pub mod constants;
 pub mod message;
 pub mod text_wrapping;

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1,187 +1,12 @@
 use crate::core::app::App;
-use crate::core::constants::INDICATOR_SPACE;
 use crate::core::text_wrapping::{TextWrapper, WrapConfig};
 use ratatui::{
-    buffer::Buffer,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout},
     style::{Color, Style},
-    widgets::{Block, Borders, Paragraph, Widget, Wrap},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
     Frame,
 };
-
-/// A custom input widget that handles text wrapping, cursor positioning, and streaming indicator
-struct InputWidget<'a> {
-    text: &'a str,
-    cursor_position: usize,
-    scroll_offset: u16,
-    style: Style,
-    block: Option<Block<'a>>,
-    is_streaming: bool,
-    pulse_start: std::time::Instant,
-}
-
-impl<'a> InputWidget<'a> {
-    fn new(text: &'a str) -> Self {
-        Self {
-            text,
-            cursor_position: 0,
-            scroll_offset: 0,
-            style: Style::default(),
-            block: None,
-            is_streaming: false,
-            pulse_start: std::time::Instant::now(),
-        }
-    }
-
-    fn cursor_position(mut self, position: usize) -> Self {
-        self.cursor_position = position;
-        self
-    }
-
-    fn scroll(mut self, offset: u16) -> Self {
-        self.scroll_offset = offset;
-        self
-    }
-
-    fn style(mut self, style: Style) -> Self {
-        self.style = style;
-        self
-    }
-
-    fn block(mut self, block: Block<'a>) -> Self {
-        self.block = Some(block);
-        self
-    }
-
-    fn streaming(mut self, is_streaming: bool, pulse_start: std::time::Instant) -> Self {
-        self.is_streaming = is_streaming;
-        self.pulse_start = pulse_start;
-        self
-    }
-}
-
-impl<'a> Widget for InputWidget<'a> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        // Render the block (border and title) first
-        let inner_area = if let Some(ref block) = self.block {
-            let inner = block.inner(area);
-            block.render(area, buf);
-            inner
-        } else {
-            area
-        };
-
-        // Reserve space for streaming indicator
-        let text_area = Rect {
-            x: inner_area.x,
-            y: inner_area.y,
-            width: inner_area.width.saturating_sub(INDICATOR_SPACE),
-            height: inner_area.height,
-        };
-
-        // Pre-process text to insert line breaks at character boundaries
-        let wrapped_text = self.wrap_text_at_boundaries(self.text, text_area.width as usize);
-
-        // Render the pre-wrapped text without additional wrapping
-        let paragraph = Paragraph::new(wrapped_text.as_str())
-            .style(self.style)
-            .scroll((self.scroll_offset, 0));
-
-        paragraph.render(text_area, buf);
-
-        // Render streaming indicator if needed
-        if self.is_streaming {
-            self.render_streaming_indicator(area, buf);
-        }
-
-        // Set cursor position if we're in input mode
-        // Note: This is handled by the caller since Widget trait doesn't have access to Frame
-    }
-}
-
-impl<'a> InputWidget<'a> {
-    /// Pre-process text to insert line breaks at word boundaries while preserving spacing
-    fn wrap_text_at_boundaries(&self, text: &str, width: usize) -> String {
-        let config = WrapConfig::new(width);
-        TextWrapper::wrap_text(text, &config)
-    }
-
-    /// Calculate cursor position using word wrapping logic that matches text rendering
-    fn calculate_cursor_position(&self, area: Rect) -> Option<(u16, u16)> {
-        let inner_area = if self.block.is_some() {
-            Rect {
-                x: area.x + 1,
-                y: area.y + 1,
-                width: area.width.saturating_sub(2),
-                height: area.height.saturating_sub(2),
-            }
-        } else {
-            area
-        };
-
-        let text_area = Rect {
-            x: inner_area.x,
-            y: inner_area.y,
-            width: inner_area.width.saturating_sub(INDICATOR_SPACE),
-            height: inner_area.height,
-        };
-
-        if text_area.width == 0 {
-            return None;
-        }
-
-        let cursor_position = self.cursor_position.min(self.text.chars().count());
-
-        // Use TextWrapper to calculate cursor position
-        let config = WrapConfig::new(text_area.width as usize);
-        let (line, col) = TextWrapper::calculate_cursor_position_in_wrapped_text(
-            self.text,
-            cursor_position,
-            &config,
-        );
-
-        // Apply scroll offset
-        let visible_line = (line as u16).saturating_sub(self.scroll_offset);
-
-        // Only return position if cursor is within visible area
-        if visible_line < text_area.height {
-            Some((text_area.x + col as u16, text_area.y + visible_line))
-        } else {
-            None
-        }
-    }
-
-    /// Render the streaming indicator
-    fn render_streaming_indicator(&self, area: Rect, buf: &mut Buffer) {
-        // Calculate pulse animation
-        let elapsed = self.pulse_start.elapsed().as_millis() as f32 / 1000.0;
-        let pulse_phase = (elapsed * 2.0) % 2.0;
-        let pulse_intensity = if pulse_phase < 1.0 {
-            pulse_phase
-        } else {
-            2.0 - pulse_phase
-        };
-
-        // Choose symbol based on pulse intensity
-        let symbol = if pulse_intensity < 0.33 {
-            "○"
-        } else if pulse_intensity < 0.66 {
-            "◐"
-        } else {
-            "●"
-        };
-
-        // Position indicator in top-right of the widget
-        let indicator_x = area.x + area.width.saturating_sub(3);
-        let indicator_y = area.y + 1;
-
-        if indicator_x < area.x + area.width && indicator_y < area.y + area.height {
-            buf[(indicator_x, indicator_y)]
-                .set_symbol(symbol)
-                .set_style(Style::default().fg(Color::Cyan));
-        }
-    }
-}
 
 pub fn ui(f: &mut Frame, app: &App) {
     // Calculate dynamic input area height based on content
@@ -227,41 +52,74 @@ pub fn ui(f: &mut Frame, app: &App) {
     f.render_widget(messages_paragraph, chunks[0]);
 
     // Input area takes full width
-    let input_style = if app.input_mode {
-        Style::default().fg(Color::Cyan)
+
+    // Pulsing indicator rendered in the title for simplicity
+    let indicator = if app.is_streaming {
+        let elapsed = app.pulse_start.elapsed().as_millis() as f32 / 1000.0;
+        let phase = (elapsed * 2.0) % 2.0;
+        if phase < 0.33 {
+            "○"
+        } else if phase < 0.66 {
+            "◐"
+        } else {
+            "●"
+        }
     } else {
-        Style::default()
+        ""
     };
 
-    let input_title = if app.is_streaming {
+    let base_title = if app.is_streaming {
         "Type message (Esc to interrupt, Ctrl+R to retry)"
     } else {
         "Type message (Alt+Enter for new line, /help for help, Ctrl+C to quit)"
     };
+    // Build a styled title with a distinct-colored indicator and a touch more right padding
+    let input_title: Line = if indicator.is_empty() {
+        Line::from(base_title.to_string())
+    } else {
+        Line::from(vec![
+            Span::raw(base_title.to_string()),
+            Span::raw(" "), // 1 space before indicator
+            Span::styled(
+                indicator.to_string(),
+                // Match assistant output color for now
+                Style::default().fg(Color::White),
+            ),
+            Span::raw("  "), // 2 spaces after indicator for a bit more padding
+        ])
+    };
 
-    // Create and render the custom input widget
+    // Render border/title and the textarea inside
     let input_block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Reset))
         .title(input_title);
 
-    let input_widget = InputWidget::new(&app.input)
-        .cursor_position(app.input_cursor_position)
-        .scroll(app.input_scroll_offset)
-        .style(input_style)
-        .block(input_block)
-        .streaming(app.is_streaming, app.pulse_start);
+    let area = chunks[1];
+    let inner = input_block.inner(area);
+    f.render_widget(input_block, area);
 
-    f.render_widget(input_widget, chunks[1]);
+    // Render wrapped input text with a one-column right margin
+    // Wrap one character earlier to avoid cursor touching the border
+    let available_width = inner.width.saturating_sub(1);
+    let config = WrapConfig::new(available_width as usize);
+    let wrapped_text = TextWrapper::wrap_text(app.get_input_text(), &config);
+    let paragraph = Paragraph::new(wrapped_text)
+        .wrap(Wrap { trim: false })
+        .scroll((app.input_scroll_offset, 0));
+    f.render_widget(paragraph, inner);
 
-    // Set cursor position using the widget's calculation
-    if app.input_mode {
-        let widget_for_cursor = InputWidget::new(&app.input)
-            .cursor_position(app.input_cursor_position)
-            .scroll(app.input_scroll_offset)
-            .block(Block::default().borders(Borders::ALL));
-
-        if let Some((cursor_x, cursor_y)) = widget_for_cursor.calculate_cursor_position(chunks[1]) {
+    // Set cursor based on wrapped text and linear cursor position
+    if app.input_mode && available_width > 0 {
+        let (line, col) = TextWrapper::calculate_cursor_position_in_wrapped_text(
+            app.get_input_text(),
+            app.input_cursor_position,
+            &config,
+        );
+        let visible_line = (line as u16).saturating_sub(app.input_scroll_offset);
+        if visible_line < inner.height {
+            let cursor_x = inner.x.saturating_add(col as u16);
+            let cursor_y = inner.y.saturating_add(visible_line);
             f.set_cursor_position((cursor_x, cursor_y));
         }
     }

--- a/src/utils/editor.rs
+++ b/src/utils/editor.rs
@@ -24,8 +24,9 @@ pub async fn handle_external_editor(app: &mut App) -> Result<Option<String>, Box
     let temp_path = temp_file.path().to_path_buf();
 
     // Write current input to the temp file if there's any
-    if !app.input.is_empty() {
-        fs::write(&temp_path, &app.input)?;
+    let current_text = app.get_input_text();
+    if !current_text.is_empty() {
+        fs::write(&temp_path, current_text)?;
     }
 
     // We need to temporarily exit raw mode to allow the editor to run
@@ -64,7 +65,7 @@ pub async fn handle_external_editor(app: &mut App) -> Result<Option<String>, Box
         Ok(None)
     } else {
         // Clear the input and return the content to be sent immediately
-        app.input.clear();
+        app.clear_input();
         let message = content.trim_end().to_string(); // Remove trailing newlines but preserve internal formatting
         Ok(Some(message))
     }

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -32,6 +32,7 @@ pub fn create_test_app() -> App {
         last_retry_time: std::time::Instant::now(),
         retrying_message_index: None,
         input_scroll_offset: 0,
+        textarea: tui_textarea::TextArea::default(),
     }
 }
 


### PR DESCRIPTION
- Move pulse indicator to title with right padding; remove reserved width
- Wrap input one column early to avoid right border collision
- Fix Shift+Up/Down and Shift+Left/Right to move exactly one line/char
- Fix cursor mapping on blank lines via position-based mapping
- DRY: add textarea edit helpers; cache term size; layout helpers
- Delete INDICATOR_SPACE and constants module
- Update README for tui-textarea; add/adjust tests