### PR TITLE
feat(ui): paging + Home/End; Ctrl+D exit; Del

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Most should be intuitive. A couple of choices may be a bit jarring at first:
 - Alt+Enter to start a new line: We've found this to be most reliable across terminals.
 - Shift+Cursor to move around in input: This is so the cursor keys can be used at any time to scroll in the output area.
 
-Fedeback and suggestions are always welcome!
+Feedback and suggestions are always welcome!
 
 ### External Editor
 Set `EDITOR` environment variable:

--- a/src/ui/builtin_help.md
+++ b/src/ui/builtin_help.md
@@ -7,12 +7,15 @@ Thanks for using Chabeau! Find a bug? Let us know: https://github.com/permacommo
 - Enter: Send message
 - Alt+Enter: New line in input
 - Ctrl+R: Retry last response
+- Ctrl+D: Exit when input is empty; otherwise behaves like [Del]
 - Ctrl+P: Edit previous messages (select mode)
 - Ctrl+B: Select code blocks (copy `c`, save `s`)
 - Ctrl+L: Clear status message
 - Ctrl+T: Open in external editor (requires `$EDITOR` to be set)
 - Esc: Interrupt streaming / cancel modes
 - Up/Down/Mouse: Scroll history
+- PageUp/PageDown: Scroll one page in history
+- Home/End: Jump to top/bottom of history
 - Shift+Cursor Keys: Move cursor in input
 
 ## Picker Navigation

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -704,7 +704,6 @@ fn render_message_with_ranges_with_width_and_policy(
     terminal_width: Option<usize>,
     table_policy: crate::ui::layout::TableOverflowPolicy,
 ) -> (Vec<Line<'static>>, Vec<(usize, usize, String)>) {
-
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TABLES);
@@ -1955,7 +1954,8 @@ End of table."###
             content: r#"| Feature | Benefits |
 |---------|----------|
 | X | **Dramatically** _improved_ decision-making capabilities with ***real-time*** analytics |
-"#.into(),
+"#
+            .into(),
         });
 
         let theme = crate::ui::theme::Theme::dark_default();
@@ -1993,9 +1993,13 @@ End of table."###
 
         // 2) Hyphenated word may wrap after the hyphen, but not mid-segment
         // Accept either kept together or split at the hyphen with a space inserted by wrapping
-        let hyphen_ok = all_content.contains("decision-making")
-            || all_content.contains("decision- making");
-        assert!(hyphen_ok, "Hyphen should be a soft break point: {}", all_content);
+        let hyphen_ok =
+            all_content.contains("decision-making") || all_content.contains("decision- making");
+        assert!(
+            hyphen_ok,
+            "Hyphen should be a soft break point: {}",
+            all_content
+        );
 
         // 3) No truncation
         for line in &lines {


### PR DESCRIPTION
- Add PageUp/PageDown and Home/End for output scrolling using width-aware line counts (no skipped content).
- Add Ctrl+D: exit only when input is truly empty; otherwise perform forward delete; ignored while pickers are open.
- Make Delete in input perform forward delete
- Update built-in help; add unit tests for paging and scroll helpers.