### PR TITLE
feat(ui): compose mode, Ctrl+J, F6 sort

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -88,6 +88,8 @@ pub struct App {
     pub startup_multiple_providers_available: bool,
     pub exit_requested: bool,
     pub startup_env_only: bool,
+    // Compose mode: Enter inserts newline; Alt+Enter sends; persists until toggled
+    pub compose_mode: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -248,6 +250,7 @@ impl App {
             startup_multiple_providers_available: false,
             exit_requested: false,
             startup_env_only: false,
+            compose_mode: false,
         };
 
         // Keep textarea state in sync with the string input initially
@@ -353,6 +356,7 @@ impl App {
             startup_multiple_providers_available: false,
             exit_requested: false,
             startup_env_only: false,
+            compose_mode: false,
         };
 
         app.set_input_text(String::new());
@@ -546,6 +550,7 @@ impl App {
             startup_multiple_providers_available: false,
             exit_requested: false,
             startup_env_only: false,
+            compose_mode: false,
         }
     }
 

--- a/src/ui/builtin_help.md
+++ b/src/ui/builtin_help.md
@@ -5,7 +5,8 @@ Thanks for using Chabeau! Find a bug? Let us know: https://github.com/permacommo
 ## Keys
 
 - Enter: Send message
-- Alt+Enter: New line in input
+- Alt+Enter or Ctrl+J: New line in input
+- F4: Toggle compose mode (Enter=new line, Alt+Enter=send)
 - Ctrl+R: Retry last response
 - Ctrl+D: Exit when input is empty; otherwise behaves like [Del]
 - Ctrl+P: Edit previous messages (select mode)
@@ -21,11 +22,11 @@ Thanks for using Chabeau! Find a bug? Let us know: https://github.com/permacommo
 ## Picker Navigation
 
 - Enter: Apply selection (session only)
-- Alt+Enter: Apply selection and save to config
+- Alt+Enter or Ctrl+J: Apply selection and save to config
 - Esc: Cancel picker
 - ↑/↓ or j/k: Navigate options
 - Home/End: Jump to first/last option
-- F2: Toggle sort mode
+- F6: Toggle sort mode
 - Type: Filter options
 
 ## Commands

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -123,6 +123,8 @@ pub fn ui(f: &mut Frame, app: &mut App) {
         "Specify new filename (Esc=Cancel • Alt+Enter=Overwrite)"
     } else if app.in_place_edit_index.is_some() {
         "Edit in place: Enter=Apply • Esc=Cancel (no send)"
+    } else if app.compose_mode {
+        "Compose a message (F4=toggle compose mode, Enter=new line, Alt+Enter=send)"
     } else if app.is_streaming {
         "Type a new message (Esc=interrupt • Ctrl+R=retry)"
     } else {
@@ -382,9 +384,9 @@ fn generate_picker_help_text(app: &App) -> String {
     };
 
     let first_line = if search_filter.is_empty() {
-        format!("↑/↓=Navigate • F2=Sort • Type=Filter{}", del_help)
+        format!("↑/↓=Navigate • F6=Sort • Type=Filter{}", del_help)
     } else {
-        format!("↑/↓=Navigate • Backspace=Clear • F2=Sort{}", del_help)
+        format!("↑/↓=Navigate • Backspace=Clear • F6=Sort{}", del_help)
     };
 
     // Suppress persistent save option during env-only startup model selection
@@ -496,7 +498,7 @@ mod tests {
 
         let help_text = generate_picker_help_text(&app);
 
-        assert!(help_text.contains("↑/↓=Navigate • F2=Sort • Type=Filter"));
+        assert!(help_text.contains("↑/↓=Navigate • F6=Sort • Type=Filter"));
         assert!(help_text.contains("Enter=This session • Alt+Enter=As default"));
         assert!(!help_text.contains("Del=Remove default"));
     }
@@ -517,7 +519,7 @@ mod tests {
 
         let help_text = generate_picker_help_text(&app);
 
-        assert!(help_text.contains("↑/↓=Navigate • Backspace=Clear • F2=Sort"));
+        assert!(help_text.contains("↑/↓=Navigate • Backspace=Clear • F6=Sort"));
         assert!(help_text.contains("Enter=This session • Alt+Enter=As default"));
         assert!(!help_text.contains("Type=Filter"));
     }
@@ -540,7 +542,7 @@ mod tests {
         let help_text = generate_picker_help_text(&app);
 
         assert!(help_text.contains("Del=Remove default"));
-        assert!(help_text.contains("↑/↓=Navigate • F2=Sort • Type=Filter • Del=Remove default"));
+        assert!(help_text.contains("↑/↓=Navigate • F6=Sort • Type=Filter • Del=Remove default"));
         assert!(help_text.contains("Enter=This session • Alt+Enter=As default"));
     }
 
@@ -562,7 +564,7 @@ mod tests {
         let help_text = generate_picker_help_text(&app);
 
         assert!(help_text.contains("Del=Remove default"));
-        assert!(help_text.contains("↑/↓=Navigate • F2=Sort • Type=Filter • Del=Remove default"));
+        assert!(help_text.contains("↑/↓=Navigate • F6=Sort • Type=Filter • Del=Remove default"));
         assert!(help_text.contains("Enter=This session • Alt+Enter=As default"));
     }
 
@@ -582,7 +584,7 @@ mod tests {
 
         let help_text = generate_picker_help_text(&app);
 
-        assert!(help_text.contains("↑/↓=Navigate • F2=Sort • Type=Filter"));
+        assert!(help_text.contains("↑/↓=Navigate • F6=Sort • Type=Filter"));
         assert!(help_text.contains("Enter=This session • Alt+Enter=As default"));
         assert!(!help_text.contains("Del=Remove default"));
     }

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -69,6 +69,7 @@ pub fn create_test_app() -> App {
         startup_multiple_providers_available: false,
         exit_requested: false,
         startup_env_only: false,
+        compose_mode: false,
     }
 }
 


### PR DESCRIPTION
- Add compose mode (F4): Enter=newline; arrows move input; Shift+arrows scroll
- Make Ctrl+J newline (normal) and send (compose); persist in pickers
- Unify picker apply path for Enter/Ctrl+J; consume event to avoid leaks
- Switch picker sort key to F6; update in‑TUI titles/help accordingly
- Add App.compose_mode state and wire through renderer/help/test utils