### PR TITLE
Refactoring: Chat loop

### DIFF
--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -22,9 +22,9 @@ Items are removed when completed.
 
 ## Code quality
 
-- Refactor `src/ui/chat_loop.rs` into smaller, testable units — [OPEN]
-  - Extract input handling, selection mode, picker handling, and streaming dispatch into helpers/modules — [OPEN]
-  - Add pure functions for selection navigation (wrap-around) and reuse across keys (↑/↓/j/k/Ctrl+P) — [OPEN]
+- Refactor `src/ui/chat_loop.rs` into smaller, testable units — [PARTIAL]
+  - Extract input handling, selection mode, picker handling, and streaming dispatch into helpers/modules — [PARTIAL]
+  - Add pure functions for selection navigation (wrap-around) and reuse across keys (↑/↓/j/k/Ctrl+P) — [PARTIAL]
 - Reduce duplication in `src/ui/markdown.rs` for code block flushing (extract helper) — [OPEN]
 - Consolidate plain vs markdown rendering path selection — [PARTIAL]
 - Centralize help text — [OPEN]

--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -24,7 +24,6 @@ Items are removed when completed.
 
 - Refactor `src/ui/chat_loop.rs` into smaller, testable units — [PARTIAL]
   - Extract input handling, selection mode, picker handling, and streaming dispatch into helpers/modules — [PARTIAL]
-  - Add pure functions for selection navigation (wrap-around) and reuse across keys (↑/↓/j/k/Ctrl+P) — [PARTIAL]
 - Reduce duplication in `src/ui/markdown.rs` for code block flushing (extract helper) — [OPEN]
 - Consolidate plain vs markdown rendering path selection — [PARTIAL]
 - Centralize help text — [OPEN]

--- a/src/ui/chat_loop/setup.rs
+++ b/src/ui/chat_loop/setup.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::{
+    auth::AuthManager,
+    core::{app::App, builtin_providers::load_builtin_providers, config::Config},
+};
+
+/// Build the application state for the chat loop, including startup picker flows.
+///
+/// This logic was historically embedded inside `run_chat`; extracting it keeps the event loop
+/// focused on UI concerns while centralising provider/model setup policy.
+pub async fn bootstrap_app(
+    model: String,
+    log: Option<String>,
+    provider: Option<String>,
+    env_only: bool,
+) -> Result<Arc<Mutex<App>>, Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+    let auth_manager = AuthManager::new();
+
+    // Gather providers with stored tokens (ignored in env-only mode)
+    let mut token_providers: Vec<String> = Vec::new();
+    if !env_only {
+        for bp in load_builtin_providers() {
+            if auth_manager.get_token(&bp.id).unwrap_or(None).is_some() {
+                token_providers.push(bp.id);
+            }
+        }
+        for (id, _display, _url, has_token) in auth_manager.list_custom_providers() {
+            if has_token {
+                token_providers.push(id);
+            }
+        }
+    }
+
+    let has_env_openai = std::env::var("OPENAI_API_KEY").is_ok();
+
+    // Provider selection rules mirror the prior implementation.
+    let mut selected_provider: Option<String> = None;
+    let mut open_provider_picker = false;
+    let total_available = token_providers.len() + if has_env_openai { 1 } else { 0 };
+    let multiple_providers_available = total_available > 1;
+
+    if !env_only {
+        if let Some(p) = provider.clone() {
+            if !p.is_empty() {
+                selected_provider = Some(p);
+            }
+        }
+    }
+
+    if selected_provider.is_none() {
+        if env_only && !has_env_openai {
+            eprintln!("❌ --env used but OPENAI_API_KEY is not set");
+            std::process::exit(2);
+        }
+        if let Some(default_p) = &config.default_provider {
+            selected_provider = Some(default_p.clone());
+        } else if token_providers.len() == 1 {
+            selected_provider = token_providers.first().cloned();
+        } else if total_available > 1 {
+            open_provider_picker = true;
+        } else if has_env_openai {
+            selected_provider = None;
+        } else {
+            eprintln!("❌ No authentication configured and OPENAI_API_KEY environment variable not set\n\nPlease either:\n1. Run 'chabeau auth' to set up authentication, or\n2. Set environment variables:\n   export OPENAI_API_KEY=\"your-api-key-here\"\n   export OPENAI_BASE_URL=\"https://api.openai.com/v1\"  # Optional");
+            std::process::exit(2);
+        }
+    }
+
+    let app = if open_provider_picker {
+        let app = Arc::new(Mutex::new(
+            App::new_uninitialized(log.clone()).await.expect("init app"),
+        ));
+        {
+            let mut app_guard = app.lock().await;
+            app_guard.startup_requires_provider = true;
+            app_guard.startup_multiple_providers_available = multiple_providers_available;
+            app_guard.open_provider_picker();
+        }
+        app
+    } else {
+        let app = Arc::new(Mutex::new(
+            match App::new_with_auth(model.clone(), log.clone(), selected_provider, env_only).await
+            {
+                Ok(app) => app,
+                Err(e) => {
+                    let error_msg = e.to_string();
+                    if error_msg.contains("No authentication")
+                        || error_msg.contains("OPENAI_API_KEY")
+                    {
+                        eprintln!("{error_msg}");
+                        eprintln!();
+                        eprintln!("💡 Quick fixes:");
+                        eprintln!("  • chabeau auth                    # Interactive setup");
+                        eprintln!("  • chabeau -p                      # Check provider status");
+                        eprintln!("  • export OPENAI_API_KEY=sk-...    # Use environment variable (defaults to OpenAI API)");
+                        std::process::exit(2);
+                    } else {
+                        eprintln!("❌ Error: {e}");
+                        std::process::exit(1);
+                    }
+                }
+            },
+        ));
+        let mut need_model_picker = false;
+        {
+            let app_guard = app.lock().await;
+            if app_guard.model.is_empty() {
+                need_model_picker = true;
+            }
+        }
+        if need_model_picker {
+            let mut app_guard = app.lock().await;
+            app_guard.startup_requires_model = true;
+            app_guard.startup_multiple_providers_available = multiple_providers_available;
+            let env_only = has_env_openai && token_providers.is_empty();
+            app_guard.startup_env_only = env_only;
+            if let Err(e) = app_guard.open_model_picker().await {
+                app_guard.set_status(format!("Model picker error: {}", e));
+            }
+        }
+        app
+    };
+
+    Ok(app)
+}

--- a/src/ui/chat_loop/stream.rs
+++ b/src/ui/chat_loop/stream.rs
@@ -1,0 +1,129 @@
+use futures_util::StreamExt;
+use memchr::memchr;
+use tokio::sync::mpsc;
+
+use crate::api::{ChatRequest, ChatResponse};
+use crate::utils::url::construct_api_url;
+
+pub const STREAM_END_MARKER: &str = "<<STREAM_END>>";
+
+pub struct StreamParams {
+    pub client: reqwest::Client,
+    pub base_url: String,
+    pub api_key: String,
+    pub model: String,
+    pub api_messages: Vec<crate::api::ChatMessage>,
+    pub cancel_token: tokio_util::sync::CancellationToken,
+    pub stream_id: u64,
+}
+
+#[derive(Clone)]
+pub struct StreamDispatcher {
+    tx: mpsc::UnboundedSender<(String, u64)>,
+}
+
+impl StreamDispatcher {
+    pub fn new(tx: mpsc::UnboundedSender<(String, u64)>) -> Self {
+        Self { tx }
+    }
+
+    pub fn spawn(&self, params: StreamParams) {
+        let tx_clone = self.tx.clone();
+        tokio::spawn(async move {
+            let StreamParams {
+                client,
+                base_url,
+                api_key,
+                model,
+                api_messages,
+                cancel_token,
+                stream_id,
+            } = params;
+
+            let request = ChatRequest {
+                model,
+                messages: api_messages,
+                stream: true,
+            };
+
+            tokio::select! {
+                _ = async {
+                    let chat_url = construct_api_url(&base_url, "chat/completions");
+                    match client
+                        .post(chat_url)
+                        .header("Authorization", format!("Bearer {api_key}"))
+                        .header("Content-Type", "application/json")
+                        .json(&request)
+                        .send()
+                        .await
+                    {
+                        Ok(response) => {
+                            if !response.status().is_success() {
+                                let error_text = response
+                                    .text()
+                                    .await
+                                    .unwrap_or_else(|_| "<no body>".to_string());
+                                let _ = tx_clone
+                                    .send((format!("<<API_ERROR>>{}", error_text), stream_id));
+                                let _ = tx_clone.send((STREAM_END_MARKER.to_string(), stream_id));
+                                return;
+                            }
+
+                            let mut stream = response.bytes_stream();
+                            let mut buffer: Vec<u8> = Vec::new();
+
+                            while let Some(chunk) = stream.next().await {
+                                if cancel_token.is_cancelled() {
+                                    return;
+                                }
+
+                                if let Ok(chunk_bytes) = chunk {
+                                    buffer.extend_from_slice(&chunk_bytes);
+
+                                    while let Some(newline_pos) = memchr(b'\n', &buffer) {
+                                        let line_str = match std::str::from_utf8(&buffer[..newline_pos]) {
+                                            Ok(s) => s.trim(),
+                                            Err(e) => {
+                                                eprintln!("Invalid UTF-8 in stream: {e}");
+                                                buffer.drain(..=newline_pos);
+                                                continue;
+                                            }
+                                        };
+
+                                        if let Some(data) = line_str.strip_prefix("data: ") {
+                                            if data == "[DONE]" {
+                                                let _ = tx_clone
+                                                    .send((STREAM_END_MARKER.to_string(), stream_id));
+                                                return;
+                                            }
+
+                                            match serde_json::from_str::<ChatResponse>(data) {
+                                                Ok(response) => {
+                                                    if let Some(choice) = response.choices.first() {
+                                                        if let Some(content) = &choice.delta.content {
+                                                            let _ = tx_clone
+                                                                .send((content.clone(), stream_id));
+                                                        }
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    eprintln!("Failed to parse JSON: {e} - Data: {data}");
+                                                }
+                                            }
+                                        }
+                                        buffer.drain(..=newline_pos);
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            let _ = tx_clone.send((format!("<<API_ERROR>>{}", e), stream_id));
+                            let _ = tx_clone.send((STREAM_END_MARKER.to_string(), stream_id));
+                        }
+                    }
+                } => {}
+                _ = cancel_token.cancelled() => {}
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR finishes untangling the chat loop by carving the monolithic module into dedicated pieces. We now lean on setup.rs for startup/provider bootstrapping, stream.rs for streaming dispatch, and the refactored mod.rs orchestrates the loop using typed PickerSession state. That split keeps picker lifecycle, retry prep, and code block selection logic focused and testable while preserving existing UI behavior.

On top of that structural work, the patch pulls all picker, block-select, and edit-select shortcuts out of the main loop and into self-contained helpers.  Shared wrap-around utilities back those helpers, and a single recompute_input_layout_if_due replaces the old closure. It means Ctrl+P, Ctrl+B, block-copy/ save, and the picker apply/cancel paths workout in isolation and the loop only coordinates escape hatches.

Finally, the commit that sealed this PR handles the remaining key handling “soup.” Escape, Ctrl+D, Ctrl+J, Ctrl+T, Enter, and Ctrl+R are now async helpers that either short-circuit or spawn streams, while the leftovers in the match cover just textarea movement and viewport scrolling. Tests, clippy, and fmt all pass, so the loop is slimmer and ready for follow-on work like grouping the navigation keys into their own helper.
