### PR TITLE
fix: implement event-driven rendering to enable mouse selection

### DIFF
--- a/src/utils/auth.rs
+++ b/src/utils/auth.rs
@@ -31,7 +31,7 @@ pub fn add_auth_headers(
                 .header("anthropic-version", "2023-06-01");
         }
     }
-    
+
     // Default to OpenAI-style authentication for all other providers
     request.header("Authorization", format!("Bearer {api_key}"))
 }


### PR DESCRIPTION
- Replace continuous repainting with conditional rendering
- Add 60 FPS frame rate limiting to prevent excessive redraws
- Request redraws only after key events, paste, resize, or streaming
- Add idle yielding to prevent busy waiting when no events occur
- Remove non-functional mouse event handling code that never ran (we benefited from automatic translation of scroll wheel events to cursor keys)