### PR TITLE
fix: keep markdown links from splitting words

### DIFF
--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -33,6 +33,9 @@ Items are removed when completed.
 - Logging durability — [OPEN]
   - Make log rewrites (after truncate/in-place edit) atomic via temp file + rename — [OPEN]
   - Optionally append a log marker indicating manual history edits — [OPEN]
+- Markdown span metadata — [OPEN]
+  - Replace style-based link detection with explicit span metadata (e.g., `SpanKind`) carried through wrapping helpers
+  - Update scroll pre-wrap, selection highlighting, and markdown renderer to consume the richer span information
 - Height/scroll DRYing — [PARTIAL]
   - Prefer `App::calculate_available_height` everywhere; keep a single helper for “scroll selected index into view” (already added) — [PARTIAL]
   - Standardize usage in renderer and chat loop — [OPEN]

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -8,6 +8,10 @@ use ratatui::text::{Line, Span};
 use std::collections::VecDeque;
 use unicode_width::UnicodeWidthStr;
 
+#[path = "markdown_wrap.rs"]
+mod wrap;
+use wrap::wrap_spans_to_width_generic_shared;
+
 #[derive(Clone, Debug)]
 enum ListKind {
     Unordered,
@@ -3131,131 +3135,6 @@ fn flush_current_line(lines: &mut Vec<Line<'static>>, current_spans: &mut Vec<Sp
 fn detab(s: &str) -> String {
     // Simple, predictable detab: replace tabs with 4 spaces
     s.replace('\t', "    ")
-}
-
-// Shared helper: wrap generic paragraph spans (non-table) to width, preserving styles.
-// Used by both the main renderer and width-aware range computation to ensure consistency.
-fn wrap_spans_to_width_generic_shared(
-    spans: &[Span<'static>],
-    max_width: usize,
-) -> Vec<Vec<Span<'static>>> {
-    const MAX_UNBREAKABLE_LENGTH: usize = 30;
-    if spans.is_empty() {
-        return vec![Vec::new()];
-    }
-    let mut wrapped_lines = Vec::new();
-    let mut current_line: Vec<Span<'static>> = Vec::new();
-    let mut current_width = 0usize;
-    // Break incoming spans into owned (text, style) parts
-    let mut parts: Vec<(String, Style)> = spans
-        .iter()
-        .map(|s| (s.content.to_string(), s.style))
-        .collect();
-    for (mut text, style) in parts.drain(..) {
-        while !text.is_empty() {
-            let mut chars_to_fit = 0usize;
-            let mut width_so_far = 0usize;
-            let mut last_break_pos: Option<(usize, usize)> = None;
-            for (char_pos, ch) in text.char_indices() {
-                let cw = UnicodeWidthStr::width(ch.encode_utf8(&mut [0; 4]));
-                if current_width + width_so_far + cw <= max_width {
-                    width_so_far += cw;
-                    chars_to_fit = char_pos + ch.len_utf8();
-                    if ch.is_whitespace() {
-                        last_break_pos = Some((char_pos + ch.len_utf8(), width_so_far));
-                    }
-                } else {
-                    break;
-                }
-            }
-            if chars_to_fit == 0 {
-                // Nothing fits on this line
-                if !current_line.is_empty() {
-                    wrapped_lines.push(std::mem::take(&mut current_line));
-                    current_width = 0;
-                    continue;
-                } else {
-                    // Consider unbreakable word
-                    let next_word_end = text.find(char::is_whitespace).unwrap_or(text.len());
-                    let next_word = &text[..next_word_end];
-                    let ww = UnicodeWidthStr::width(next_word);
-                    if ww <= MAX_UNBREAKABLE_LENGTH {
-                        current_line.push(Span::styled(next_word.to_string(), style));
-                        current_width += ww;
-                        if next_word_end < text.len() {
-                            text = text[next_word_end..].to_string();
-                        } else {
-                            break;
-                        }
-                    } else {
-                        // Hard break the very long token
-                        let mut forced_width = 0usize;
-                        let mut forced_end = text.len();
-                        for (char_pos, ch) in text.char_indices() {
-                            let cw = UnicodeWidthStr::width(ch.encode_utf8(&mut [0; 4]));
-                            if forced_width + cw > max_width {
-                                forced_end = char_pos;
-                                break;
-                            }
-                            forced_width += cw;
-                        }
-                        if forced_end > 0 {
-                            let chunk = text[..forced_end].to_string();
-                            current_line.push(Span::styled(chunk, style));
-                            current_width = forced_width;
-                            text = text[forced_end..].to_string();
-                            if !text.is_empty() {
-                                wrapped_lines.push(std::mem::take(&mut current_line));
-                                current_width = 0;
-                            }
-                        } else {
-                            current_line.push(Span::styled(text.clone(), style));
-                            current_width += UnicodeWidthStr::width(text.as_str());
-                            break;
-                        }
-                    }
-                }
-            } else if chars_to_fit >= text.len() {
-                current_line.push(Span::styled(text.clone(), style));
-                current_width += width_so_far;
-                break;
-            } else {
-                let (break_pos, _bw) = last_break_pos.unwrap_or((chars_to_fit, width_so_far));
-                if last_break_pos.is_none() && current_width > 0 {
-                    // No natural break inside the incoming span; start it on the next line so
-                    // multi-word links and long tokens stay intact.
-                    wrapped_lines.push(std::mem::take(&mut current_line));
-                    current_width = 0;
-                    continue;
-                }
-                let left = text[..break_pos].trim_end();
-                if !left.is_empty() {
-                    let left_width = UnicodeWidthStr::width(left);
-                    if current_width > 0 && current_width + left_width > max_width {
-                        wrapped_lines.push(std::mem::take(&mut current_line));
-                        current_width = 0;
-                    }
-                    if left_width > 0 {
-                        current_line.push(Span::styled(left.to_string(), style));
-                        current_width += left_width;
-                    }
-                }
-                text = text[break_pos..].trim_start().to_string();
-                if !text.is_empty() {
-                    wrapped_lines.push(std::mem::take(&mut current_line));
-                    current_width = 0;
-                }
-            }
-        }
-    }
-    if !current_line.is_empty() {
-        wrapped_lines.push(current_line);
-    }
-    if wrapped_lines.is_empty() {
-        vec![Vec::new()]
-    } else {
-        wrapped_lines
-    }
 }
 
 /// Build display lines for all messages using markdown rendering

--- a/src/ui/markdown_wrap.rs
+++ b/src/ui/markdown_wrap.rs
@@ -1,0 +1,146 @@
+use ratatui::{style::Style, text::Span};
+use unicode_width::UnicodeWidthStr;
+
+/// Wrap spans to the provided width while preserving styles and word boundaries.
+/// Shared between markdown rendering and range computation so downstream
+/// consumers stay in sync.
+pub(crate) fn wrap_spans_to_width_generic_shared(
+    spans: &[Span<'static>],
+    max_width: usize,
+) -> Vec<Vec<Span<'static>>> {
+    const MAX_UNBREAKABLE_LENGTH: usize = 30;
+    if spans.is_empty() {
+        return vec![Vec::new()];
+    }
+    let mut wrapped_lines = Vec::new();
+    let mut current_line: Vec<Span<'static>> = Vec::new();
+    let mut current_width = 0usize;
+    // Break incoming spans into owned (text, style) parts
+    let mut parts: Vec<(String, Style)> = spans
+        .iter()
+        .map(|s| (s.content.to_string(), s.style))
+        .collect();
+    for (mut text, style) in parts.drain(..) {
+        while !text.is_empty() {
+            let mut chars_to_fit = 0usize;
+            let mut width_so_far = 0usize;
+            let mut last_break_pos: Option<(usize, usize)> = None;
+            for (char_pos, ch) in text.char_indices() {
+                let cw = UnicodeWidthStr::width(ch.encode_utf8(&mut [0; 4]));
+                if current_width + width_so_far + cw <= max_width {
+                    width_so_far += cw;
+                    chars_to_fit = char_pos + ch.len_utf8();
+                    if ch.is_whitespace() {
+                        last_break_pos = Some((char_pos + ch.len_utf8(), width_so_far));
+                    }
+                } else {
+                    break;
+                }
+            }
+            if chars_to_fit == 0 {
+                // Nothing fits on this line
+                if !current_line.is_empty() {
+                    wrapped_lines.push(std::mem::take(&mut current_line));
+                    current_width = 0;
+                    continue;
+                } else {
+                    // Consider unbreakable word
+                    let next_word_end = text.find(char::is_whitespace).unwrap_or(text.len());
+                    let next_word = &text[..next_word_end];
+                    let ww = UnicodeWidthStr::width(next_word);
+                    if ww <= MAX_UNBREAKABLE_LENGTH {
+                        current_line.push(Span::styled(next_word.to_string(), style));
+                        current_width += ww;
+                        if next_word_end < text.len() {
+                            text = text[next_word_end..].to_string();
+                        } else {
+                            break;
+                        }
+                    } else {
+                        // Hard break the very long token
+                        let mut forced_width = 0usize;
+                        let mut forced_end = text.len();
+                        for (char_pos, ch) in text.char_indices() {
+                            let cw = UnicodeWidthStr::width(ch.encode_utf8(&mut [0; 4]));
+                            if forced_width + cw > max_width {
+                                forced_end = char_pos;
+                                break;
+                            }
+                            forced_width += cw;
+                        }
+                        if forced_end > 0 {
+                            let chunk = text[..forced_end].to_string();
+                            current_line.push(Span::styled(chunk, style));
+                            current_width = forced_width;
+                            text = text[forced_end..].to_string();
+                            if !text.is_empty() {
+                                wrapped_lines.push(std::mem::take(&mut current_line));
+                                current_width = 0;
+                            }
+                        } else {
+                            current_line.push(Span::styled(text.clone(), style));
+                            current_width += UnicodeWidthStr::width(text.as_str());
+                            break;
+                        }
+                    }
+                }
+            } else if chars_to_fit >= text.len() {
+                current_line.push(Span::styled(text.clone(), style));
+                current_width += width_so_far;
+                break;
+            } else {
+                let (break_pos, _bw) = last_break_pos.unwrap_or((chars_to_fit, width_so_far));
+                if last_break_pos.is_none() && current_width > 0 {
+                    // No natural break inside the incoming span; start it on the next line so
+                    // multi-word links and long tokens stay intact.
+                    wrapped_lines.push(std::mem::take(&mut current_line));
+                    current_width = 0;
+                    continue;
+                }
+                let left = text[..break_pos].trim_end();
+                if !left.is_empty() {
+                    let left_width = UnicodeWidthStr::width(left);
+                    if current_width > 0 && current_width + left_width > max_width {
+                        wrapped_lines.push(std::mem::take(&mut current_line));
+                        current_width = 0;
+                    }
+                    if left_width > 0 {
+                        current_line.push(Span::styled(left.to_string(), style));
+                        current_width += left_width;
+                    }
+                }
+                text = text[break_pos..].trim_start().to_string();
+                if !text.is_empty() {
+                    wrapped_lines.push(std::mem::take(&mut current_line));
+                    current_width = 0;
+                }
+            }
+        }
+    }
+    if !current_line.is_empty() {
+        wrapped_lines.push(current_line);
+    }
+    if wrapped_lines.is_empty() {
+        vec![Vec::new()]
+    } else {
+        wrapped_lines
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wrap_spans_to_width_generic_shared;
+    use ratatui::text::Span;
+
+    #[test]
+    fn wrap_splits_at_spaces() {
+        let spans = vec![Span::raw("word boundary test")];
+        let wrapped = wrap_spans_to_width_generic_shared(&spans, 6);
+        let lines: Vec<String> = wrapped
+            .into_iter()
+            .map(|line| line.iter().map(|s| s.content.as_ref()).collect::<String>())
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert_eq!(lines, vec!["word", "bounda", "ry", "test"]);
+    }
+}

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -75,3 +75,6 @@ pub fn create_test_messages() -> VecDeque<Message> {
     ));
     messages
 }
+
+#[cfg(test)]
+pub const SAMPLE_HYPERTEXT_PARAGRAPH: &str = "The story of hypertext begins not with Tim Berners-Lee's World Wide Web, but with Vannevar Bush's 1945 essay \"As We May Think,\" where he envisioned the Memex - a device that would store books, records, and communications, and mechanically link them together by association. Ted Nelson, inspired by Bush's vision, coined the term \"hypertext\" in 1963 and spent decades developing [the original web proposal](https://www.example.com) - a system that would revolutionize how we think about documents, copyright, and knowledge itself. Nelson's Xanadu wasn't just about linking documents; it was about creating a [hypertext dreams](https://docs.hypertext.org) where every quotation would be automatically linked to its source, authors would be compensated for every use of their work, and the sum of human knowledge would be accessible through an elegant web of associations.";


### PR DESCRIPTION
- track no-break spans correctly when width wrapping spans lack natural breakpoints
- detect link spans via styling hint and treat in-link whitespace as valid wrap points
- add shared hypertext sample plus regression tests across markdown and prewrap paths
- refactor in preparation for larger changes to link handling