### PR TITLE
Add link rendering support via OSC sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "futures-util",
  "keyring",
  "memchr",
+ "once_cell",
  "pulldown-cmark",
  "ratatui",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ syntect = "5"
 async-trait = "0.1"
 unicode-width = "0.2.0"
 memchr = "2.7"
+once_cell = "1.19"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"

--- a/src/ui/chat_loop/keybindings/handlers.rs
+++ b/src/ui/chat_loop/keybindings/handlers.rs
@@ -617,7 +617,7 @@ impl KeyHandler for CtrlRHandler {
 pub struct CtrlTHandler {
     pub stream_dispatcher: Arc<StreamDispatcher>,
     pub terminal:
-        Arc<Mutex<ratatui::Terminal<ratatui::prelude::CrosstermBackend<std::io::Stdout>>>>,
+        Arc<Mutex<ratatui::Terminal<crate::ui::osc_backend::OscBackend<std::io::Stdout>>>>,
 }
 
 #[async_trait::async_trait]

--- a/src/ui/chat_loop/keybindings/mod.rs
+++ b/src/ui/chat_loop/keybindings/mod.rs
@@ -21,7 +21,7 @@ pub enum KeyLoopAction {
 pub fn build_mode_aware_registry(
     stream_dispatcher: std::sync::Arc<crate::ui::chat_loop::stream::StreamDispatcher>,
     terminal: std::sync::Arc<
-        tokio::sync::Mutex<ratatui::Terminal<ratatui::prelude::CrosstermBackend<std::io::Stdout>>>,
+        tokio::sync::Mutex<ratatui::Terminal<crate::ui::osc_backend::OscBackend<std::io::Stdout>>>,
     >,
 ) -> ModeAwareRegistry {
     use handlers::*;

--- a/src/ui/chat_loop/mod.rs
+++ b/src/ui/chat_loop/mod.rs
@@ -18,6 +18,7 @@ use self::stream::{StreamDispatcher, StreamParams, STREAM_END_MARKER};
 use crate::commands::process_input;
 use crate::commands::CommandResult;
 use crate::core::app::App;
+use crate::ui::osc_backend::OscBackend;
 use crate::ui::renderer::ui;
 use crate::utils::editor::handle_external_editor;
 use ratatui::crossterm::{
@@ -25,7 +26,7 @@ use ratatui::crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::{backend::CrosstermBackend, Terminal};
+use ratatui::Terminal;
 use std::{
     error::Error,
     io,
@@ -87,7 +88,7 @@ pub async fn run_chat(
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
-    let backend = CrosstermBackend::new(stdout);
+    let backend = OscBackend::new(stdout);
     let terminal = Arc::new(Mutex::new(Terminal::new(backend)?));
 
     // Channel for streaming updates with stream ID
@@ -531,7 +532,7 @@ async fn handle_block_select_mode_event(
 
 async fn handle_external_editor_shortcut(
     app: &Arc<Mutex<App>>,
-    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    terminal: &mut Terminal<OscBackend<io::Stdout>>,
     stream_dispatcher: &StreamDispatcher,
     term_width: u16,
     term_height: u16,

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -208,4 +208,21 @@ mod tests {
             assert!(kinds.iter().all(|k| k.is_text()));
         }
     }
+
+    #[test]
+    fn layout_lines_can_be_encoded_with_osc_links() {
+        let mut messages = VecDeque::new();
+        messages.push_back(Message {
+            role: "assistant".into(),
+            content: "[Rust](https://www.rust-lang.org) and [Go](https://go.dev)".into(),
+        });
+        let theme = Theme::dark_default();
+        let layout = LayoutEngine::layout_messages(&messages, &theme, &LayoutConfig::default());
+        let encoded = crate::ui::osc::encode_lines_with_links(&layout.lines, &layout.span_metadata);
+        let joined = encoded.join("\n");
+        assert!(joined.contains("Rust"));
+        assert!(joined.contains("Go"));
+        assert!(joined.matches("\x1b]8;;").count() >= 4);
+        assert!(joined.matches("\x1b]8;;\x1b\\").count() >= 2);
+    }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -219,10 +219,30 @@ mod tests {
         let theme = Theme::dark_default();
         let layout = LayoutEngine::layout_messages(&messages, &theme, &LayoutConfig::default());
         let encoded = crate::ui::osc::encode_lines_with_links(&layout.lines, &layout.span_metadata);
-        let joined = encoded.join("\n");
+        let joined = encoded
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(joined.contains("Rust"));
         assert!(joined.contains("Go"));
         assert!(joined.matches("\x1b]8;;").count() >= 4);
         assert!(joined.matches("\x1b]8;;\x1b\\").count() >= 2);
+    }
+
+    #[test]
+    fn link_metadata_spans_cover_spaces_within_link_text() {
+        let mut messages = VecDeque::new();
+        messages.push_back(Message {
+            role: "assistant".into(),
+            content: "[associative trails](https://example.com)".into(),
+        });
+        let theme = Theme::dark_default();
+        let layout = LayoutEngine::layout_messages(&messages, &theme, &LayoutConfig::default());
+
+        let first_line = layout.lines.first().expect("line");
+        let first_meta = layout.span_metadata.first().expect("meta");
+        assert_eq!(first_line.spans.len(), first_meta.len());
+        assert!(first_meta.iter().all(|kind| kind.is_link()));
     }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -168,7 +168,7 @@ impl LayoutEngine {
 
 #[cfg(test)]
 mod tests {
-    use super::{LayoutConfig, LayoutEngine, SpanKind, Theme};
+    use super::{LayoutConfig, LayoutEngine, Theme};
     use crate::core::message::Message;
     use std::collections::VecDeque;
 
@@ -185,7 +185,7 @@ mod tests {
         assert_eq!(layout.lines.len(), layout.span_metadata.len());
         let mut saw_link = false;
         for kinds in &layout.span_metadata {
-            if kinds.iter().any(|k| *k == SpanKind::Link) {
+            if kinds.iter().any(|k| k.is_link()) {
                 saw_link = true;
                 break;
             }
@@ -205,7 +205,7 @@ mod tests {
 
         assert_eq!(layout.lines.len(), layout.span_metadata.len());
         for kinds in &layout.span_metadata {
-            assert!(kinds.iter().all(|k| *k == SpanKind::Text));
+            assert!(kinds.iter().all(|k| k.is_text()));
         }
     }
 }

--- a/src/ui/markdown_wrap.rs
+++ b/src/ui/markdown_wrap.rs
@@ -19,7 +19,7 @@ pub(crate) fn wrap_spans_to_width_generic_shared(
     // Break incoming spans into owned (text, style) parts
     let mut parts: Vec<(String, Style, SpanKind)> = spans
         .iter()
-        .map(|(s, kind)| (s.content.to_string(), s.style, *kind))
+        .map(|(s, kind)| (s.content.to_string(), s.style, kind.clone()))
         .collect();
     for (mut text, style, kind) in parts.drain(..) {
         while !text.is_empty() {
@@ -50,7 +50,8 @@ pub(crate) fn wrap_spans_to_width_generic_shared(
                     let next_word = &text[..next_word_end];
                     let ww = UnicodeWidthStr::width(next_word);
                     if ww <= MAX_UNBREAKABLE_LENGTH {
-                        current_line.push((Span::styled(next_word.to_string(), style), kind));
+                        current_line
+                            .push((Span::styled(next_word.to_string(), style), kind.clone()));
                         current_width += ww;
                         if next_word_end < text.len() {
                             text = text[next_word_end..].to_string();
@@ -71,7 +72,7 @@ pub(crate) fn wrap_spans_to_width_generic_shared(
                         }
                         if forced_end > 0 {
                             let chunk = text[..forced_end].to_string();
-                            current_line.push((Span::styled(chunk, style), kind));
+                            current_line.push((Span::styled(chunk, style), kind.clone()));
                             current_width = forced_width;
                             text = text[forced_end..].to_string();
                             if !text.is_empty() {
@@ -79,14 +80,14 @@ pub(crate) fn wrap_spans_to_width_generic_shared(
                                 current_width = 0;
                             }
                         } else {
-                            current_line.push((Span::styled(text.clone(), style), kind));
+                            current_line.push((Span::styled(text.clone(), style), kind.clone()));
                             current_width += UnicodeWidthStr::width(text.as_str());
                             break;
                         }
                     }
                 }
             } else if chars_to_fit >= text.len() {
-                current_line.push((Span::styled(text.clone(), style), kind));
+                current_line.push((Span::styled(text.clone(), style), kind.clone()));
                 current_width += width_so_far;
                 break;
             } else {
@@ -106,7 +107,7 @@ pub(crate) fn wrap_spans_to_width_generic_shared(
                         current_width = 0;
                     }
                     if left_width > 0 {
-                        current_line.push((Span::styled(left.to_string(), style), kind));
+                        current_line.push((Span::styled(left.to_string(), style), kind.clone()));
                         current_width += left_width;
                     }
                 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,8 @@ pub mod help;
 pub mod layout;
 pub mod markdown;
 pub mod osc;
+pub mod osc_backend;
+pub mod osc_state;
 pub mod picker;
 pub mod renderer;
 pub mod span;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub mod chat_loop;
 pub mod help;
 pub mod layout;
 pub mod markdown;
+pub mod osc;
 pub mod picker;
 pub mod renderer;
 pub mod span;

--- a/src/ui/osc.rs
+++ b/src/ui/osc.rs
@@ -2,6 +2,9 @@
 
 use std::borrow::Cow;
 
+use crate::ui::span::SpanKind;
+use ratatui::text::Line;
+
 const OSC_PREFIX: &str = "\x1b]8;;";
 const ST: &str = "\x1b\\";
 const OSC_SUFFIX: &str = "\x1b]8;;\x1b\\";
@@ -62,9 +65,34 @@ fn contains_disallowed_control(input: &str) -> bool {
     input.bytes().any(|b| (b < 0x20 && b != b'\t') || b == 0x1b)
 }
 
+pub fn encode_line_with_links(line: &Line, kinds: &[SpanKind]) -> String {
+    let mut out = String::new();
+    for (span, kind) in line.spans.iter().zip(kinds.iter()) {
+        let content = span.content.as_ref();
+        if let Some(meta) = kind.link_meta() {
+            if let Some(link) = encode_hyperlink(content, meta.href()) {
+                link.push_to(&mut out);
+                continue;
+            }
+        }
+        out.push_str(content);
+    }
+    out
+}
+
+pub fn encode_lines_with_links(lines: &[Line], metadata: &[Vec<SpanKind>]) -> Vec<String> {
+    lines
+        .iter()
+        .zip(metadata.iter())
+        .map(|(line, kinds)| encode_line_with_links(line, kinds))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{contains_disallowed_control, encode_hyperlink, OSC_PREFIX, OSC_SUFFIX, ST};
+    use crate::ui::span::SpanKind;
+    use ratatui::text::{Line, Span};
 
     #[test]
     fn encode_hyperlink_wraps_text_with_balanced_sequences() {
@@ -98,5 +126,37 @@ mod tests {
         assert!(contains_disallowed_control("carriage\rreturn"));
         assert!(!contains_disallowed_control("tab\tallowed"));
         assert!(!contains_disallowed_control("normal"));
+    }
+
+    #[test]
+    fn encode_line_with_links_applies_osc_sequences() {
+        let line = Line::from(vec![Span::raw("Visit "), Span::raw("Rust"), Span::raw("!")]);
+        let kinds = vec![
+            SpanKind::Text,
+            SpanKind::link("https://www.rust-lang.org"),
+            SpanKind::Text,
+        ];
+        let encoded = super::encode_line_with_links(&line, &kinds);
+        assert!(encoded.contains("Visit "));
+        assert!(encoded.contains("Rust"));
+        assert!(encoded.ends_with(format!("{OSC_SUFFIX}!").as_str()));
+        assert_eq!(encoded.matches(OSC_PREFIX).count(), 2);
+        assert_eq!(encoded.matches(OSC_SUFFIX).count(), 1);
+    }
+
+    #[test]
+    fn encode_lines_with_links_handles_adjacent_links() {
+        let lines = vec![Line::from(vec![Span::raw("Rust"), Span::raw("Go")])];
+        let kinds = vec![vec![
+            SpanKind::link("https://www.rust-lang.org"),
+            SpanKind::link("https://go.dev"),
+        ]];
+        let encoded = super::encode_lines_with_links(&lines, &kinds);
+        assert_eq!(encoded.len(), 1);
+        let first = &encoded[0];
+        assert!(first.contains("Rust"));
+        assert!(first.contains("Go"));
+        assert_eq!(first.matches(OSC_PREFIX).count(), 4);
+        assert_eq!(first.matches(OSC_SUFFIX).count(), 2);
     }
 }

--- a/src/ui/osc.rs
+++ b/src/ui/osc.rs
@@ -1,0 +1,102 @@
+#![cfg_attr(not(test), allow(dead_code))]
+
+use std::borrow::Cow;
+
+const OSC_PREFIX: &str = "\x1b]8;;";
+const ST: &str = "\x1b\\";
+const OSC_SUFFIX: &str = "\x1b]8;;\x1b\\";
+
+/// Encapsulates the pieces required to write an OSC 8 hyperlink without
+/// exposing partially constructed escape sequences.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OscHyperlink<'a> {
+    prefix: String,
+    text: Cow<'a, str>,
+    suffix: &'static str,
+}
+
+impl<'a> OscHyperlink<'a> {
+    /// Append the OSC hyperlink to the provided buffer. The method guarantees
+    /// that the start and end escape sequences are written atomically.
+    pub fn push_to(&self, buf: &mut String) {
+        buf.push_str(&self.prefix);
+        buf.push_str(self.text.as_ref());
+        buf.push_str(self.suffix);
+    }
+
+    /// Returns the OSC-encoded string in a single allocation for convenience
+    /// in tests and log output.
+    pub fn as_encoded_string(&self) -> String {
+        let mut out =
+            String::with_capacity(self.prefix.len() + self.text.len() + self.suffix.len());
+        self.push_to(&mut out);
+        out
+    }
+}
+
+/// Attempt to encode `text` as an OSC 8 hyperlink pointing to `href`. Returns
+/// `None` when emission would be unsafe (empty segments or control characters)
+/// so callers can gracefully fall back to plain text.
+pub fn encode_hyperlink<'a>(text: &'a str, href: &str) -> Option<OscHyperlink<'a>> {
+    if text.is_empty() || href.is_empty() {
+        return None;
+    }
+
+    if contains_disallowed_control(text) || contains_disallowed_control(href) {
+        return None;
+    }
+
+    let mut prefix = String::with_capacity(OSC_PREFIX.len() + href.len() + ST.len());
+    prefix.push_str(OSC_PREFIX);
+    prefix.push_str(href);
+    prefix.push_str(ST);
+
+    Some(OscHyperlink {
+        prefix,
+        text: Cow::Borrowed(text),
+        suffix: OSC_SUFFIX,
+    })
+}
+
+fn contains_disallowed_control(input: &str) -> bool {
+    input.bytes().any(|b| (b < 0x20 && b != b'\t') || b == 0x1b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{contains_disallowed_control, encode_hyperlink, OSC_PREFIX, OSC_SUFFIX, ST};
+
+    #[test]
+    fn encode_hyperlink_wraps_text_with_balanced_sequences() {
+        let link = encode_hyperlink("Rust", "https://www.rust-lang.org").expect("link");
+        let encoded = link.as_encoded_string();
+        assert!(encoded.starts_with(OSC_PREFIX));
+        assert!(encoded.ends_with(OSC_SUFFIX));
+        assert_eq!(encoded.matches(OSC_PREFIX).count(), 2);
+        assert_eq!(encoded.matches(OSC_SUFFIX).count(), 1);
+        assert_eq!(encoded.matches(ST).count(), 2);
+        assert!(encoded.contains("Rust"));
+    }
+
+    #[test]
+    fn encode_hyperlink_rejects_empty_segments() {
+        assert!(encode_hyperlink("", "https://example.com").is_none());
+        assert!(encode_hyperlink("Example", "").is_none());
+    }
+
+    #[test]
+    fn encode_hyperlink_rejects_control_bytes() {
+        assert!(encode_hyperlink("hi", "bad\u{1b}url").is_none());
+        assert!(encode_hyperlink("bad\u{7}text", "https://example.com").is_none());
+    }
+
+    #[test]
+    fn control_detection_catches_bel_and_escape() {
+        assert!(contains_disallowed_control("\u{1b}"));
+        assert!(contains_disallowed_control("\u{7}"));
+        assert!(contains_disallowed_control("line\n"));
+        assert!(contains_disallowed_control("carriage\rreturn"));
+        assert!(!contains_disallowed_control("tab\tallowed"));
+        assert!(!contains_disallowed_control("normal"));
+    }
+}

--- a/src/ui/osc_backend.rs
+++ b/src/ui/osc_backend.rs
@@ -1,0 +1,257 @@
+use std::collections::HashMap;
+use std::io::{self, Write};
+
+use ratatui::{
+    backend::{Backend, ClearType, CrosstermBackend, WindowSize},
+    buffer::Cell,
+    crossterm::{
+        cursor::MoveTo,
+        execute, queue,
+        style::{
+            Attribute as CAttribute, Color as CColor, Colors, Print, SetAttribute,
+            SetBackgroundColor, SetColors, SetForegroundColor,
+        },
+        terminal::{Clear, ClearType as CrosstermClearType},
+    },
+    layout::{Position, Size},
+    style::{Color, Modifier},
+};
+
+use crate::ui::osc_state::take_render_state;
+
+/// Crossterm backend wrapper that injects OSC8 hyperlinks while preserving ratatui invariants.
+#[derive(Debug)]
+pub struct OscBackend<W: Write> {
+    inner: CrosstermBackend<W>,
+}
+
+struct LinkEvents {
+    starts: HashMap<(u16, u16), Vec<String>>,
+    ends: HashMap<(u16, u16), Vec<String>>,
+}
+
+impl<W> OscBackend<W>
+where
+    W: Write,
+{
+    pub const fn new(writer: W) -> Self {
+        Self {
+            inner: CrosstermBackend::new(writer),
+        }
+    }
+
+    fn hyperlink_events(&self) -> LinkEvents {
+        let state = take_render_state();
+        let mut starts: HashMap<(u16, u16), Vec<String>> = HashMap::new();
+        let mut ends: HashMap<(u16, u16), Vec<String>> = HashMap::new();
+
+        for span in state.spans {
+            let start = (*span.x_range.start(), span.y);
+            let end = (*span.x_range.end(), span.y);
+            let href = span.href.href().to_string();
+            starts.entry(start).or_default().push(href.clone());
+            ends.entry(end).or_default().push(href);
+        }
+
+        LinkEvents { starts, ends }
+    }
+
+    fn queue_prefix(&mut self, href: &str) -> io::Result<()> {
+        queue!(self.inner, Print("\x1b]8;;"))?;
+        queue!(self.inner, Print(href))?;
+        queue!(self.inner, Print("\x1b\\"))
+    }
+
+    fn queue_suffix(&mut self) -> io::Result<()> {
+        queue!(self.inner, Print("\x1b]8;;\x1b\\"))
+    }
+}
+
+impl<W> Write for OscBackend<W>
+where
+    W: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        std::io::Write::flush(&mut self.inner)
+    }
+}
+
+impl<W> Backend for OscBackend<W>
+where
+    W: Write,
+{
+    fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>,
+    {
+        let events = self.hyperlink_events();
+
+        let mut fg = Color::Reset;
+        let mut bg = Color::Reset;
+        let mut modifier = Modifier::empty();
+        let mut last_pos: Option<Position> = None;
+
+        for (x, y, cell) in content {
+            if !matches!(last_pos, Some(p) if x == p.x + 1 && y == p.y) {
+                queue!(self.inner, MoveTo(x, y))?;
+            }
+            last_pos = Some(Position { x, y });
+
+            if let Some(hrefs) = events.starts.get(&(x, y)) {
+                for href in hrefs {
+                    self.queue_prefix(href)?;
+                }
+            }
+
+            if cell.modifier != modifier {
+                let diff = ModifierDiff {
+                    from: modifier,
+                    to: cell.modifier,
+                };
+                diff.queue(&mut self.inner)?;
+                modifier = cell.modifier;
+            }
+            if cell.fg != fg || cell.bg != bg {
+                queue!(
+                    self.inner,
+                    SetColors(Colors::new(cell.fg.into(), cell.bg.into()))
+                )?;
+                fg = cell.fg;
+                bg = cell.bg;
+            }
+            queue!(self.inner, Print(cell.symbol()))?;
+
+            if let Some(hrefs) = events.ends.get(&(x, y)) {
+                for _ in hrefs {
+                    self.queue_suffix()?;
+                }
+            }
+        }
+
+        queue!(
+            self.inner,
+            SetForegroundColor(CColor::Reset),
+            SetBackgroundColor(CColor::Reset),
+            SetAttribute(CAttribute::Reset),
+        )
+    }
+
+    fn hide_cursor(&mut self) -> io::Result<()> {
+        self.inner.hide_cursor()
+    }
+
+    fn show_cursor(&mut self) -> io::Result<()> {
+        self.inner.show_cursor()
+    }
+
+    fn get_cursor_position(&mut self) -> io::Result<Position> {
+        self.inner.get_cursor_position()
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+        self.inner.set_cursor_position(position)
+    }
+
+    fn clear(&mut self) -> io::Result<()> {
+        self.inner.clear()
+    }
+
+    fn clear_region(&mut self, clear_type: ClearType) -> io::Result<()> {
+        execute!(
+            self.inner,
+            Clear(match clear_type {
+                ClearType::All => CrosstermClearType::All,
+                ClearType::AfterCursor => CrosstermClearType::FromCursorDown,
+                ClearType::BeforeCursor => CrosstermClearType::FromCursorUp,
+                ClearType::CurrentLine => CrosstermClearType::CurrentLine,
+                ClearType::UntilNewLine => CrosstermClearType::UntilNewLine,
+            })
+        )
+    }
+
+    fn append_lines(&mut self, n: u16) -> io::Result<()> {
+        self.inner.append_lines(n)
+    }
+
+    fn size(&self) -> io::Result<Size> {
+        self.inner.size()
+    }
+
+    fn window_size(&mut self) -> io::Result<WindowSize> {
+        self.inner.window_size()
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Backend::flush(&mut self.inner)
+    }
+}
+
+struct ModifierDiff {
+    from: Modifier,
+    to: Modifier,
+}
+
+impl ModifierDiff {
+    fn queue<W>(&self, mut w: W) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let removed = self.from - self.to;
+        if removed.contains(Modifier::REVERSED) {
+            queue!(w, SetAttribute(CAttribute::NoReverse))?;
+        }
+        if removed.contains(Modifier::BOLD) {
+            queue!(w, SetAttribute(CAttribute::NormalIntensity))?;
+            if self.to.contains(Modifier::DIM) {
+                queue!(w, SetAttribute(CAttribute::Dim))?;
+            }
+        }
+        if removed.contains(Modifier::ITALIC) {
+            queue!(w, SetAttribute(CAttribute::NoItalic))?;
+        }
+        if removed.contains(Modifier::UNDERLINED) {
+            queue!(w, SetAttribute(CAttribute::NoUnderline))?;
+        }
+        if removed.contains(Modifier::DIM) {
+            queue!(w, SetAttribute(CAttribute::NormalIntensity))?;
+        }
+        if removed.contains(Modifier::CROSSED_OUT) {
+            queue!(w, SetAttribute(CAttribute::NotCrossedOut))?;
+        }
+        if removed.contains(Modifier::SLOW_BLINK) || removed.contains(Modifier::RAPID_BLINK) {
+            queue!(w, SetAttribute(CAttribute::NoBlink))?;
+        }
+
+        let added = self.to - self.from;
+        if added.contains(Modifier::REVERSED) {
+            queue!(w, SetAttribute(CAttribute::Reverse))?;
+        }
+        if added.contains(Modifier::BOLD) {
+            queue!(w, SetAttribute(CAttribute::Bold))?;
+        }
+        if added.contains(Modifier::ITALIC) {
+            queue!(w, SetAttribute(CAttribute::Italic))?;
+        }
+        if added.contains(Modifier::UNDERLINED) {
+            queue!(w, SetAttribute(CAttribute::Underlined))?;
+        }
+        if added.contains(Modifier::DIM) {
+            queue!(w, SetAttribute(CAttribute::Dim))?;
+        }
+        if added.contains(Modifier::CROSSED_OUT) {
+            queue!(w, SetAttribute(CAttribute::CrossedOut))?;
+        }
+        if added.contains(Modifier::SLOW_BLINK) {
+            queue!(w, SetAttribute(CAttribute::SlowBlink))?;
+        }
+        if added.contains(Modifier::RAPID_BLINK) {
+            queue!(w, SetAttribute(CAttribute::RapidBlink))?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/ui/osc_state.rs
+++ b/src/ui/osc_state.rs
@@ -1,0 +1,172 @@
+use std::ops::RangeInclusive;
+use std::sync::{Arc, Mutex};
+
+use once_cell::sync::Lazy;
+use ratatui::{layout::Rect, text::Line};
+use unicode_width::UnicodeWidthChar;
+
+use crate::ui::span::{LinkMeta, SpanKind};
+
+#[derive(Clone, Debug)]
+pub struct OscSpan {
+    pub href: Arc<LinkMeta>,
+    pub y: u16,
+    pub x_range: RangeInclusive<u16>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OscRenderState {
+    pub spans: Vec<OscSpan>,
+}
+
+static OSC_RENDER_STATE: Lazy<Mutex<OscRenderState>> =
+    Lazy::new(|| Mutex::new(OscRenderState::default()));
+
+pub fn set_render_state(state: OscRenderState) {
+    if let Ok(mut guard) = OSC_RENDER_STATE.lock() {
+        *guard = state;
+    }
+}
+
+pub fn take_render_state() -> OscRenderState {
+    OSC_RENDER_STATE
+        .lock()
+        .map(|state| state.clone())
+        .unwrap_or_default()
+}
+
+pub fn compute_render_state(
+    area: Rect,
+    lines: &[Line<'static>],
+    metadata: &[Vec<SpanKind>],
+    vertical_offset: usize,
+    horizontal_offset: u16,
+) -> OscRenderState {
+    if area.width == 0 || area.height == 0 {
+        return OscRenderState::default();
+    }
+
+    let mut spans: Vec<OscSpan> = Vec::new();
+    let start_col = horizontal_offset as usize;
+    let area_width = area.width as usize;
+    let end_col = start_col + area_width;
+
+    for row in 0..area.height as usize {
+        let line_index = vertical_offset + row;
+        if line_index >= lines.len() {
+            break;
+        }
+        let line = &lines[line_index];
+        let kinds = metadata.get(line_index);
+        let y = area.y + row as u16;
+
+        struct Run {
+            meta: Arc<LinkMeta>,
+            start_x: Option<u16>,
+            end_x: Option<u16>,
+        }
+
+        let mut active_run: Option<Run> = None;
+        let mut absolute_col = 0usize;
+
+        for (span_idx, span) in line.spans.iter().enumerate() {
+            let span_kind = kinds
+                .and_then(|k| k.get(span_idx))
+                .cloned()
+                .unwrap_or(SpanKind::Text);
+
+            for ch in span.content.chars() {
+                let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+                if ch_width == 0 {
+                    continue;
+                }
+
+                let char_start = absolute_col;
+                let char_end = absolute_col + ch_width;
+                let visible_start = char_start.max(start_col);
+                let visible_end = char_end.min(end_col);
+                let is_visible = visible_start < visible_end;
+
+                match span_kind.link_meta() {
+                    Some(meta) => {
+                        let same_run = active_run
+                            .as_ref()
+                            .map(|run| run.meta.href() == meta.href())
+                            .unwrap_or(false);
+                        if !same_run {
+                            if let Some(run) = active_run.take() {
+                                if let (Some(start_x), Some(end_x)) = (run.start_x, run.end_x) {
+                                    spans.push(OscSpan {
+                                        href: run.meta,
+                                        y,
+                                        x_range: start_x..=end_x,
+                                    });
+                                }
+                            }
+                            active_run = Some(Run {
+                                meta: Arc::new(meta.clone()),
+                                start_x: None,
+                                end_x: None,
+                            });
+                        }
+
+                        if let Some(run) = active_run.as_mut() {
+                            if is_visible {
+                                let first_cell = area.x + (visible_start - start_col) as u16;
+                                let last_cell = area.x + (visible_end - start_col - 1) as u16;
+                                if run.start_x.is_none() {
+                                    run.start_x = Some(first_cell);
+                                }
+                                run.end_x = Some(last_cell);
+                            }
+                        }
+                    }
+                    None => {
+                        if let Some(run) = active_run.take() {
+                            if let (Some(start_x), Some(end_x)) = (run.start_x, run.end_x) {
+                                spans.push(OscSpan {
+                                    href: run.meta,
+                                    y,
+                                    x_range: start_x..=end_x,
+                                });
+                            }
+                        }
+                    }
+                }
+
+                absolute_col = char_end;
+            }
+        }
+
+        if let Some(run) = active_run {
+            if let (Some(start_x), Some(end_x)) = (run.start_x, run.end_x) {
+                spans.push(OscSpan {
+                    href: run.meta,
+                    y,
+                    x_range: start_x..=end_x,
+                });
+            }
+        }
+    }
+
+    OscRenderState { spans }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::text::{Line, Span};
+
+    #[test]
+    fn compute_render_state_tracks_visible_link_segment() {
+        let line = Line::from(vec![Span::raw("Visit "), Span::raw("Rust")]);
+        let metadata = vec![SpanKind::Text, SpanKind::link("https://www.rust-lang.org")];
+        let area = Rect::new(0, 0, 20, 1);
+        let state = compute_render_state(area, &[line], &[metadata], 0, 0);
+        assert_eq!(state.spans.len(), 1);
+        let span = &state.spans[0];
+        assert_eq!(*span.x_range.start(), 6);
+        assert_eq!(*span.x_range.end(), 9);
+        assert_eq!(span.href.href(), "https://www.rust-lang.org");
+    }
+}

--- a/src/ui/span.rs
+++ b/src/ui/span.rs
@@ -1,7 +1,9 @@
+use std::sync::Arc;
+
 /// Semantic classification for rendered spans. Enables downstream
 /// consumers (scroll, selection, accessibility) to make decisions
 /// without relying on styling heuristics such as underline detection.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(dead_code)]
 pub enum SpanKind {
     /// Default text content with no special interaction.
@@ -9,5 +11,55 @@ pub enum SpanKind {
     /// A user message prefix (e.g., "You: ") rendered ahead of content.
     UserPrefix,
     /// A hyperlink span emitted by the markdown renderer.
-    Link,
+    Link(LinkMeta),
+}
+
+impl SpanKind {
+    #[inline]
+    pub fn is_link(&self) -> bool {
+        matches!(self, SpanKind::Link(_))
+    }
+
+    #[inline]
+    pub fn is_user_prefix(&self) -> bool {
+        matches!(self, SpanKind::UserPrefix)
+    }
+
+    #[inline]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn is_text(&self) -> bool {
+        matches!(self, SpanKind::Text)
+    }
+
+    #[inline]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn link_href(&self) -> Option<&str> {
+        match self {
+            SpanKind::Link(meta) => Some(meta.href()),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn link(href: impl Into<String>) -> Self {
+        SpanKind::Link(LinkMeta::new(href))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct LinkMeta {
+    href: Arc<str>,
+}
+
+impl LinkMeta {
+    pub fn new(href: impl Into<String>) -> Self {
+        Self {
+            href: Arc::<str>::from(href.into()),
+        }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn href(&self) -> &str {
+        &self.href
+    }
 }

--- a/src/ui/span.rs
+++ b/src/ui/span.rs
@@ -21,6 +21,14 @@ impl SpanKind {
     }
 
     #[inline]
+    pub fn link_meta(&self) -> Option<&LinkMeta> {
+        match self {
+            SpanKind::Link(meta) => Some(meta),
+            _ => None,
+        }
+    }
+
+    #[inline]
     pub fn is_user_prefix(&self) -> bool {
         matches!(self, SpanKind::UserPrefix)
     }


### PR DESCRIPTION
This was fairly complex because neither ratatui nor crossterm currently support it (https://github.com/crossterm-rs/crossterm/issues/602, https://github.com/ratatui/ratatui/issues/1028). I've spotted occasional issues with scrolling during testing, as well as with the "picker" overlay modals, but these seemed minor enough to land the change and improve from there.