### PR TITLE
refactor: reuse transcript clone for picker

### DIFF
--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -46,3 +46,5 @@ Items are removed when completed.
   - Add tests for `/markdown` and `/syntax` commands by injecting a test config path or IO layer — [OPEN]
   - Consider adding integration tests for the complete Del key workflow in picker dialogs — [OPEN]
   - Consider testing UI state changes after Del key operations (picker refresh) — [OPEN]
+- Picker OSC8 state handling — [OPEN]
+  - Investigate replacing the temporary clone used to strip link modifiers with a render-time style mask so we reuse the cached transcript buffer and toggle hyperlink styling without allocating new `Line` vectors when pickers open/close.


### PR DESCRIPTION
## Summary
- reuse the existing transcript clone and only strip hyperlink modifiers when a picker is active
- note a future render-time masking approach for picker OSC8 state handling in the wishlist

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68da24613078832b86cc1638a403e683