### PR TITLE
Fix OSC hyperlink offsets for emoji presentation sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tui-textarea",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
  "vergen",
  "vergen-git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tui-textarea = "0.7"
 syntect = "5"
 async-trait = "0.1"
 unicode-width = "0.2.0"
+unicode-segmentation = "1.11"
 memchr = "2.7"
 once_cell = "1.19"
 


### PR DESCRIPTION
## Summary
- compute OSC hyperlink spans by iterating grapheme clusters so emoji width matches the rendered table
- add a regression test that covers emoji presentation sequences next to linked text
- pull in unicode-segmentation to support grapheme-aware iteration

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68db66cf172c832bb3c2585bc4731ca1