### PR TITLE
Refactor chat height calculations to use App helper

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -2321,6 +2321,24 @@ mod tests {
     }
 
     #[test]
+    fn calculate_available_height_matches_expected_layout_rules() {
+        let app = create_test_app();
+
+        let cases = [
+            (30, 5, 22), // 30 - (5 + 2) - 1
+            (10, 8, 0),  // Saturating at zero when chat area would be negative
+            (5, 0, 2),   // Just borders and title removed
+        ];
+
+        for (term_height, input_height, expected) in cases {
+            assert_eq!(
+                app.calculate_available_height(term_height, input_height),
+                expected
+            );
+        }
+    }
+
+    #[test]
     fn default_sort_mode_helper_behaviour() {
         let mut app = create_test_app();
         // Theme picker prefers alphabetical → Name

--- a/src/ui/chat_loop/keybindings/handlers.rs
+++ b/src/ui/chat_loop/keybindings/handlers.rs
@@ -62,9 +62,7 @@ pub fn scroll_block_into_view(
             Some(term_width as usize),
         );
     let input_area_height = app_guard.calculate_input_area_height(term_width);
-    let available_height = term_height
-        .saturating_sub(input_area_height + 2)
-        .saturating_sub(1);
+    let available_height = app_guard.calculate_available_height(term_height, input_area_height);
     let desired = crate::utils::scroll::ScrollCalculator::scroll_offset_to_line_start(
         &lines,
         term_width,
@@ -228,25 +226,22 @@ impl KeyHandler for NavigationHandler {
             }
             KeyCode::End => {
                 let input_area_height = app_guard.calculate_input_area_height(term_width);
-                let available_height = term_height
-                    .saturating_sub(input_area_height + 2)
-                    .saturating_sub(1);
+                let available_height =
+                    app_guard.calculate_available_height(term_height, input_area_height);
                 app_guard.scroll_to_bottom_view(available_height, term_width);
                 KeyResult::Handled
             }
             KeyCode::PageUp => {
                 let input_area_height = app_guard.calculate_input_area_height(term_width);
-                let available_height = term_height
-                    .saturating_sub(input_area_height + 2)
-                    .saturating_sub(1);
+                let available_height =
+                    app_guard.calculate_available_height(term_height, input_area_height);
                 app_guard.page_up(available_height);
                 KeyResult::Handled
             }
             KeyCode::PageDown => {
                 let input_area_height = app_guard.calculate_input_area_height(term_width);
-                let available_height = term_height
-                    .saturating_sub(input_area_height + 2)
-                    .saturating_sub(1);
+                let available_height =
+                    app_guard.calculate_available_height(term_height, input_area_height);
                 app_guard.page_down(available_height, term_width);
                 KeyResult::Handled
             }
@@ -319,9 +314,8 @@ impl KeyHandler for ArrowKeyHandler {
                 } else {
                     app_guard.auto_scroll = false;
                     let input_area_height = app_guard.calculate_input_area_height(term_width);
-                    let available_height = term_height
-                        .saturating_sub(input_area_height + 2)
-                        .saturating_sub(1);
+                    let available_height =
+                        app_guard.calculate_available_height(term_height, input_area_height);
                     let max_scroll =
                         app_guard.calculate_max_scroll_offset(available_height, term_width);
                     app_guard.scroll_offset =

--- a/src/ui/chat_loop/mod.rs
+++ b/src/ui/chat_loop/mod.rs
@@ -294,19 +294,15 @@ pub async fn run_chat(
                 app_guard.is_streaming = false;
                 // Ensure the new system message is visible
                 let input_area_height = app_guard.calculate_input_area_height(term_size.width);
-                let available_height = term_size
-                    .height
-                    .saturating_sub(input_area_height + 2)
-                    .saturating_sub(1);
+                let available_height =
+                    app_guard.calculate_available_height(term_size.height, input_area_height);
                 app_guard.update_scroll_position(available_height, term_size.width);
                 drop(app_guard);
                 received_any = true;
             } else {
                 let input_area_height = app_guard.calculate_input_area_height(term_size.width);
-                let available_height = term_size
-                    .height
-                    .saturating_sub(input_area_height + 2) // Dynamic input area + borders
-                    .saturating_sub(1); // 1 for title
+                let available_height =
+                    app_guard.calculate_available_height(term_size.height, input_area_height);
                 app_guard.append_to_response(&content, available_height, term_size.width);
                 drop(app_guard);
                 received_any = true;
@@ -502,9 +498,8 @@ async fn handle_block_select_mode_event(
                     app_guard.exit_block_select_mode();
                     app_guard.auto_scroll = true;
                     let input_area_height = app_guard.calculate_input_area_height(term_width);
-                    let available_height = term_height
-                        .saturating_sub(input_area_height + 2)
-                        .saturating_sub(1);
+                    let available_height =
+                        app_guard.calculate_available_height(term_height, input_area_height);
                     app_guard.update_scroll_position(available_height, term_width);
                 }
             }
@@ -532,9 +527,8 @@ async fn handle_block_select_mode_event(
                     app_guard.exit_block_select_mode();
                     app_guard.auto_scroll = true;
                     let input_area_height = app_guard.calculate_input_area_height(term_width);
-                    let available_height = term_height
-                        .saturating_sub(input_area_height + 2)
-                        .saturating_sub(1);
+                    let available_height =
+                        app_guard.calculate_available_height(term_height, input_area_height);
                     app_guard.update_scroll_position(available_height, term_width);
                 }
             }
@@ -572,9 +566,8 @@ async fn handle_external_editor_shortcut(
         Ok(None) => {
             let mut app_guard = app.lock().await;
             let input_area_height = app_guard.calculate_input_area_height(term_width);
-            let available_height = term_height
-                .saturating_sub(input_area_height + 2)
-                .saturating_sub(1);
+            let available_height =
+                app_guard.calculate_available_height(term_height, input_area_height);
             app_guard.update_scroll_position(available_height, term_width);
             Ok(Some(KeyLoopAction::Continue))
         }
@@ -583,9 +576,8 @@ async fn handle_external_editor_shortcut(
             let mut app_guard = app.lock().await;
             app_guard.set_status(format!("Editor error: {}", error_msg));
             let input_area_height = app_guard.calculate_input_area_height(term_width);
-            let available_height = term_height
-                .saturating_sub(input_area_height + 2)
-                .saturating_sub(1);
+            let available_height =
+                app_guard.calculate_available_height(term_height, input_area_height);
             app_guard.update_scroll_position(available_height, term_width);
             Ok(Some(KeyLoopAction::Continue))
         }


### PR DESCRIPTION
## Summary
- replace manual chat height calculations in key handlers with `App::calculate_available_height`
- reuse the same helper throughout `chat_loop` scrolling logic
- add coverage to confirm the helper matches the layout rules

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68db7801a48c832b8837ae431b9cb3a8