### PR TITLE
docs: capture post-0.3.5 feature updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Not yet released]
+
+### Added
+- Compose mode toggled with F4 (Enter inserts newlines; Alt+Enter/Ctrl+J send) to make long-form drafting easier (`src/ui/chat_loop`, `src/ui/builtin_help.md`).
+- OSC 8 hyperlink rendering across chat, tables, and pickers via span metadata and a custom Crossterm backend (`src/ui/osc_backend.rs`, `src/ui/osc_state.rs`, `src/ui/osc.rs`).
+- Adaptive color fallback that detects truecolor/256/16-color terminals and exposes a `CHABEAU_COLOR` override (`src/utils/color.rs`, `src/core/app.rs`).
+- In-app provider picker and config persistence so `/provider` mirrors `/model` for discovery and defaults (`src/ui/picker.rs`, `src/ui/chat_loop`, `src/ui/builtin_help.md`).
+- `--env` startup mode to force environment-based credentials when providers are configured (`src/core/app.rs`, `src/cli/mod.rs`).
+
+### Changed
+- Introduced a shared width-aware layout engine and span metadata pipeline for Markdown/plain rendering, enabling horizontal table scrolling and consistent wrapping (`src/ui/layout.rs`, `src/ui/markdown.rs`, `src/utils/scroll.rs`).
+- Modularized the chat loop with a keybinding registry, centralized redraw/height management, and event-driven rendering for smoother selection and paging (`src/ui/chat_loop`, `src/core/app.rs`).
+
 ## 0.3.5
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Chabeau is not a coding agent, nor does it aspire to be one. Instead, it brings 
 - Efficient byte-level parsing for smooth streaming output
 - Secure API key storage in system keyring with config-based provider management
 - Multi-line input (IME-friendly)
+- Compose mode for drafting long prompts (F4 toggles Enter vs. send, Ctrl+J mirrors Alt+Enter)
 - Multiple OpenAI-compatible providers (OpenAI, OpenRouter, Poe, Anthropic, Venice AI, Groq, Mistral, Cerebras, custom)
-- Interactive theme and model pickers with filtering and sorting
+- Interactive provider, model, and theme pickers with filtering, sorting, and config persistence
 - Message retry and external editor support
 - Conversation logging with pause/resume
-- Markdown rendering in the chat area (headings, lists, quotes, tables, inline/fenced code)
+- Markdown rendering in the chat area (headings, lists, quotes, tables, inline/fenced code) with clickable OSC 8 hyperlinks
 - Syntax highlighting for fenced code blocks (Python, Bash, JavaScript, and more)
 - Inline block selection (Ctrl+B) to copy or save fenced code blocks
 
@@ -158,8 +159,8 @@ See [the built-in help](src/ui/builtin_help.md) for a full list of keyboard cont
 
 Most should be intuitive. A couple of choices may be a bit jarring at first:
 
-- Alt+Enter to start a new line: We've found this to be most reliable across terminals.
-- Shift+Cursor to move around in input: This is so the cursor keys can be used at any time to scroll in the output area.
+- Alt+Enter (or Ctrl+J) to start a new line: We've found this to be most reliable across terminals.
+- Compose mode (F4) flips the defaults: Enter inserts a newline, Alt+Enter/Ctrl+J sends, arrow keys stay in the input, and Shift+arrow scrolls the transcript.
 
 Feedback and suggestions are always welcome!
 
@@ -195,11 +196,15 @@ Modular design with focused components:
   - `models.rs` - Model fetching and sorting functionality
 - `ui/` - Terminal interface rendering
   - `mod.rs` - UI module declarations
-  - `chat_loop.rs` - Main chat event loop and UI rendering
-  - `renderer.rs` - Terminal interface rendering
-  - `markdown.rs` - Lightweight Markdown rendering tuned for terminals
+  - `chat_loop/` - Mode-aware chat loop with setup, streaming, and keybinding registries
+  - `layout.rs` - Shared width-aware layout engine for Markdown and plain text
+  - `markdown.rs` / `markdown_wrap.rs` - Markdown renderer and wrapping helpers that emit span metadata
+  - `renderer.rs` - Terminal interface rendering (chat area, input, pickers)
+  - `osc_backend.rs` / `osc_state.rs` / `osc.rs` - Crossterm backend wrapper that emits OSC 8 hyperlinks
+  - `picker.rs` / `appearance.rs` / `theme.rs` - Picker controls and theming utilities
 - `utils/` - Utility functions and helpers
   - `mod.rs` - Utility module declarations
+  - `color.rs` - Terminal color detection and palette quantization
   - `editor.rs` - External editor integration
   - `logging.rs` - Chat logging functionality
   - `scroll.rs` - Text wrapping and scroll calculations

--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -6,7 +6,6 @@ Items are removed when completed.
 
 ## Features
 
-- More complete keyboard mapping (Page Up/Dn; Ctrl+D) — [OPEN]
 - Custom styling for system messages — [OPEN]
   - Add dedicated `RoleKind::System` with configurable styling separate from assistant messages
   - Allow theme customization of system message colors, prefixes, and formatting
@@ -14,7 +13,6 @@ Items are removed when completed.
 - Tiny copy/paste affordances — [PARTIAL]
 - Better handling of repeating messages like "Generating..."
   - Deduplicate/compress repeated status lines — [OPEN]
-- In-TUI provider selector — [OPEN]
 - In-TUI default picker — [OPEN]
 - Tab completion for commands — [OPEN]
 - Support common "character cards" — [OPEN]
@@ -23,7 +21,6 @@ Items are removed when completed.
 - Basic "push a file into context" support — [OPEN]
 - "Rapid refine" - apply a previously created prompt to an output — [OPEN]
 - Microphone/speaker support? — [OPEN]
-- Emit OSC 8 hyperlinks for rendered links leveraging `SpanKind::Link` metadata — [OPEN]
 - Extend span metadata to code blocks (e.g., `SpanKind::CodeBlock`) to unlock richer TUI interactions — [OPEN]
 
 ## Code quality


### PR DESCRIPTION
## Summary
- document compose mode, OSC 8 hyperlinks, and expanded picker capabilities in the README
- add a "Not yet released" changelog entry summarizing major features and architectural refactors since 0.3.5
- prune wishlist items that were satisfied by recent keyboard and hyperlink work

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68db7ca81a08832b98583ebad28b74a8