### PR TITLE
fix: append streaming chunks to assistant message

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -873,12 +873,12 @@ impl App {
         if let Some(retry_index) = self.retrying_message_index {
             if let Some(msg) = self.messages.get_mut(retry_index) {
                 if msg.role == "assistant" {
-                    msg.content = self.current_response.clone();
+                    msg.content.push_str(content);
                 }
             }
         } else if let Some(last_msg) = self.messages.back_mut() {
             if last_msg.role == "assistant" {
-                last_msg.content = self.current_response.clone();
+                last_msg.content.push_str(content);
             }
         }
 


### PR DESCRIPTION
## Summary
- update `App::append_to_response` to append streaming chunks directly to the tracked assistant message
- ensure the retry path grows message content incrementally instead of re-cloning

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dda6159b90832babb70f3d84f743f3