### PR TITLE
Refactor app state into structured contexts

### DIFF
--- a/src/ui/chat_loop/setup.rs
+++ b/src/ui/chat_loop/setup.rs
@@ -79,8 +79,8 @@ pub async fn bootstrap_app(
         ));
         {
             let mut app_guard = app.lock().await;
-            app_guard.startup_requires_provider = true;
-            app_guard.startup_multiple_providers_available = multiple_providers_available;
+            app_guard.picker.startup_requires_provider = true;
+            app_guard.picker.startup_multiple_providers_available = multiple_providers_available;
             app_guard.open_provider_picker();
         }
         app
@@ -118,16 +118,16 @@ pub async fn bootstrap_app(
         let mut need_model_picker = false;
         {
             let app_guard = app.lock().await;
-            if app_guard.model.is_empty() {
+            if app_guard.session.model.is_empty() {
                 need_model_picker = true;
             }
         }
         if need_model_picker {
             let mut app_guard = app.lock().await;
-            app_guard.startup_requires_model = true;
-            app_guard.startup_multiple_providers_available = multiple_providers_available;
+            app_guard.picker.startup_requires_model = true;
+            app_guard.picker.startup_multiple_providers_available = multiple_providers_available;
             let env_only = has_env_openai && token_providers.is_empty();
-            app_guard.startup_env_only = env_only;
+            app_guard.session.startup_env_only = env_only;
             if let Err(e) = app_guard.open_model_picker().await {
                 app_guard.set_status(format!("Model picker error: {}", e));
             }

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use crate::core::app::{App, UiMode};
+use crate::core::app::{App, PickerController, SessionContext, UiState};
 #[cfg(test)]
 use crate::core::message::Message;
 #[cfg(test)]
@@ -11,47 +11,27 @@ use std::collections::VecDeque;
 
 #[cfg(test)]
 pub fn create_test_app() -> App {
-    App {
-        messages: VecDeque::new(),
-        input: String::new(),
-        input_cursor_position: 0,
-        mode: UiMode::Typing,
-        current_response: String::new(),
+    let session = SessionContext {
         client: reqwest::Client::new(),
         model: "test-model".to_string(),
         api_key: "test-key".to_string(),
         base_url: "https://api.test.com".to_string(),
         provider_name: "test".to_string(),
         provider_display_name: "Test".to_string(),
-        scroll_offset: 0,
-        horizontal_scroll_offset: 0,
-        auto_scroll: true,
-        is_streaming: false,
-        pulse_start: std::time::Instant::now(),
-        stream_interrupted: false,
         logging: LoggingState::new(None).unwrap(),
         stream_cancel_token: None,
         current_stream_id: 0,
         last_retry_time: std::time::Instant::now(),
         retrying_message_index: None,
-        input_scroll_offset: 0,
-        textarea: tui_textarea::TextArea::default(),
-        theme: Theme::dark_default(),
-        current_theme_id: None,
-        picker_session: None,
-        in_provider_model_transition: false,
-        provider_model_transition_state: None,
-        markdown_enabled: true,
-        syntax_enabled: true,
-        prewrap_cache: None,
-        status: None,
-        status_set_at: None,
-        startup_requires_provider: false,
-        startup_requires_model: false,
-        startup_multiple_providers_available: false,
-        exit_requested: false,
         startup_env_only: false,
-        compose_mode: false,
+    };
+
+    let ui = UiState::new_basic(Theme::dark_default(), true, true, None);
+
+    App {
+        session,
+        ui,
+        picker: PickerController::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
- group `App` fields into `SessionContext`, `UiState`, and `PickerController`, and add helpers for logging and theme setup
- refactor `new_with_auth`/`new_uninitialized` to reuse the shared initialization logic and the new state structures
- update commands, UI modules, and test scaffolding to follow the nested state layout

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68de117f8f64832b9f4ce9ab8eb04511