### PR TITLE
Refactor appearance theme mapping coverage

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -126,6 +126,13 @@ impl PickerSession {
     }
 }
 
+fn theme_from_detected_appearance(appearance: Option<Appearance>) -> Theme {
+    match appearance {
+        Some(Appearance::Light) => Theme::light(),
+        Some(Appearance::Dark) | None => Theme::dark_default(),
+    }
+}
+
 pub struct App {
     pub messages: VecDeque<Message>,
     pub input: String,
@@ -418,11 +425,7 @@ impl App {
                     Theme::from_name(name)
                 }
             }
-            None => match detect_preferred_appearance() {
-                Some(Appearance::Light) => Theme::light(),
-                Some(Appearance::Dark) => Theme::dark_default(),
-                None => Theme::dark_default(),
-            },
+            None => theme_from_detected_appearance(detect_preferred_appearance()),
         };
 
         // Quantize theme colors for current terminal depth
@@ -2204,6 +2207,22 @@ mod tests {
     use super::*;
     use crate::utils::test_utils::{create_test_app, create_test_message};
     use tui_textarea::{CursorMove, Input, Key};
+
+    #[test]
+    fn theme_from_detected_appearance_prefers_light_theme() {
+        let theme = theme_from_detected_appearance(Some(Appearance::Light));
+        assert_eq!(theme.background_color, Theme::light().background_color);
+    }
+
+    #[test]
+    fn theme_from_detected_appearance_defaults_to_dark() {
+        let expected_background = Theme::dark_default().background_color;
+        let dark_theme = theme_from_detected_appearance(Some(Appearance::Dark));
+        let fallback_theme = theme_from_detected_appearance(None);
+
+        assert_eq!(dark_theme.background_color, expected_background);
+        assert_eq!(fallback_theme.background_color, expected_background);
+    }
 
     #[test]
     fn theme_picker_highlights_active_theme_over_default() {

--- a/src/ui/appearance.rs
+++ b/src/ui/appearance.rs
@@ -1,21 +1,8 @@
-#[cfg(test)]
-use crate::ui::theme::Theme;
-
 /// Preferred appearance used to choose a default theme when none is set
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Appearance {
     Light,
     Dark,
-}
-
-#[cfg(test)]
-impl Appearance {
-    pub fn to_theme(self) -> Theme {
-        match self {
-            Appearance::Light => Theme::light(),
-            Appearance::Dark => Theme::dark_default(),
-        }
-    }
 }
 
 /// Try to detect the preferred appearance via OS-level app theme preference.
@@ -108,16 +95,5 @@ fn detect_via_os_hint() -> Option<Appearance> {
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
         None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn appearance_to_theme_rounds() {
-        let _ = Appearance::Light.to_theme();
-        let _ = Appearance::Dark.to_theme();
     }
 }


### PR DESCRIPTION
## Summary
- remove the test-only appearance to theme helper from the appearance module
- extract the appearance-to-theme mapping in the app module into a reusable helper and add focused unit coverage

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68de1612288c832b996dc71d77b7755e