### PR TITLE
Refactor session initialization into dedicated module

### DIFF
--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -1,22 +1,18 @@
 use crate::auth::AuthManager;
 use crate::core::config::Config;
 use crate::core::message::Message;
-use crate::ui::appearance::{detect_preferred_appearance, Appearance};
 use crate::ui::builtin_themes::{find_builtin_theme, theme_spec_from_custom};
 use crate::ui::picker::PickerState;
 use crate::ui::span::SpanKind;
 use crate::ui::theme::Theme;
-use crate::utils::logging::LoggingState;
 use crate::utils::scroll::ScrollCalculator;
-use crate::utils::url::construct_api_url;
-use chrono::Utc;
 use ratatui::text::Line;
-use reqwest::Client;
 use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tui_textarea::TextArea;
 
 pub mod picker;
+pub mod session;
 pub mod ui_state;
 
 #[cfg_attr(not(test), allow(unused_imports))]
@@ -24,66 +20,29 @@ pub use picker::{
     ModelPickerState, PickerController, PickerData, PickerSession, ProviderPickerState,
     ThemePickerState,
 };
+pub use session::SessionContext;
 pub use ui_state::{FilePrompt, FilePromptKind, UiMode, UiState};
 
-pub struct SessionContext {
-    pub client: Client,
-    pub model: String,
-    pub api_key: String,
-    pub base_url: String,
-    pub provider_name: String,
-    pub provider_display_name: String,
-    pub logging: LoggingState,
-    pub stream_cancel_token: Option<CancellationToken>,
-    pub current_stream_id: u64,
-    pub last_retry_time: Instant,
-    pub retrying_message_index: Option<usize>,
-    pub startup_env_only: bool,
+pub async fn new_with_auth(
+    model: String,
+    log_file: Option<String>,
+    provider: Option<String>,
+    env_only: bool,
+    config: &Config,
+) -> Result<App, Box<dyn std::error::Error>> {
+    session::new_with_auth(model, log_file, provider, env_only, config).await
+}
+
+pub async fn new_uninitialized(
+    log_file: Option<String>,
+) -> Result<App, Box<dyn std::error::Error>> {
+    session::new_uninitialized(log_file).await
 }
 
 pub struct App {
     pub session: SessionContext,
     pub ui: UiState,
     pub picker: PickerController,
-}
-
-fn initialize_logging(
-    log_file: Option<String>,
-) -> Result<LoggingState, Box<dyn std::error::Error>> {
-    let logging = LoggingState::new(log_file.clone())?;
-    if let Some(_log_path) = log_file {
-        let timestamp = Utc::now().to_rfc3339();
-        if let Err(e) = logging.log_message(&format!("## Logging started at {}", timestamp)) {
-            eprintln!("Warning: Failed to write initial log timestamp: {}", e);
-        }
-    }
-    Ok(logging)
-}
-
-fn theme_from_appearance(appearance: Appearance) -> Theme {
-    match appearance {
-        Appearance::Light => Theme::light(),
-        Appearance::Dark => Theme::dark_default(),
-    }
-}
-
-fn resolve_theme(config: &Config) -> Theme {
-    let resolved_theme = match &config.theme {
-        Some(name) => {
-            if let Some(ct) = config.get_custom_theme(name) {
-                Theme::from_spec(&theme_spec_from_custom(ct))
-            } else if let Some(spec) = find_builtin_theme(name) {
-                Theme::from_spec(&spec)
-            } else {
-                Theme::from_name(name)
-            }
-        }
-        None => detect_preferred_appearance()
-            .map(theme_from_appearance)
-            .unwrap_or_else(Theme::dark_default),
-    };
-
-    crate::utils::color::quantize_theme_for_current_terminal(resolved_theme)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -218,118 +177,6 @@ impl App {
     /// Close any active picker session.
     pub fn close_picker(&mut self) {
         self.picker.close();
-    }
-
-    /// Returns true if current picker should use alphabetical sorting (A–Z / Z–A)
-    pub async fn new_with_auth(
-        model: String,
-        log_file: Option<String>,
-        provider: Option<String>,
-        env_only: bool,
-        config: &Config,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        use crate::core::providers::{resolve_env_session, resolve_session, ResolveSessionError};
-
-        let auth_manager = AuthManager::new();
-
-        // Resolve authentication: if env_only, force env vars; otherwise use shared resolution
-        let session = if env_only {
-            resolve_env_session().map_err(|err| Box::new(err) as Box<dyn std::error::Error>)?
-        } else {
-            match resolve_session(&auth_manager, config, provider.as_deref()) {
-                Ok(session) => session,
-                Err(ResolveSessionError::Provider(err)) => return Err(Box::new(err)),
-                Err(ResolveSessionError::Source(err)) => return Err(err),
-            }
-        };
-
-        let (api_key, base_url, provider_name, provider_display_name) = session.into_tuple();
-
-        // Determine the model to use:
-        // 1. If a specific model was requested (not "default"), use that
-        // 2. If a default model is set for this provider in config, use that
-        // 3. Otherwise, leave it unset and let the UI open the model picker
-        let final_model = if model != "default" {
-            model
-        } else if let Some(default_model) = config.get_default_model(&provider_name) {
-            default_model.clone()
-        } else {
-            String::new()
-        };
-
-        // Build API endpoint for internal use (no noisy startup prints)
-        let _api_endpoint = construct_api_url(&base_url, "chat/completions");
-
-        let logging = initialize_logging(log_file)?;
-        let resolved_theme = resolve_theme(config);
-
-        let session = SessionContext {
-            client: Client::new(),
-            model: final_model,
-            api_key,
-            base_url,
-            provider_name: provider_name.to_string(),
-            provider_display_name,
-            logging,
-            stream_cancel_token: None,
-            current_stream_id: 0,
-            last_retry_time: Instant::now(),
-            retrying_message_index: None,
-            startup_env_only: false,
-        };
-
-        let mut app = App {
-            session,
-            ui: UiState::from_config(resolved_theme, config),
-            picker: PickerController::new(),
-        };
-
-        // Keep textarea state in sync with the string input initially
-        app.set_input_text(String::new());
-        app.configure_textarea_appearance();
-
-        Ok(app)
-    }
-
-    /// Create an app without a selected provider or model. Used when multiple providers
-    /// are available but none is configured as default; the UI will open the provider picker.
-    pub async fn new_uninitialized(
-        log_file: Option<String>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let config = Config::load()?;
-
-        // Quiet startup; no noisy prints here
-
-        let logging = initialize_logging(log_file)?;
-        let resolved_theme = resolve_theme(&config);
-
-        let session = SessionContext {
-            client: Client::new(),
-            model: String::new(),
-            api_key: String::new(),
-            base_url: String::new(),
-            provider_name: String::new(),
-            provider_display_name: "(no provider selected)".to_string(),
-            logging,
-            stream_cancel_token: None,
-            current_stream_id: 0,
-            last_retry_time: Instant::now(),
-            retrying_message_index: None,
-            startup_env_only: false,
-        };
-
-        let mut picker = PickerController::new();
-        picker.startup_requires_provider = true;
-
-        let mut app = App {
-            session,
-            ui: UiState::from_config(resolved_theme, &config),
-            picker,
-        };
-
-        app.set_input_text(String::new());
-        app.configure_textarea_appearance();
-        Ok(app)
     }
 
     /// Return prewrapped chat lines for current state, caching across frames when safe.
@@ -1201,37 +1048,6 @@ mod tests {
     use crate::ui::picker::PickerItem;
     use crate::utils::test_utils::{create_test_app, create_test_message};
     use tui_textarea::{CursorMove, Input, Key};
-
-    #[test]
-    fn theme_from_appearance_matches_light_theme() {
-        let theme = theme_from_appearance(Appearance::Light);
-        assert_eq!(theme.background_color, Theme::light().background_color);
-    }
-
-    #[test]
-    fn theme_from_appearance_matches_dark_theme() {
-        let theme = theme_from_appearance(Appearance::Dark);
-        assert_eq!(
-            theme.background_color,
-            Theme::dark_default().background_color
-        );
-    }
-
-    #[test]
-    fn resolve_theme_prefers_configured_theme() {
-        let config = Config {
-            theme: Some("light".to_string()),
-            ..Default::default()
-        };
-
-        let resolved_theme = resolve_theme(&config);
-        let expected_theme =
-            crate::utils::color::quantize_theme_for_current_terminal(Theme::light());
-        assert_eq!(
-            resolved_theme.background_color,
-            expected_theme.background_color
-        );
-    }
 
     #[test]
     fn theme_picker_highlights_active_theme_over_default() {

--- a/src/core/app/session.rs
+++ b/src/core/app/session.rs
@@ -1,0 +1,204 @@
+use std::time::Instant;
+
+use chrono::Utc;
+use reqwest::Client;
+use tokio_util::sync::CancellationToken;
+
+use super::{App, PickerController, UiState};
+use crate::auth::AuthManager;
+use crate::core::config::Config;
+use crate::core::providers::{resolve_env_session, resolve_session, ResolveSessionError};
+use crate::ui::appearance::{detect_preferred_appearance, Appearance};
+use crate::ui::builtin_themes::{find_builtin_theme, theme_spec_from_custom};
+use crate::ui::theme::Theme;
+use crate::utils::color::quantize_theme_for_current_terminal;
+use crate::utils::logging::LoggingState;
+use crate::utils::url::construct_api_url;
+
+pub struct SessionContext {
+    pub client: Client,
+    pub model: String,
+    pub api_key: String,
+    pub base_url: String,
+    pub provider_name: String,
+    pub provider_display_name: String,
+    pub logging: LoggingState,
+    pub stream_cancel_token: Option<CancellationToken>,
+    pub current_stream_id: u64,
+    pub last_retry_time: Instant,
+    pub retrying_message_index: Option<usize>,
+    pub startup_env_only: bool,
+}
+
+pub(crate) fn initialize_logging(
+    log_file: Option<String>,
+) -> Result<LoggingState, Box<dyn std::error::Error>> {
+    let logging = LoggingState::new(log_file.clone())?;
+    if let Some(_log_path) = log_file {
+        let timestamp = Utc::now().to_rfc3339();
+        if let Err(e) = logging.log_message(&format!("## Logging started at {}", timestamp)) {
+            eprintln!("Warning: Failed to write initial log timestamp: {}", e);
+        }
+    }
+    Ok(logging)
+}
+
+fn theme_from_appearance(appearance: Appearance) -> Theme {
+    match appearance {
+        Appearance::Light => Theme::light(),
+        Appearance::Dark => Theme::dark_default(),
+    }
+}
+
+pub(crate) fn resolve_theme(config: &Config) -> Theme {
+    let resolved_theme = match &config.theme {
+        Some(name) => {
+            if let Some(ct) = config.get_custom_theme(name) {
+                Theme::from_spec(&theme_spec_from_custom(ct))
+            } else if let Some(spec) = find_builtin_theme(name) {
+                Theme::from_spec(&spec)
+            } else {
+                Theme::from_name(name)
+            }
+        }
+        None => detect_preferred_appearance()
+            .map(theme_from_appearance)
+            .unwrap_or_else(Theme::dark_default),
+    };
+
+    quantize_theme_for_current_terminal(resolved_theme)
+}
+
+pub(crate) async fn new_with_auth(
+    model: String,
+    log_file: Option<String>,
+    provider: Option<String>,
+    env_only: bool,
+    config: &Config,
+) -> Result<App, Box<dyn std::error::Error>> {
+    let auth_manager = AuthManager::new();
+
+    let session = if env_only {
+        resolve_env_session().map_err(|err| Box::new(err) as Box<dyn std::error::Error>)?
+    } else {
+        match resolve_session(&auth_manager, config, provider.as_deref()) {
+            Ok(session) => session,
+            Err(ResolveSessionError::Provider(err)) => return Err(Box::new(err)),
+            Err(ResolveSessionError::Source(err)) => return Err(err),
+        }
+    };
+
+    let (api_key, base_url, provider_name, provider_display_name) = session.into_tuple();
+
+    let final_model = if model != "default" {
+        model
+    } else if let Some(default_model) = config.get_default_model(&provider_name) {
+        default_model.clone()
+    } else {
+        String::new()
+    };
+
+    let _api_endpoint = construct_api_url(&base_url, "chat/completions");
+
+    let logging = initialize_logging(log_file)?;
+    let resolved_theme = resolve_theme(config);
+
+    let session = SessionContext {
+        client: Client::new(),
+        model: final_model,
+        api_key,
+        base_url,
+        provider_name: provider_name.to_string(),
+        provider_display_name,
+        logging,
+        stream_cancel_token: None,
+        current_stream_id: 0,
+        last_retry_time: Instant::now(),
+        retrying_message_index: None,
+        startup_env_only: false,
+    };
+
+    let mut app = App {
+        session,
+        ui: UiState::from_config(resolved_theme, config),
+        picker: PickerController::new(),
+    };
+
+    app.set_input_text(String::new());
+    app.configure_textarea_appearance();
+
+    Ok(app)
+}
+
+pub(crate) async fn new_uninitialized(
+    log_file: Option<String>,
+) -> Result<App, Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+
+    let logging = initialize_logging(log_file)?;
+    let resolved_theme = resolve_theme(&config);
+
+    let session = SessionContext {
+        client: Client::new(),
+        model: String::new(),
+        api_key: String::new(),
+        base_url: String::new(),
+        provider_name: String::new(),
+        provider_display_name: "(no provider selected)".to_string(),
+        logging,
+        stream_cancel_token: None,
+        current_stream_id: 0,
+        last_retry_time: Instant::now(),
+        retrying_message_index: None,
+        startup_env_only: false,
+    };
+
+    let mut picker = PickerController::new();
+    picker.startup_requires_provider = true;
+
+    let mut app = App {
+        session,
+        ui: UiState::from_config(resolved_theme, &config),
+        picker,
+    };
+
+    app.set_input_text(String::new());
+    app.configure_textarea_appearance();
+    Ok(app)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::Config;
+
+    #[test]
+    fn theme_from_appearance_matches_light_theme() {
+        let theme = theme_from_appearance(Appearance::Light);
+        assert_eq!(theme.background_color, Theme::light().background_color);
+    }
+
+    #[test]
+    fn theme_from_appearance_matches_dark_theme() {
+        let theme = theme_from_appearance(Appearance::Dark);
+        assert_eq!(
+            theme.background_color,
+            Theme::dark_default().background_color
+        );
+    }
+
+    #[test]
+    fn resolve_theme_prefers_configured_theme() {
+        let config = Config {
+            theme: Some("light".to_string()),
+            ..Default::default()
+        };
+
+        let resolved_theme = resolve_theme(&config);
+        let expected_theme = quantize_theme_for_current_terminal(Theme::light());
+        assert_eq!(
+            resolved_theme.background_color,
+            expected_theme.background_color
+        );
+    }
+}

--- a/src/ui/chat_loop/setup.rs
+++ b/src/ui/chat_loop/setup.rs
@@ -5,7 +5,9 @@ use tokio::sync::Mutex;
 use crate::{
     auth::AuthManager,
     core::{
-        app::App, builtin_providers::load_builtin_providers, config::Config,
+        app::{self, App},
+        builtin_providers::load_builtin_providers,
+        config::Config,
         providers::ProviderResolutionError,
     },
 };
@@ -75,7 +77,7 @@ pub async fn bootstrap_app(
 
     let app = if open_provider_picker {
         let app = Arc::new(Mutex::new(
-            App::new_uninitialized(log.clone()).await.expect("init app"),
+            app::new_uninitialized(log.clone()).await.expect("init app"),
         ));
         {
             let mut app_guard = app.lock().await;
@@ -86,7 +88,7 @@ pub async fn bootstrap_app(
         app
     } else {
         let app = Arc::new(Mutex::new(
-            match App::new_with_auth(
+            match app::new_with_auth(
                 model.clone(),
                 log.clone(),
                 selected_provider,


### PR DESCRIPTION
## Summary
- extract session setup, theme resolution, and logging helpers into `core::app::session`
- expose async constructor wrappers from `core::app` that delegate to the session module
- update the chat loop bootstrap to use the new helpers

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68deacc36434832ba130ac2c9fd2bd89