### PR TITLE
refactor: move picker mode enum into picker module

### DIFF
--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -17,7 +17,7 @@ pub mod ui_state;
 
 #[cfg_attr(not(test), allow(unused_imports))]
 pub use picker::{
-    ModelPickerState, PickerController, PickerData, PickerSession, ProviderPickerState,
+    ModelPickerState, PickerController, PickerData, PickerMode, PickerSession, ProviderPickerState,
     ThemePickerState,
 };
 pub use session::{SessionBootstrap, SessionContext, UninitializedSessionBootstrap};
@@ -83,13 +83,6 @@ pub struct App {
     pub session: SessionContext,
     pub ui: UiState,
     pub picker: PickerController,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PickerMode {
-    Theme,
-    Model,
-    Provider,
 }
 
 impl App {

--- a/src/core/app/picker/mod.rs
+++ b/src/core/app/picker/mod.rs
@@ -1,4 +1,3 @@
-use super::PickerMode;
 use super::{SessionContext, UiState};
 use crate::api::models::{fetch_models, sort_models};
 use crate::auth::AuthManager;
@@ -7,6 +6,13 @@ use crate::core::config::Config;
 use crate::ui::builtin_themes::load_builtin_themes;
 use crate::ui::picker::{PickerItem, PickerState, SortMode};
 use crate::ui::theme::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PickerMode {
+    Theme,
+    Model,
+    Provider,
+}
 
 #[derive(Debug, Clone)]
 pub struct ThemePickerState {


### PR DESCRIPTION
## Summary
- move the PickerMode enum alongside other picker types
- re-export PickerMode from the picker module and core app module to keep existing paths working

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68debae3d148832ba11b64daf47ed378