### PR TITLE
Refactor UI helpers into UiState

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -67,7 +67,7 @@ pub fn process_input(app: &mut App, input: &str) -> CommandResult {
                         let msg = e.to_string();
                         if msg.contains("already exists") {
                             app.set_status("Log file already exists.");
-                            app.start_file_prompt_dump(filename);
+                            app.ui.start_file_prompt_dump(filename);
                             CommandResult::Continue
                         } else {
                             handle_dump_result(app, Err(e), &filename)

--- a/src/utils/editor.rs
+++ b/src/utils/editor.rs
@@ -24,7 +24,7 @@ pub async fn handle_external_editor(app: &mut App) -> Result<Option<String>, Box
     let temp_path = temp_file.path().to_path_buf();
 
     // Write current input to the temp file if there's any
-    let current_text = app.get_input_text();
+    let current_text = app.ui.get_input_text();
     if !current_text.is_empty() {
         fs::write(&temp_path, current_text)?;
     }
@@ -63,7 +63,7 @@ pub async fn handle_external_editor(app: &mut App) -> Result<Option<String>, Box
         Ok(None)
     } else {
         // Clear the input and return the content to be sent immediately
-        app.clear_input();
+        app.ui.clear_input();
         let message = content.trim_end().to_string(); // Remove trailing newlines but preserve internal formatting
         Ok(Some(message))
     }


### PR DESCRIPTION
## Summary
- add mode, file prompt, scrolling, and textarea helpers directly on `UiState` and drop the redundant `App` wrappers
- update the chat loop, renderer, commands, editor integration, and tests to call the new `UiState` API

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dec989a934832baf7843e0f59d1e1d