### PR TITLE
Refactor message navigation into UiState

### DIFF
--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -21,6 +21,7 @@ pub use picker::{
 };
 pub use session::{SessionBootstrap, SessionContext, UninitializedSessionBootstrap};
 pub use settings::{ProviderController, ThemeController};
+#[allow(unused_imports)]
 pub use ui_state::{UiMode, UiState};
 
 pub async fn new_with_auth(
@@ -366,93 +367,6 @@ impl App {
         let available_height = self.calculate_available_height(term_height, input_area_height);
         self.ui.scroll_offset =
             self.calculate_scroll_to_message(index, term_width, available_height);
-    }
-
-    /// Find the last user-authored message index
-    pub fn last_user_message_index(&self) -> Option<usize> {
-        self.ui
-            .messages
-            .iter()
-            .enumerate()
-            .rev()
-            .find(|(_, m)| m.role == "user")
-            .map(|(i, _)| i)
-    }
-
-    /// Find previous user message index before `from_index` (exclusive)
-    pub fn prev_user_message_index(&self, from_index: usize) -> Option<usize> {
-        if from_index == 0 {
-            return None;
-        }
-        self.ui
-            .messages
-            .iter()
-            .enumerate()
-            .take(from_index)
-            .rev()
-            .find(|(_, m)| m.role == "user")
-            .map(|(i, _)| i)
-    }
-
-    /// Find next user message index after `from_index` (exclusive)
-    pub fn next_user_message_index(&self, from_index: usize) -> Option<usize> {
-        self.ui
-            .messages
-            .iter()
-            .enumerate()
-            .skip(from_index + 1)
-            .find(|(_, m)| m.role == "user")
-            .map(|(i, _)| i)
-    }
-
-    /// Find the first user-authored message index
-    pub fn first_user_message_index(&self) -> Option<usize> {
-        self.ui
-            .messages
-            .iter()
-            .enumerate()
-            .find(|(_, m)| m.role == "user")
-            .map(|(i, _)| i)
-    }
-
-    /// Enter edit-select mode: lock input and select most recent user message
-    pub fn enter_edit_select_mode(&mut self) {
-        if let Some(idx) = self.last_user_message_index() {
-            self.ui.set_mode(UiMode::EditSelect {
-                selected_index: idx,
-            });
-        }
-    }
-
-    /// Exit edit-select mode
-    pub fn exit_edit_select_mode(&mut self) {
-        if self.ui.in_edit_select_mode() {
-            self.ui.set_mode(UiMode::Typing);
-        }
-    }
-
-    /// Begin in-place edit of a user message at `index`
-    pub fn start_in_place_edit(&mut self, index: usize) {
-        self.ui.set_mode(UiMode::InPlaceEdit { index });
-    }
-
-    /// Cancel in-place edit (does not modify history)
-    pub fn cancel_in_place_edit(&mut self) {
-        if self.ui.in_place_edit_index().is_some() {
-            self.ui.set_mode(UiMode::Typing);
-        }
-    }
-
-    /// Enter block select mode: lock input and set selected block index
-    pub fn enter_block_select_mode(&mut self, index: usize) {
-        self.ui.set_mode(UiMode::BlockSelect { block_index: index });
-    }
-
-    /// Exit block select mode and unlock input
-    pub fn exit_block_select_mode(&mut self) {
-        if self.ui.in_block_select_mode() {
-            self.ui.set_mode(UiMode::Typing);
-        }
     }
 
     pub fn prepare_retry(
@@ -1345,8 +1259,8 @@ mod tests {
     fn test_last_and_first_user_message_index() {
         let mut app = create_test_app();
         // No messages
-        assert_eq!(app.last_user_message_index(), None);
-        assert_eq!(app.first_user_message_index(), None);
+        assert_eq!(app.ui.last_user_message_index(), None);
+        assert_eq!(app.ui.first_user_message_index(), None);
 
         // Add messages: user, assistant, user
         app.ui.messages.push_back(create_test_message("user", "u1"));
@@ -1355,8 +1269,8 @@ mod tests {
             .push_back(create_test_message("assistant", "a1"));
         app.ui.messages.push_back(create_test_message("user", "u2"));
 
-        assert_eq!(app.first_user_message_index(), Some(0));
-        assert_eq!(app.last_user_message_index(), Some(2));
+        assert_eq!(app.ui.first_user_message_index(), Some(0));
+        assert_eq!(app.ui.last_user_message_index(), Some(2));
     }
 
     #[test]
@@ -1655,13 +1569,13 @@ Some additional text after the table."#;
         app.ui.messages.push_back(create_test_message("user", "u2"));
 
         // From index 3 (user) prev should be 0 (skipping non-user)
-        assert_eq!(app.prev_user_message_index(3), Some(0));
+        assert_eq!(app.ui.prev_user_message_index(3), Some(0));
         // From index 0 next should be 3 (skipping non-user)
-        assert_eq!(app.next_user_message_index(0), Some(3));
+        assert_eq!(app.ui.next_user_message_index(0), Some(3));
         // From index 1 prev should be 0
-        assert_eq!(app.prev_user_message_index(1), Some(0));
+        assert_eq!(app.ui.prev_user_message_index(1), Some(0));
         // From index 1 next should be 3
-        assert_eq!(app.next_user_message_index(1), Some(3));
+        assert_eq!(app.ui.next_user_message_index(1), Some(3));
     }
 
     #[test]

--- a/src/core/app/ui_state.rs
+++ b/src/core/app/ui_state.rs
@@ -99,6 +99,80 @@ impl UiState {
         }
     }
 
+    pub fn last_user_message_index(&self) -> Option<usize> {
+        self.messages
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, m)| m.role == "user")
+            .map(|(i, _)| i)
+    }
+
+    pub fn prev_user_message_index(&self, from_index: usize) -> Option<usize> {
+        if from_index == 0 {
+            return None;
+        }
+
+        self.messages
+            .iter()
+            .enumerate()
+            .take(from_index)
+            .rev()
+            .find(|(_, m)| m.role == "user")
+            .map(|(i, _)| i)
+    }
+
+    pub fn next_user_message_index(&self, from_index: usize) -> Option<usize> {
+        self.messages
+            .iter()
+            .enumerate()
+            .skip(from_index + 1)
+            .find(|(_, m)| m.role == "user")
+            .map(|(i, _)| i)
+    }
+
+    pub fn first_user_message_index(&self) -> Option<usize> {
+        self.messages
+            .iter()
+            .enumerate()
+            .find(|(_, m)| m.role == "user")
+            .map(|(i, _)| i)
+    }
+
+    pub fn enter_edit_select_mode(&mut self) {
+        if let Some(idx) = self.last_user_message_index() {
+            self.set_mode(UiMode::EditSelect {
+                selected_index: idx,
+            });
+        }
+    }
+
+    pub fn exit_edit_select_mode(&mut self) {
+        if self.in_edit_select_mode() {
+            self.set_mode(UiMode::Typing);
+        }
+    }
+
+    pub fn start_in_place_edit(&mut self, index: usize) {
+        self.set_mode(UiMode::InPlaceEdit { index });
+    }
+
+    pub fn cancel_in_place_edit(&mut self) {
+        if self.in_place_edit_index().is_some() {
+            self.set_mode(UiMode::Typing);
+        }
+    }
+
+    pub fn enter_block_select_mode(&mut self, index: usize) {
+        self.set_mode(UiMode::BlockSelect { block_index: index });
+    }
+
+    pub fn exit_block_select_mode(&mut self) {
+        if self.in_block_select_mode() {
+            self.set_mode(UiMode::Typing);
+        }
+    }
+
     pub fn in_place_edit_index(&self) -> Option<usize> {
         if let UiMode::InPlaceEdit { index } = self.mode {
             Some(index)

--- a/src/ui/chat_loop/mod.rs
+++ b/src/ui/chat_loop/mod.rs
@@ -381,19 +381,21 @@ async fn handle_edit_select_mode_event(
 
     match key.code {
         KeyCode::Esc => {
-            app_guard.exit_edit_select_mode();
+            app_guard.ui.exit_edit_select_mode();
             true
         }
         KeyCode::Up | KeyCode::Char('k') => {
             if let Some(current) = app_guard.ui.selected_user_message_index() {
-                if let Some(prev) = app_guard
-                    .prev_user_message_index(current)
-                    .or_else(|| app_guard.last_user_message_index())
-                {
+                let prev = {
+                    let ui = &app_guard.ui;
+                    ui.prev_user_message_index(current)
+                        .or_else(|| ui.last_user_message_index())
+                };
+                if let Some(prev) = prev {
                     app_guard.ui.set_selected_user_message_index(prev);
                     app_guard.scroll_index_into_view(prev, term_width, term_height);
                 }
-            } else if let Some(last) = app_guard.last_user_message_index() {
+            } else if let Some(last) = app_guard.ui.last_user_message_index() {
                 app_guard.ui.set_selected_user_message_index(last);
             }
             true
@@ -401,14 +403,16 @@ async fn handle_edit_select_mode_event(
 
         KeyCode::Down | KeyCode::Char('j') => {
             if let Some(current) = app_guard.ui.selected_user_message_index() {
-                if let Some(next) = app_guard
-                    .next_user_message_index(current)
-                    .or_else(|| app_guard.first_user_message_index())
-                {
+                let next = {
+                    let ui = &app_guard.ui;
+                    ui.next_user_message_index(current)
+                        .or_else(|| ui.first_user_message_index())
+                };
+                if let Some(next) = next {
                     app_guard.ui.set_selected_user_message_index(next);
                     app_guard.scroll_index_into_view(next, term_width, term_height);
                 }
-            } else if let Some(last) = app_guard.last_user_message_index() {
+            } else if let Some(last) = app_guard.ui.last_user_message_index() {
                 app_guard.ui.set_selected_user_message_index(last);
             }
             true
@@ -425,7 +429,7 @@ async fn handle_edit_select_mode_event(
                         .logging
                         .rewrite_log_without_last_response(&app_guard.ui.messages);
                     app_guard.ui.set_input_text(content);
-                    app_guard.exit_edit_select_mode();
+                    app_guard.ui.exit_edit_select_mode();
                     let input_area_height = app_guard.ui.calculate_input_area_height(term_width);
                     let available_height =
                         app_guard.calculate_available_height(term_height, input_area_height);
@@ -439,8 +443,8 @@ async fn handle_edit_select_mode_event(
                 if idx < app_guard.ui.messages.len() && app_guard.ui.messages[idx].role == "user" {
                     let content = app_guard.ui.messages[idx].content.clone();
                     app_guard.ui.set_input_text(content);
-                    app_guard.start_in_place_edit(idx);
-                    app_guard.exit_edit_select_mode();
+                    app_guard.ui.start_in_place_edit(idx);
+                    app_guard.ui.exit_edit_select_mode();
                 }
             }
             true
@@ -455,7 +459,7 @@ async fn handle_edit_select_mode_event(
                         .session
                         .logging
                         .rewrite_log_without_last_response(&app_guard.ui.messages);
-                    app_guard.exit_edit_select_mode();
+                    app_guard.ui.exit_edit_select_mode();
                     let input_area_height = app_guard.ui.calculate_input_area_height(term_width);
                     let available_height =
                         app_guard.calculate_available_height(term_height, input_area_height);
@@ -490,7 +494,7 @@ async fn handle_block_select_mode_event(
 
     match key.code {
         KeyCode::Esc => {
-            app_guard.exit_block_select_mode();
+            app_guard.ui.exit_block_select_mode();
             true
         }
         KeyCode::Up | KeyCode::Char('k') => {
@@ -529,7 +533,7 @@ async fn handle_block_select_mode_event(
                         Ok(()) => app_guard.set_status("Copied code block"),
                         Err(_e) => app_guard.set_status("Clipboard error"),
                     }
-                    app_guard.exit_block_select_mode();
+                    app_guard.ui.exit_block_select_mode();
                     app_guard.ui.auto_scroll = true;
                     let input_area_height = app_guard.ui.calculate_input_area_height(term_width);
                     let available_height =
@@ -561,7 +565,7 @@ async fn handle_block_select_mode_event(
                             Err(_e) => app_guard.set_status("Error saving code block"),
                         }
                     }
-                    app_guard.exit_block_select_mode();
+                    app_guard.ui.exit_block_select_mode();
                     app_guard.ui.auto_scroll = true;
                     let input_area_height = app_guard.ui.calculate_input_area_height(term_width);
                     let available_height =


### PR DESCRIPTION
## Summary
- move user message navigation and mode transition helpers into `UiState`
- update chat loop handlers and tests to call the refactored API

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68deda02484c832b9a04600eeee6f6c9