### PR TITLE
Reprioritize code quality wishlist items

### DIFF
--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -25,22 +25,34 @@ Items are removed when completed.
 
 ## Code quality
 
-- Reduce duplication in `src/ui/markdown.rs` for code block flushing (extract helper) — [OPEN]
-- Consolidate plain vs markdown rendering path selection — [PARTIAL]
-- Centralize help text — [OPEN]
-  - Create a small `ui/help.rs` with canonical key-hint strings used by CLI long_about, `/help`, and renderer titles — [OPEN]
+### High priority
+
 - Logging durability — [OPEN]
   - Make log rewrites (after truncate/in-place edit) atomic via temp file + rename — [OPEN]
   - Optionally append a log marker indicating manual history edits — [OPEN]
-- Height/scroll DRYing — [PARTIAL]
-  - Continue standardizing on the conversation controller helpers across renderer and chat loop — [OPEN]
-- Stream spawning DRYing — [PARTIAL]
-  - Use a config struct (already added) and consider moving the helper out of `chat_loop` for reuse — [PARTIAL]
 - Tests — [OPEN]
   - Add unit tests for selection wrap-around and mode transitions (pure helpers) — [OPEN]
   - Add integration-style tests for event handling if feasible (simulate key events) — [OPEN]
   - Add tests for `/markdown` and `/syntax` commands by injecting a test config path or IO layer — [OPEN]
   - Consider adding integration tests for the complete Del key workflow in picker dialogs — [OPEN]
   - Consider testing UI state changes after Del key operations (picker refresh) — [OPEN]
+- Reduce locking churn in `src/ui/chat_loop/mod.rs` — [OPEN]
+  - Extract focused handlers for drawing, keyboard routing, and stream dispatch so a mutable `App` borrow does not cross await points and to make event ordering easier to reason about — [OPEN]
+
+### Medium priority
+
+- Reduce duplication in `src/ui/markdown.rs` for code block flushing (extract helper) — [OPEN]
+- Consolidate plain vs markdown rendering path selection — [PARTIAL]
+- Height/scroll DRYing — [PARTIAL]
+  - Continue standardizing on the conversation controller helpers across renderer and chat loop — [OPEN]
+- Stream spawning DRYing — [PARTIAL]
+  - Use a config struct (already added) and consider moving the helper out of `chat_loop` for reuse — [PARTIAL]
+- Unify command routing in `src/commands/mod.rs` — [OPEN]
+  - Replace the long conditional ladder with a registry of commands plus shared helpers so new commands stay declarative and testable — [OPEN]
+
+### Low priority
+
+- Centralize help text — [OPEN]
+  - Create a small `ui/help.rs` with canonical key-hint strings used by CLI long_about, `/help`, and renderer titles — [OPEN]
 - Picker OSC8 state handling — [OPEN]
   - Investigate replacing the temporary clone used to strip link modifiers with a render-time style mask so we reuse the cached transcript buffer and toggle hyperlink styling without allocating new `Line` vectors when pickers open/close.


### PR DESCRIPTION
## Summary
- group code quality wishlist items by priority tiers to highlight urgent work
- add follow-up notes around chat loop locking and command routing improvements

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68def0005f48832b8f342f5114624455