### PR TITLE
Fix color depth tests to ignore CHABEAU_COLOR override

### DIFF
--- a/src/utils/color.rs
+++ b/src/utils/color.rs
@@ -269,9 +269,16 @@ mod tests {
     #[test]
     fn detects_truecolor_from_env() {
         let _guard = ENV_LOCK.lock().unwrap();
+        let prev_chabeau_color = std::env::var("CHABEAU_COLOR").ok();
         let prev_colorterm = std::env::var("COLORTERM").ok();
+        std::env::remove_var("CHABEAU_COLOR");
         std::env::set_var("COLORTERM", "truecolor");
         assert_eq!(detect_color_depth(), ColorDepth::Truecolor);
+        if let Some(prev) = prev_chabeau_color {
+            std::env::set_var("CHABEAU_COLOR", prev);
+        } else {
+            std::env::remove_var("CHABEAU_COLOR");
+        }
         if let Some(prev) = prev_colorterm {
             std::env::set_var("COLORTERM", prev);
         } else {
@@ -282,12 +289,19 @@ mod tests {
     #[test]
     fn detects_256_from_term() {
         let _guard = ENV_LOCK.lock().unwrap();
+        let prev_chabeau_color = std::env::var("CHABEAU_COLOR").ok();
         let prev_colorterm = std::env::var("COLORTERM").ok();
         let prev_term = std::env::var("TERM").ok();
         // Ensure COLORTERM doesn't force truecolor in this environment
+        std::env::remove_var("CHABEAU_COLOR");
         std::env::remove_var("COLORTERM");
         std::env::set_var("TERM", "xterm-256color");
         assert_eq!(detect_color_depth(), ColorDepth::X256);
+        if let Some(prev) = prev_chabeau_color {
+            std::env::set_var("CHABEAU_COLOR", prev);
+        } else {
+            std::env::remove_var("CHABEAU_COLOR");
+        }
         if let Some(prev) = prev_colorterm {
             std::env::set_var("COLORTERM", prev);
         } else {


### PR DESCRIPTION
## Summary
- ensure color depth detection tests clear any CHABEAU_COLOR override
- restore the previous environment values after the assertions run

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy --all-targets

------
https://chatgpt.com/codex/tasks/task_e_68df0d587210832b828a3b400ed3bd84