### PR TITLE
Refactor model picker loading to avoid holding app lock

### DIFF
--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -17,8 +17,8 @@ pub mod ui_state;
 pub use conversation::ConversationController;
 #[allow(unused_imports)]
 pub use picker::{
-    ModelPickerState, PickerController, PickerData, PickerMode, PickerSession, ProviderPickerState,
-    ThemePickerState,
+    ModelPickerItems, ModelPickerLoaderRequest, ModelPickerState, PickerController, PickerData,
+    PickerMode, PickerSession, ProviderPickerState, ThemePickerState,
 };
 pub use session::{SessionBootstrap, SessionContext, UninitializedSessionBootstrap};
 pub use settings::{ProviderController, ThemeController};
@@ -215,11 +215,6 @@ impl App {
     pub fn revert_theme_preview(&mut self) {
         let mut controller = self.theme_controller();
         controller.revert_theme_preview();
-    }
-
-    /// Open a model picker modal with available models from current provider
-    pub async fn open_model_picker(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        self.picker.open_model_picker(&self.session).await
     }
 
     /// Filter models based on search term and update picker


### PR DESCRIPTION
## Summary
- add `ModelPickerLoaderRequest`/`ModelPickerItems` helpers to fetch and apply models without holding the app mutex
- update chat loop handlers and bootstrap to drop the mutex guard before awaiting model fetches and reapply results afterwards
- remove the unused `App::open_model_picker` entrypoint and rely on the new two-step picker API

## Testing
- `cargo test`
- `cargo check`
- `cargo fmt`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68df28e12594832ba4ad362f06732b2d