### PR TITLE
fix: extend scroll span runs in place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chabeau"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "chrono",

--- a/src/utils/scroll.rs
+++ b/src/utils/scroll.rs
@@ -99,14 +99,14 @@ impl ScrollCalculator {
                 if text.is_empty() {
                     return;
                 }
-                if let Some(last) = collector_spans.last_mut() {
-                    if last.style == style && collector_kinds.last() == Some(&kind) {
-                        let mut combined = String::with_capacity(last.content.len() + text.len());
-                        combined.push_str(&last.content);
-                        combined.push_str(text);
-                        let st = last.style;
-                        *last = Span::styled(combined, st);
-                        return;
+                if let Some(last_kind) = collector_kinds.last() {
+                    if *last_kind == kind {
+                        if let Some(last_span) = collector_spans.last_mut() {
+                            if last_span.style == style {
+                                last_span.content.to_mut().push_str(text);
+                                return;
+                            }
+                        }
                     }
                 }
                 collector_spans.push(Span::styled(text.to_string(), style));


### PR DESCRIPTION
## Summary
- extend the scroll append helper to mutate existing spans instead of reallocating strings
- refresh Cargo.lock to match the current crate version metadata

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e049c57c80832baceb817adf250652