### PR TITLE
fix: respect emoji width in text wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chabeau"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "chrono",


### PR DESCRIPTION
## Summary
- update the text wrapping engine to measure grapheme widths and avoid splitting multi-cell emoji
- adjust long-word breaking and cursor mapping to align with rendered cell widths
- add regression tests for double-width emoji

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e040f94dfc832b997392e6bc2d17c7