### PR TITLE
Fix markdown wrapping on grapheme boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chabeau"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "chrono",


### PR DESCRIPTION
## Summary
- iterate over grapheme clusters when wrapping markdown spans to avoid splitting composed emoji
- adjust forced break handling to operate on grapheme widths instead of scalar values
- add tests covering ZWJ emoji and skin tone modifier clusters

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e040dfb570832b8373d79f73d01c03