### PR TITLE
Refactor chat loop handlers to reduce locking churn

### DIFF
--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -34,9 +34,6 @@ Items are removed when completed.
   - Add integration-style tests for event handling if feasible (simulate key events) — [OPEN]
   - Consider adding integration tests for the complete Del key workflow in picker dialogs — [OPEN]
   - Consider testing UI state changes after Del key operations (picker refresh) — [OPEN]
-- Reduce locking churn in `src/ui/chat_loop/mod.rs` — [OPEN]
-  - Extract focused handlers for drawing, keyboard routing, and stream dispatch so a mutable `App` borrow does not cross await points and to make event ordering easier to reason about — [OPEN]
-
 ### Medium priority
 
 - Reduce duplication in `src/ui/markdown.rs` for code block flushing (extract helper) — [OPEN]


### PR DESCRIPTION
## Summary
- add focused helpers for exit detection, drawing, keyboard routing, paste handling, and stream dispatch in the chat loop
- rework the main chat loop to use the new helpers so App mutex guards do not span await points
- remove the completed locking-churn entry from the wishlist

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e059dd4ed0832b9f632e65d62a891a