### PR TITLE
Refactor chat streaming into core service module

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod builtin_providers;
+pub mod chat_stream;
 pub mod config;
 pub mod message;
 pub mod providers;

--- a/src/ui/chat_loop/keybindings/mod.rs
+++ b/src/ui/chat_loop/keybindings/mod.rs
@@ -19,7 +19,7 @@ pub enum KeyLoopAction {
 
 /// Build a complete mode-aware registry with all handlers
 pub fn build_mode_aware_registry(
-    stream_dispatcher: std::sync::Arc<crate::ui::chat_loop::stream::StreamDispatcher>,
+    stream_service: std::sync::Arc<crate::core::chat_stream::ChatStreamService>,
     terminal: std::sync::Arc<
         tokio::sync::Mutex<ratatui::Terminal<crate::ui::osc_backend::OscBackend<std::io::Stdout>>>,
     >,
@@ -210,7 +210,7 @@ pub fn build_mode_aware_registry(
             KeyContext::Typing,
             KeyPattern::ctrl(KeyCode::Char('j')),
             Box::new(CtrlJHandler {
-                stream_dispatcher: stream_dispatcher.clone(),
+                stream_service: stream_service.clone(),
                 event_tx: event_tx.clone(),
             }),
         )
@@ -218,7 +218,7 @@ pub fn build_mode_aware_registry(
             KeyContext::Typing,
             KeyPattern::simple(KeyCode::Enter),
             Box::new(EnterHandler {
-                stream_dispatcher: stream_dispatcher.clone(),
+                stream_service: stream_service.clone(),
                 event_tx: event_tx.clone(),
             }),
         )
@@ -226,7 +226,7 @@ pub fn build_mode_aware_registry(
             KeyContext::Typing,
             KeyPattern::with_modifiers(KeyCode::Enter, KeyModifiers::ALT),
             Box::new(AltEnterHandler {
-                stream_dispatcher: stream_dispatcher.clone(),
+                stream_service: stream_service.clone(),
                 event_tx: event_tx.clone(),
             }),
         )
@@ -235,7 +235,7 @@ pub fn build_mode_aware_registry(
             KeyContext::FilePrompt,
             KeyPattern::simple(KeyCode::Enter),
             Box::new(EnterHandler {
-                stream_dispatcher: stream_dispatcher.clone(),
+                stream_service: stream_service.clone(),
                 event_tx: event_tx.clone(),
             }),
         )
@@ -243,7 +243,7 @@ pub fn build_mode_aware_registry(
             KeyContext::FilePrompt,
             KeyPattern::with_modifiers(KeyCode::Enter, KeyModifiers::ALT),
             Box::new(AltEnterHandler {
-                stream_dispatcher: stream_dispatcher.clone(),
+                stream_service: stream_service.clone(),
                 event_tx: event_tx.clone(),
             }),
         )
@@ -251,7 +251,7 @@ pub fn build_mode_aware_registry(
             KeyContext::InPlaceEdit,
             KeyPattern::simple(KeyCode::Enter),
             Box::new(EnterHandler {
-                stream_dispatcher: stream_dispatcher.clone(),
+                stream_service: stream_service.clone(),
                 event_tx: event_tx.clone(),
             }),
         )
@@ -259,14 +259,14 @@ pub fn build_mode_aware_registry(
             KeyContext::Typing,
             KeyPattern::ctrl(KeyCode::Char('r')),
             Box::new(CtrlRHandler {
-                stream_dispatcher: stream_dispatcher.clone(),
+                stream_service: stream_service.clone(),
             }),
         )
         .register_for_context(
             KeyContext::Typing,
             KeyPattern::ctrl(KeyCode::Char('t')),
             Box::new(CtrlTHandler {
-                stream_dispatcher,
+                stream_service,
                 terminal,
             }),
         )


### PR DESCRIPTION
## Summary
- move chat streaming logic into `core::chat_stream` with a reusable `ChatStreamService`
- update the chat loop and keybinding handlers to consume the new service abstraction
- refresh unit tests to use the relocated service and maintain streaming coverage

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e0b32e565c832bbe79d695fc662bc3