### PR TITLE
feat: add command registry dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,9 @@ Modular design with focused components:
   - `logging.rs` - Chat logging functionality
   - `scroll.rs` - Text wrapping and scroll calculations
   - `clipboard.rs` - Cross-platform clipboard helper
-- `commands/` - Chat command processing
-  - `mod.rs` - Command processing implementation
+- `commands/` - Chat command processing and registry-driven dispatch
+  - `mod.rs` - Command handlers and dispatcher
+  - `registry.rs` - Static command metadata registry
 
 ## Development
 

--- a/src/builtins/help.md
+++ b/src/builtins/help.md
@@ -29,20 +29,6 @@ Thanks for using Chabeau! Find a bug? Let us know: https://github.com/permacommo
 - F6: Toggle sort mode
 - Type: Filter options
 
-## Commands
-
-- `/theme` — Pick a theme (built-in or custom) with filtering and sorting
-- `/theme <id>` — Apply a theme by id (persisted to config)
-- `/model` — Pick a model from current provider with filtering, sorting, and metadata
-- `/model <id>` — Switch to specified model (session only)
-- `/provider` — Pick a provider with filtering and sorting
-- `/provider <id>` — Switch to specified provider (session only)
-  (Tip: On startup with multiple providers, Esc from model picker returns here.)
-- `/markdown` — Toggle Markdown rendering. Persisted to config.
-- `/syntax` — Toggle code syntax highlighting. Persisted to config.
-- `/log <filename>` — Enable logging to file; `/log` toggles pause/resume
-- `/dump [filename]` — Dump conversation to file (default: `chabeau-log-YYYY-MM-DD.txt`)
-
 ## Tips
 
 - Use `/log` to start logging from where you are.

--- a/src/builtins/help.md
+++ b/src/builtins/help.md
@@ -1,6 +1,8 @@
 # Chabeau Help
 
-Thanks for using Chabeau! Find a bug? Let us know: https://github.com/permacommons/chabeau/issues
+Thanks for using Chabeau, a Permacommons project.
+
+Find a bug? Let us know: https://github.com/permacommons/chabeau/issues
 
 ## Keys
 
@@ -31,10 +33,7 @@ Thanks for using Chabeau! Find a bug? Let us know: https://github.com/permacommo
 
 ## Tips
 
+- Not all terminals support clickable hyperlinks. Even if yours does, you may need to hold a modifier key like [Ctrl] while clicking.
 - Use `/log` to start logging from where you are.
 - `/dump` creates a one-off snapshot of the _entire_ conversation so far.
 - Use Ctrl+B to copy (`c`) or save (`s`) code blocks.
-- Chabeau will try to guess a good filename. If that already exists, it will prompt
-  you to specify your own.
-
-Chabeau is a Permacommons project. It is in the public domain, forever.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -41,9 +41,15 @@ pub fn process_input(app: &mut App, input: &str) -> CommandResult {
 
 pub(super) fn handle_help(app: &mut App, _invocation: CommandInvocation<'_>) -> CommandResult {
     let mut help_md = crate::ui::help::builtin_help_md().to_string();
-    help_md.push_str("\n\n### Commands\n");
+    help_md.push_str("\n\n## Commands\n");
     for command in all_commands() {
-        help_md.push_str(&format!("* `/{}` - {}\n", command.name, command.help));
+        for usage in command.usages {
+            help_md.push_str(&format!("- `{}` — {}\n", usage.syntax, usage.description));
+        }
+        for line in command.extra_help {
+            help_md.push_str(line);
+            help_md.push('\n');
+        }
     }
     app.conversation().add_system_message(help_md);
     CommandResult::Continue
@@ -398,7 +404,7 @@ mod tests {
         let last_message = app.ui.messages.back().expect("help message");
         assert!(last_message
             .content
-            .contains("`/help` - Show available commands"));
+            .contains("- `/help` — Show available commands"));
     }
 
     #[test]

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -105,9 +105,7 @@ const COMMANDS: &[Command] = &[
                 description: "Switch to the specified provider for this session only.",
             },
         ],
-        extra_help: &[
-            "  (Tip: On startup with multiple providers, Esc from model picker returns here.)",
-        ],
+        extra_help: &[],
         handler: super::handle_provider,
     },
     Command {

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -1,0 +1,69 @@
+use super::CommandResult;
+use crate::core::app::App;
+
+pub type CommandHandler = fn(&mut App, CommandInvocation<'_>) -> CommandResult;
+
+pub struct Command {
+    pub name: &'static str,
+    pub help: &'static str,
+    pub handler: CommandHandler,
+}
+
+#[derive(Clone, Copy)]
+pub struct CommandInvocation<'a> {
+    pub input: &'a str,
+    pub args: &'a str,
+}
+
+pub fn all_commands() -> &'static [Command] {
+    COMMANDS
+}
+
+pub fn find_command(name: &str) -> Option<&'static Command> {
+    all_commands()
+        .iter()
+        .find(|command| command.name.eq_ignore_ascii_case(name))
+}
+
+const COMMANDS: &[Command] = &[
+    Command {
+        name: "help",
+        help: "Show available commands and usage information.",
+        handler: super::handle_help,
+    },
+    Command {
+        name: "log",
+        help: "Toggle logging or set the log file path.",
+        handler: super::handle_log,
+    },
+    Command {
+        name: "dump",
+        help: "Export the current conversation to a file.",
+        handler: super::handle_dump,
+    },
+    Command {
+        name: "theme",
+        help: "Open the theme picker or apply a theme directly.",
+        handler: super::handle_theme,
+    },
+    Command {
+        name: "model",
+        help: "Open the model picker or switch models immediately.",
+        handler: super::handle_model,
+    },
+    Command {
+        name: "provider",
+        help: "Open the provider picker or switch providers immediately.",
+        handler: super::handle_provider,
+    },
+    Command {
+        name: "markdown",
+        help: "Toggle markdown rendering for assistant responses.",
+        handler: super::handle_markdown,
+    },
+    Command {
+        name: "syntax",
+        help: "Toggle syntax highlighting for code blocks.",
+        handler: super::handle_syntax,
+    },
+];

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -3,9 +3,15 @@ use crate::core::app::App;
 
 pub type CommandHandler = fn(&mut App, CommandInvocation<'_>) -> CommandResult;
 
+pub struct CommandUsage {
+    pub syntax: &'static str,
+    pub description: &'static str,
+}
+
 pub struct Command {
     pub name: &'static str,
-    pub help: &'static str,
+    pub usages: &'static [CommandUsage],
+    pub extra_help: &'static [&'static str],
     pub handler: CommandHandler,
 }
 
@@ -28,42 +34,98 @@ pub fn find_command(name: &str) -> Option<&'static Command> {
 const COMMANDS: &[Command] = &[
     Command {
         name: "help",
-        help: "Show available commands and usage information.",
+        usages: &[CommandUsage {
+            syntax: "/help",
+            description: "Show available commands and usage information.",
+        }],
+        extra_help: &[],
         handler: super::handle_help,
     },
     Command {
         name: "log",
-        help: "Toggle logging or set the log file path.",
+        usages: &[CommandUsage {
+            syntax: "/log [filename]",
+            description:
+                "Enable logging to a file, or toggle pause/resume when no filename is provided.",
+        }],
+        extra_help: &[],
         handler: super::handle_log,
     },
     Command {
         name: "dump",
-        help: "Export the current conversation to a file.",
+        usages: &[CommandUsage {
+            syntax: "/dump [filename]",
+            description:
+                "Dump the full conversation to a file (default: `chabeau-log-YYYY-MM-DD.txt`).",
+        }],
+        extra_help: &[],
         handler: super::handle_dump,
     },
     Command {
         name: "theme",
-        help: "Open the theme picker or apply a theme directly.",
+        usages: &[
+            CommandUsage {
+                syntax: "/theme",
+                description:
+                    "Pick a theme (built-in or custom) with filtering and sorting options.",
+            },
+            CommandUsage {
+                syntax: "/theme <id>",
+                description: "Apply a theme by id and persist the selection to config.",
+            },
+        ],
+        extra_help: &[],
         handler: super::handle_theme,
     },
     Command {
         name: "model",
-        help: "Open the model picker or switch models immediately.",
+        usages: &[
+            CommandUsage {
+                syntax: "/model",
+                description:
+                    "Pick a model from the current provider with filtering, sorting, and metadata.",
+            },
+            CommandUsage {
+                syntax: "/model <id>",
+                description: "Switch to the specified model for this session only.",
+            },
+        ],
+        extra_help: &[],
         handler: super::handle_model,
     },
     Command {
         name: "provider",
-        help: "Open the provider picker or switch providers immediately.",
+        usages: &[
+            CommandUsage {
+                syntax: "/provider",
+                description: "Pick a provider with filtering and sorting.",
+            },
+            CommandUsage {
+                syntax: "/provider <id>",
+                description: "Switch to the specified provider for this session only.",
+            },
+        ],
+        extra_help: &[
+            "  (Tip: On startup with multiple providers, Esc from model picker returns here.)",
+        ],
         handler: super::handle_provider,
     },
     Command {
         name: "markdown",
-        help: "Toggle markdown rendering for assistant responses.",
+        usages: &[CommandUsage {
+            syntax: "/markdown [on|off|toggle]",
+            description: "Toggle Markdown rendering and persist the preference to config.",
+        }],
+        extra_help: &[],
         handler: super::handle_markdown,
     },
     Command {
         name: "syntax",
-        help: "Toggle syntax highlighting for code blocks.",
+        usages: &[CommandUsage {
+            syntax: "/syntax [on|off|toggle]",
+            description: "Toggle code syntax highlighting and persist the preference to config.",
+        }],
+        extra_help: &[],
         handler: super::handle_syntax,
     },
 ];


### PR DESCRIPTION
## Summary
- add a command registry with metadata-driven descriptors
- refactor command processing to dispatch through dedicated handlers and reuse registry help text
- add tests around registry dispatch and document the new layout

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e0e095e6d8832ba1fa2610e90191fc