### PR TITLE
feat: add slash command tab completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Most should be intuitive. A couple of choices may be a bit jarring at first:
 
 - Alt+Enter (or Ctrl+J) to start a new line: We've found this to be most reliable across terminals.
 - Compose mode (F4) flips the defaults: Enter inserts a newline, Alt+Enter/Ctrl+J sends, arrow keys stay in the input, and Shift+arrow scrolls the transcript.
+- Tab autocompletes slash commands so you can discover options quickly.
 
 Feedback and suggestions are always welcome!
 

--- a/src/builtins/help.md
+++ b/src/builtins/help.md
@@ -14,6 +14,7 @@ Find a bug? Let us know: https://github.com/permacommons/chabeau/issues
 - Ctrl+P: Edit previous messages (select mode)
 - Ctrl+B: Select code blocks (copy `c`, save `s`)
 - Ctrl+L: Clear status message
+- Tab: Autocomplete slash commands
 - Ctrl+T: Open in external editor (requires `$EDITOR` to be set)
 - Esc: Interrupt streaming / cancel modes
 - Up/Down/Mouse: Scroll history

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
 mod registry;
 
-pub use registry::{all_commands, CommandInvocation};
+pub use registry::{all_commands, matching_commands, CommandInvocation};
 
 use crate::core::app::App;
 use chrono::Utc;

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -31,6 +31,20 @@ pub fn find_command(name: &str) -> Option<&'static Command> {
         .find(|command| command.name.eq_ignore_ascii_case(name))
 }
 
+pub fn matching_commands(prefix: &str) -> Vec<&'static Command> {
+    let lower_prefix = prefix.to_ascii_lowercase();
+    all_commands()
+        .iter()
+        .filter(|command| {
+            if lower_prefix.is_empty() {
+                true
+            } else {
+                command.name.to_ascii_lowercase().starts_with(&lower_prefix)
+            }
+        })
+        .collect()
+}
+
 const COMMANDS: &[Command] = &[
     Command {
         name: "help",

--- a/src/ui/chat_loop/keybindings/mod.rs
+++ b/src/ui/chat_loop/keybindings/mod.rs
@@ -37,6 +37,11 @@ pub fn build_mode_aware_registry(
             Box::new(EscapeHandler),
         )
         .register_for_context(
+            KeyContext::Typing,
+            KeyPattern::simple(KeyCode::Tab),
+            Box::new(CommandAutocompleteHandler::new()),
+        )
+        .register_for_context(
             KeyContext::EditSelect,
             KeyPattern::simple(KeyCode::Esc),
             Box::new(EscapeHandler),


### PR DESCRIPTION
## Summary
- add a Tab key handler that autocompletes slash commands and shows candidate matches
- expose registry helpers for command prefix matching and document the shortcut
- cover the new behavior with unit tests for single and multiple completion scenarios

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e16c30eebc832b8c34a5494714acdf