### PR TITLE
test: isolate case-insensitive command dispatch

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -409,11 +409,13 @@ mod tests {
 
     #[test]
     fn commands_dispatch_case_insensitively() {
-        let mut app = create_test_app();
-        app.ui.markdown_enabled = false;
-        let result = process_input(&mut app, "/MarkDown On");
-        assert!(matches!(result, CommandResult::Continue));
-        assert!(app.ui.markdown_enabled);
+        with_temp_config_env(|_| {
+            let mut app = create_test_app();
+            app.ui.markdown_enabled = false;
+            let result = process_input(&mut app, "/MarkDown On");
+            assert!(matches!(result, CommandResult::Continue));
+            assert!(app.ui.markdown_enabled);
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- run the case-insensitive command dispatch test inside the temporary config environment to avoid cross-test interference

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test commands::tests::commands_dispatch_case_insensitively
- cargo test commands::tests::markdown_command_updates_state_and_persists
- cargo test commands::tests::syntax_command_updates_state_and_persists
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e178745634832b9985f2d26f3e2df0