### PR TITLE
Refactor bootstrap to reuse provider sessions

### DIFF
--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -3,6 +3,7 @@ use crate::api::ModelsResponse;
 use crate::core::config::Config;
 #[cfg(test)]
 use crate::core::message::Message;
+use crate::core::providers::ProviderSession;
 use crate::ui::picker::PickerState;
 use crate::ui::span::SpanKind;
 #[cfg(any(test, feature = "bench"))]
@@ -37,12 +38,21 @@ pub async fn new_with_auth(
     provider: Option<String>,
     env_only: bool,
     config: &Config,
+    pre_resolved_session: Option<ProviderSession>,
 ) -> Result<App, Box<dyn std::error::Error>> {
     let SessionBootstrap {
         session,
         theme,
         startup_requires_provider,
-    } = session::prepare_with_auth(model, log_file, provider, env_only, config).await?;
+    } = session::prepare_with_auth(
+        model,
+        log_file,
+        provider,
+        env_only,
+        config,
+        pre_resolved_session,
+    )
+    .await?;
 
     let mut app = App {
         session,


### PR DESCRIPTION
## Summary
- reuse the bootstrap auth manager to pre-resolve provider credentials and pass them into app initialization
- let `prepare_with_auth` accept pre-resolved sessions so keyring access is skipped when credentials are available
- add a unit test that covers the pre-resolved authentication path

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e20c6df32c832b9440583929930fe0