### PR TITLE
Assert model command test enforces picker result

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -600,7 +600,7 @@ mod tests {
     fn model_command_returns_open_picker_result() {
         let mut app = create_test_app();
         let res = process_input(&mut app, "/model");
-        matches!(res, CommandResult::OpenModelPicker);
+        assert!(matches!(res, CommandResult::OpenModelPicker));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- ensure the model command test asserts that the picker opens

## Testing
- cargo test model_command_returns_open_picker_result

------
https://chatgpt.com/codex/tasks/task_e_68e22908ca88832b89859f1911564806