### PR TITLE
Fix logging activation for startup log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Inside the TUI, use `/provider` and `/model` to switch, and `/help` to see a ful
 chabeau                              # Start chat with defaults (pickers on demand)
 chabeau --provider openai            # Use specific provider
 chabeau --model gpt-5                # Use specific model
-chabeau --log conversation.log       # Enable logging
+chabeau --log conversation.log       # Enable logging immediately on startup
 ```
 
 ### Discovery


### PR DESCRIPTION
## Summary
- ensure session logging activation uses `set_log_file` so startup logging writes its first entry
- add a regression test covering initialization with `--log`
- clarify README usage text for the startup logging flag

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e228f21734832b9f1ca08ad846604f