### PR TITLE
Ensure model command test asserts result

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -608,7 +608,7 @@ mod tests {
         let mut app = create_test_app();
         let original_model = app.session.model.clone();
         let res = process_input(&mut app, "/model gpt-4");
-        matches!(res, CommandResult::Continue);
+        assert!(matches!(res, CommandResult::Continue));
         assert_eq!(app.session.model, "gpt-4");
         assert_ne!(app.session.model, original_model);
     }


### PR DESCRIPTION
## Summary
- enforce that the model command test asserts the command result remains Continue

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test command

------
https://chatgpt.com/codex/tasks/task_e_68e22c0e7f4c832b8a2a1438f119ce8d