### PR TITLE
test: isolate auth config env

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -710,10 +710,80 @@ impl ProviderAuthSource for AuthManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use once_cell::sync::Lazy;
     use std::env;
-    use std::sync::{Mutex, OnceLock};
+    use std::ffi::OsString;
+    use std::path::Path;
+    use std::sync::{Mutex, MutexGuard};
+    use tempfile::TempDir;
 
-    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    static TEST_CONFIG_ENV_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    struct TestConfigEnv {
+        _lock: MutexGuard<'static, ()>,
+        temp_dir: TempDir,
+        previous_vars: Vec<(String, Option<OsString>)>,
+    }
+
+    impl TestConfigEnv {
+        fn new() -> Self {
+            let lock = TEST_CONFIG_ENV_GUARD
+                .lock()
+                .expect("config env mutex poisoned");
+            let temp_dir = TempDir::new().expect("failed to create temp dir for config");
+            let mut guard = Self {
+                _lock: lock,
+                temp_dir,
+                previous_vars: Vec::new(),
+            };
+
+            guard.capture_and_set("XDG_CONFIG_HOME");
+
+            #[cfg(target_os = "windows")]
+            {
+                guard.capture_and_set("APPDATA");
+                guard.capture_and_set("LOCALAPPDATA");
+            }
+
+            #[cfg(target_os = "macos")]
+            {
+                guard.capture_and_set("HOME");
+            }
+
+            guard
+        }
+
+        fn capture_and_set(&mut self, key: &str) {
+            let previous = env::var_os(key);
+            self.previous_vars.push((key.to_string(), previous));
+            env::set_var(key, self.temp_dir.path());
+        }
+
+        fn config_root(&self) -> &Path {
+            self.temp_dir.path()
+        }
+    }
+
+    impl Drop for TestConfigEnv {
+        fn drop(&mut self) {
+            for (key, value) in self.previous_vars.drain(..).rev() {
+                if let Some(val) = value {
+                    env::set_var(&key, val);
+                } else {
+                    env::remove_var(&key);
+                }
+            }
+        }
+    }
+
+    fn with_test_config_env<F, T>(f: F) -> T
+    where
+        F: FnOnce(&Path) -> T,
+    {
+        let guard = TestConfigEnv::new();
+        let result = f(guard.config_root());
+        result
+    }
 
     #[test]
     fn collect_configured_providers_skips_duplicate_custom_entries() {
@@ -764,7 +834,7 @@ mod tests {
     }
 
     fn create_test_auth_manager() -> AuthManager {
-        AuthManager::new_with_keyring(false)
+        with_test_config_env(|_| AuthManager::new_with_keyring(false))
     }
 
     #[test]
@@ -817,37 +887,39 @@ mod tests {
 
     #[test]
     fn env_fallback_sets_openai_provider_for_default_base() {
-        let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-        // Ensure no default provider in config and no keyring; set explicit default base
-        env::set_var("OPENAI_API_KEY", "sk-test");
-        env::set_var("OPENAI_BASE_URL", "https://api.openai.com/v1");
-        let am = AuthManager::new_with_keyring(false);
-        let cfg = Config::default();
-        let (_key, base, prov, display) = am
-            .resolve_authentication(None, &cfg)
-            .expect("env fallback should work");
-        assert_eq!(base, "https://api.openai.com/v1");
-        assert_eq!(prov, "openai");
-        assert_eq!(display, "OpenAI");
-        env::remove_var("OPENAI_API_KEY");
-        env::remove_var("OPENAI_BASE_URL");
+        with_test_config_env(|_| {
+            // Ensure no default provider in config and no keyring; set explicit default base
+            env::set_var("OPENAI_API_KEY", "sk-test");
+            env::set_var("OPENAI_BASE_URL", "https://api.openai.com/v1");
+            let am = AuthManager::new_with_keyring(false);
+            let cfg = Config::default();
+            let (_key, base, prov, display) = am
+                .resolve_authentication(None, &cfg)
+                .expect("env fallback should work");
+            assert_eq!(base, "https://api.openai.com/v1");
+            assert_eq!(prov, "openai");
+            assert_eq!(display, "OpenAI");
+            env::remove_var("OPENAI_API_KEY");
+            env::remove_var("OPENAI_BASE_URL");
+        });
     }
 
     #[test]
     fn env_fallback_sets_openai_compatible_for_custom_base() {
-        let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-        env::set_var("OPENAI_API_KEY", "sk-test");
-        env::set_var("OPENAI_BASE_URL", "https://example.com/v1");
-        let am = AuthManager::new_with_keyring(false);
-        let cfg = Config::default();
-        let (_key, base, prov, display) = am
-            .resolve_authentication(None, &cfg)
-            .expect("env fallback should work");
-        assert_eq!(base, "https://example.com/v1");
-        assert_eq!(prov, "openai-compatible");
-        assert_eq!(display, "OpenAI-compatible");
-        env::remove_var("OPENAI_API_KEY");
-        env::remove_var("OPENAI_BASE_URL");
+        with_test_config_env(|_| {
+            env::set_var("OPENAI_API_KEY", "sk-test");
+            env::set_var("OPENAI_BASE_URL", "https://example.com/v1");
+            let am = AuthManager::new_with_keyring(false);
+            let cfg = Config::default();
+            let (_key, base, prov, display) = am
+                .resolve_authentication(None, &cfg)
+                .expect("env fallback should work");
+            assert_eq!(base, "https://example.com/v1");
+            assert_eq!(prov, "openai-compatible");
+            assert_eq!(display, "OpenAI-compatible");
+            env::remove_var("OPENAI_API_KEY");
+            env::remove_var("OPENAI_BASE_URL");
+        });
     }
 
     // Note: We can't easily test the full read_masked_input function without mocking

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -608,7 +608,7 @@ mod tests {
         let mut app = create_test_app();
         let original_model = app.session.model.clone();
         let res = process_input(&mut app, "/model gpt-4");
-        matches!(res, CommandResult::Continue);
+        assert!(matches!(res, CommandResult::Continue));
         assert_eq!(app.session.model, "gpt-4");
         assert_ne!(app.session.model, original_model);
     }


### PR DESCRIPTION
## Summary
- add an isolated config environment helper for auth tests that guards configuration env vars with a mutex-backed Lazy
- update auth tests to construct managers inside the isolated helper to avoid reading the user config directory

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e22f4accb0832ba2cb301ca0e45555