### PR TITLE
Fix color test env synchronization

### DIFF
--- a/src/utils/color.rs
+++ b/src/utils/color.rs
@@ -261,57 +261,24 @@ pub fn xterm256_to_rgb(i: u8) -> (u8, u8, u8) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use once_cell::sync::Lazy;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+    use crate::utils::test_utils::TestEnvVarGuard;
 
     #[test]
     fn detects_truecolor_from_env() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let prev_chabeau_color = std::env::var("CHABEAU_COLOR").ok();
-        let prev_colorterm = std::env::var("COLORTERM").ok();
-        std::env::remove_var("CHABEAU_COLOR");
-        std::env::set_var("COLORTERM", "truecolor");
+        let mut env = TestEnvVarGuard::new();
+        env.remove_var("CHABEAU_COLOR");
+        env.set_var("COLORTERM", "truecolor");
         assert_eq!(detect_color_depth(), ColorDepth::Truecolor);
-        if let Some(prev) = prev_chabeau_color {
-            std::env::set_var("CHABEAU_COLOR", prev);
-        } else {
-            std::env::remove_var("CHABEAU_COLOR");
-        }
-        if let Some(prev) = prev_colorterm {
-            std::env::set_var("COLORTERM", prev);
-        } else {
-            std::env::remove_var("COLORTERM");
-        }
     }
 
     #[test]
     fn detects_256_from_term() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let prev_chabeau_color = std::env::var("CHABEAU_COLOR").ok();
-        let prev_colorterm = std::env::var("COLORTERM").ok();
-        let prev_term = std::env::var("TERM").ok();
+        let mut env = TestEnvVarGuard::new();
         // Ensure COLORTERM doesn't force truecolor in this environment
-        std::env::remove_var("CHABEAU_COLOR");
-        std::env::remove_var("COLORTERM");
-        std::env::set_var("TERM", "xterm-256color");
+        env.remove_var("CHABEAU_COLOR");
+        env.remove_var("COLORTERM");
+        env.set_var("TERM", "xterm-256color");
         assert_eq!(detect_color_depth(), ColorDepth::X256);
-        if let Some(prev) = prev_chabeau_color {
-            std::env::set_var("CHABEAU_COLOR", prev);
-        } else {
-            std::env::remove_var("CHABEAU_COLOR");
-        }
-        if let Some(prev) = prev_colorterm {
-            std::env::set_var("COLORTERM", prev);
-        } else {
-            std::env::remove_var("COLORTERM");
-        }
-        if let Some(prev) = prev_term {
-            std::env::set_var("TERM", prev);
-        } else {
-            std::env::remove_var("TERM");
-        }
     }
 
     #[test]

--- a/src/utils/scroll.rs
+++ b/src/utils/scroll.rs
@@ -758,7 +758,7 @@ mod tests {
     use crate::ui::span::SpanKind;
     use crate::ui::theme::Theme;
     use crate::utils::test_utils::{
-        create_test_message, create_test_messages, SAMPLE_HYPERTEXT_PARAGRAPH,
+        create_test_message, create_test_messages, TestEnvVarGuard, SAMPLE_HYPERTEXT_PARAGRAPH,
     };
     use ratatui::style::{Color, Modifier, Style};
     use ratatui::text::Line as TLine;
@@ -1411,7 +1411,8 @@ mod tests {
 
     #[test]
     fn highlight_is_correct_after_wrapped_paragraph() {
-        std::env::set_var("CHABEAU_COLOR", "truecolor");
+        let mut env = TestEnvVarGuard::new();
+        env.set_var("CHABEAU_COLOR", "truecolor");
         let theme = Theme::dark_default();
         let mut messages: VecDeque<Message> = VecDeque::new();
         let long_para = "This is a very long line that should wrap multiple times given a small terminal width so that the visual line count before the code block increases significantly.";
@@ -1463,12 +1464,12 @@ mod tests {
                 );
             }
         }
-        std::env::remove_var("CHABEAU_COLOR");
     }
 
     #[test]
     fn highlight_is_correct_after_table() {
-        std::env::set_var("CHABEAU_COLOR", "truecolor");
+        let mut env = TestEnvVarGuard::new();
+        env.set_var("CHABEAU_COLOR", "truecolor");
         let theme = Theme::dark_default();
         let mut messages: VecDeque<Message> = VecDeque::new();
         // Message 0: a table that will be rendered before the code block
@@ -1529,6 +1530,5 @@ mod tests {
                 );
             }
         }
-        std::env::remove_var("CHABEAU_COLOR");
     }
 }


### PR DESCRIPTION
## Summary
- add a shared `TestEnvVarGuard` helper to serialize environment changes in tests
- migrate scroll highlight and color depth tests to the guard so CHABEAU_COLOR overrides are restored
- derive sensible defaults for the guard types to satisfy clippy

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e236fbd768832b93065682c2aa460e