### PR TITLE
Use TestEnvVarGuard in auth env fallback tests

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -710,8 +710,7 @@ impl ProviderAuthSource for AuthManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test_utils::with_test_config_env;
-    use std::env;
+    use crate::utils::test_utils::{with_test_config_env, TestEnvVarGuard};
 
     #[test]
     fn collect_configured_providers_skips_duplicate_custom_entries() {
@@ -817,8 +816,9 @@ mod tests {
     fn env_fallback_sets_openai_provider_for_default_base() {
         with_test_config_env(|_| {
             // Ensure no default provider in config and no keyring; set explicit default base
-            env::set_var("OPENAI_API_KEY", "sk-test");
-            env::set_var("OPENAI_BASE_URL", "https://api.openai.com/v1");
+            let mut env_guard = TestEnvVarGuard::new();
+            env_guard.set_var("OPENAI_API_KEY", "sk-test");
+            env_guard.set_var("OPENAI_BASE_URL", "https://api.openai.com/v1");
             let am = AuthManager::new_with_keyring(false);
             let cfg = Config::default();
             let (_key, base, prov, display) = am
@@ -827,16 +827,17 @@ mod tests {
             assert_eq!(base, "https://api.openai.com/v1");
             assert_eq!(prov, "openai");
             assert_eq!(display, "OpenAI");
-            env::remove_var("OPENAI_API_KEY");
-            env::remove_var("OPENAI_BASE_URL");
+            env_guard.remove_var("OPENAI_API_KEY");
+            env_guard.remove_var("OPENAI_BASE_URL");
         });
     }
 
     #[test]
     fn env_fallback_sets_openai_compatible_for_custom_base() {
         with_test_config_env(|_| {
-            env::set_var("OPENAI_API_KEY", "sk-test");
-            env::set_var("OPENAI_BASE_URL", "https://example.com/v1");
+            let mut env_guard = TestEnvVarGuard::new();
+            env_guard.set_var("OPENAI_API_KEY", "sk-test");
+            env_guard.set_var("OPENAI_BASE_URL", "https://example.com/v1");
             let am = AuthManager::new_with_keyring(false);
             let cfg = Config::default();
             let (_key, base, prov, display) = am
@@ -845,8 +846,8 @@ mod tests {
             assert_eq!(base, "https://example.com/v1");
             assert_eq!(prov, "openai-compatible");
             assert_eq!(display, "OpenAI-compatible");
-            env::remove_var("OPENAI_API_KEY");
-            env::remove_var("OPENAI_BASE_URL");
+            env_guard.remove_var("OPENAI_API_KEY");
+            env_guard.remove_var("OPENAI_BASE_URL");
         });
     }
 


### PR DESCRIPTION
## Summary
- add a TestEnvVarGuard to the auth environment fallback tests
- replace direct environment manipulation with the guard helper methods

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68e2a307cfdc832b993ad35eae36719a