### PR TITLE
test: strengthen mixed content wrap assertion

### DIFF
--- a/src/utils/scroll.rs
+++ b/src/utils/scroll.rs
@@ -865,10 +865,10 @@ mod tests {
             Some(20),
         );
 
-        // With wide terminal (markdown), and narrow (plain), narrow should produce >= lines
+        // With wide terminal (markdown) and narrow (plain), the narrow width should yield
+        // at least as many lines, and wrapping should add extra lines relative to the wide view
         assert!(lines_narrow.len() >= lines_wide.len());
-        // And not fewer lines than wide
-        assert!(lines_narrow.len() >= lines_wide.len());
+        assert!(lines_narrow.len() > lines_wide.len());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- tighten the mixed-content wrapping test to require narrow layouts to produce more lines than wide layouts
- update the associated comment to reflect the stricter expectation

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68e4094ad7b8832b9d237e44ea6132c9