### PR TITLE
Refine character import environment overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ chabeau import -c path/to/character.png     # Import PNG with embedded metadata
 chabeau import -c character.json --force    # Overwrite existing card
 ```
 
-Cards are stored in the Chabeau configuration directory; you can also just copy them there yourself. Use `chabeau -c` to print the directory name and any cards Chabeau discovers.
+Cards are stored in the Chabeau configuration directory; you can also just copy them there yourself. Use `chabeau -c` to print the directory name and any cards Chabeau discovers. To point Chabeau at a different cards directory (for example, when testing or keeping cards in a synced folder), set the `CHABEAU_CARDS_DIR` environment variable before launching the app.
 
 **Use a character:**
 

--- a/src/core/app/picker/mod.rs
+++ b/src/core/app/picker/mod.rs
@@ -1058,7 +1058,7 @@ mod tests {
     fn test_turn_off_character_entry_added_when_character_active() {
         use crate::character::cache::CardCache;
         use crate::character::card::{CharacterCard, CharacterData};
-        use crate::utils::test_utils::create_test_app;
+        use crate::utils::test_utils::{create_test_app, TestEnvVarGuard};
         use std::fs;
         use tempfile::tempdir;
 
@@ -1104,11 +1104,10 @@ mod tests {
             },
         });
 
-        std::env::set_var("CHABEAU_CARDS_DIR", cards_dir.to_str().unwrap());
+        let mut env_guard = TestEnvVarGuard::new();
+        env_guard.set_var("CHABEAU_CARDS_DIR", cards_dir.as_os_str());
 
         let result = app.picker.open_character_picker(&mut cache, &app.session);
-
-        std::env::remove_var("CHABEAU_CARDS_DIR");
 
         assert!(result.is_ok());
 
@@ -1121,7 +1120,7 @@ mod tests {
     #[test]
     fn test_turn_off_character_entry_not_added_when_no_character() {
         use crate::character::cache::CardCache;
-        use crate::utils::test_utils::create_test_app;
+        use crate::utils::test_utils::{create_test_app, TestEnvVarGuard};
         use std::fs;
         use tempfile::tempdir;
 
@@ -1149,11 +1148,10 @@ mod tests {
 
         assert!(app.session.active_character.is_none());
 
-        std::env::set_var("CHABEAU_CARDS_DIR", cards_dir.to_str().unwrap());
+        let mut env_guard = TestEnvVarGuard::new();
+        env_guard.set_var("CHABEAU_CARDS_DIR", cards_dir.as_os_str());
 
         let result = app.picker.open_character_picker(&mut cache, &app.session);
-
-        std::env::remove_var("CHABEAU_CARDS_DIR");
 
         assert!(result.is_ok());
 
@@ -1167,7 +1165,7 @@ mod tests {
     fn test_turn_off_character_stays_at_top_after_sort() {
         use crate::character::cache::CardCache;
         use crate::character::card::{CharacterCard, CharacterData};
-        use crate::utils::test_utils::create_test_app;
+        use crate::utils::test_utils::{create_test_app, TestEnvVarGuard};
         use std::fs;
         use tempfile::tempdir;
 
@@ -1218,11 +1216,10 @@ mod tests {
             },
         });
 
-        std::env::set_var("CHABEAU_CARDS_DIR", cards_dir.to_str().unwrap());
+        let mut env_guard = TestEnvVarGuard::new();
+        env_guard.set_var("CHABEAU_CARDS_DIR", cards_dir.as_os_str());
 
         let result = app.picker.open_character_picker(&mut cache, &app.session);
-
-        std::env::remove_var("CHABEAU_CARDS_DIR");
 
         assert!(result.is_ok());
 


### PR DESCRIPTION
## Summary
- collapse `import_card` to use the configured cards directory and share the filesystem logic via `import_card_into`
- update unit tests to use a guarded `CHABEAU_CARDS_DIR` override helper instead of direct path wiring
- adjust the integration overwrite test to exercise the new import workflow with a conflicting filename

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68e4b9676ed8832b971d72d84464cd16