### PR TITLE
Fix character import CLI flag conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ Chabeau supports character cards in the v2 format, allowing you to chat with AI 
 
 **Import a character card:**
 ```bash
-chabeau import -c path/to/character.json    # Import JSON card
-chabeau import -c path/to/character.png     # Import PNG with embedded metadata
-chabeau import -c character.json --force    # Overwrite existing card
+chabeau import path/to/character.json       # Import JSON card
+chabeau import path/to/character.png        # Import PNG with embedded metadata
+chabeau import character.json --force       # Overwrite existing card
 ```
 
 Cards are stored in the Chabeau configuration directory; you can also just copy them there yourself. Use `chabeau -c` to print the directory name and any cards Chabeau discovers. To point Chabeau at a different cards directory (for example, when testing or keeping cards in a synced folder), set the `CHABEAU_CARDS_DIR` environment variable before launching the app.

--- a/src/cli/character_list.rs
+++ b/src/cli/character_list.rs
@@ -13,7 +13,7 @@ pub async fn list_characters() -> Result<(), Box<dyn Error>> {
             if cards.is_empty() {
                 println!("  No character cards found.");
                 println!("\n💡 Import character cards with:");
-                println!("   chabeau import -c <file.json|file.png>");
+                println!("   chabeau import <file.json|file.png>");
             } else {
                 for (name, path) in cards {
                     let filename = path

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -94,7 +94,7 @@ To select providers (e.g., Anthropic, OpenAI) and their models:\n\
   • Otherwise, it will ask you to select the provider.\n\
   • It will then give you a choice of models.\n\n\
 Character cards:\n\
-  • Import character cards with 'chabeau import -c <file.json|file.png>'.\n\
+  • Import character cards with 'chabeau import <file.json|file.png>'.\n\
   • Use '-c [CHARACTER]' to start a chat with a specific character:\n\
     - By name: '-c alice' (looks in {cards_dir})\n\
     - By path: '-c ./alice.json' or '-c /path/to/alice.json'\n\
@@ -171,7 +171,7 @@ pub enum Commands {
     /// Import and validate a character card
     Import {
         /// Path to character card file (JSON or PNG)
-        #[arg(short = 'c', long)]
+        #[arg(value_name = "CARD")]
         card: String,
         /// Force overwrite if card already exists
         #[arg(short = 'f', long)]
@@ -283,7 +283,7 @@ async fn async_main() -> Result<(), Box<dyn Error>> {
                                         character
                                     );
                                     eprintln!(
-                                        "   Run 'chabeau import -c <file>' to import a character card first"
+                                        "   Run 'chabeau import <file>' to import a character card first"
                                     );
                                     std::process::exit(1);
                                 }

--- a/src/core/app/picker/mod.rs
+++ b/src/core/app/picker/mod.rs
@@ -923,7 +923,7 @@ impl PickerController {
 
         if cards.is_empty() {
             return Err(
-                "No character cards found. Use 'chabeau import -c <file>' to import cards."
+                "No character cards found. Use 'chabeau import <file>' to import cards."
                     .to_string(),
             );
         }


### PR DESCRIPTION
## Summary
- make the character import card argument positional to avoid the -c short flag collision
- refresh CLI help text, picker messaging, and README instructions to use the new syntax

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e6d8ee6280832bbcb6d615187985f1