### PR TITLE
Refactor bench helper into shared test helper

### DIFF
--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -195,9 +195,8 @@ impl App {
         self.ui.invalidate_prewrap_cache();
     }
 
-    // Used by Criterion benches in `benches/`.
     #[cfg(any(test, feature = "bench"))]
-    pub fn new_bench(theme: Theme, markdown_enabled: bool, syntax_enabled: bool) -> Self {
+    pub fn new_test_app(theme: Theme, markdown_enabled: bool, syntax_enabled: bool) -> Self {
         let session = SessionContext {
             client: reqwest::Client::new(),
             model: "bench".into(),
@@ -223,6 +222,12 @@ impl App {
             picker: PickerController::new(),
             character_cache: crate::character::cache::CardCache::new(),
         }
+    }
+
+    // Used by Criterion benches in `benches/`.
+    #[cfg(feature = "bench")]
+    pub fn new_bench(theme: Theme, markdown_enabled: bool, syntax_enabled: bool) -> Self {
+        Self::new_test_app(theme, markdown_enabled, syntax_enabled)
     }
 
     pub fn get_logging_status(&self) -> String {

--- a/src/ui/chat_loop/mod.rs
+++ b/src/ui/chat_loop/mod.rs
@@ -1117,7 +1117,7 @@ mod tests {
     }
 
     fn setup_app() -> App {
-        App::new_bench(Theme::dark_default(), true, true)
+        App::new_test_app(Theme::dark_default(), true, true)
     }
 
     fn default_context() -> AppActionContext {

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -514,7 +514,7 @@ mod tests {
     use crate::ui::theme::Theme;
 
     fn create_test_app() -> App {
-        App::new_bench(Theme::dark_default(), true, false)
+        App::new_test_app(Theme::dark_default(), true, false)
     }
 
     fn set_model_picker(

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -1,13 +1,9 @@
 #[cfg(test)]
-use crate::core::app::ui_state::UiState;
-#[cfg(test)]
-use crate::core::app::{App, PickerController, SessionContext};
+use crate::core::app::App;
 #[cfg(test)]
 use crate::core::message::Message;
 #[cfg(test)]
 use crate::ui::theme::Theme;
-#[cfg(test)]
-use crate::utils::logging::LoggingState;
 #[cfg(test)]
 use once_cell::sync::Lazy;
 #[cfg(test)]
@@ -176,31 +172,13 @@ impl Default for TestEnvVarGuard {
 
 #[cfg(test)]
 pub fn create_test_app() -> App {
-    let session = SessionContext {
-        client: reqwest::Client::new(),
-        model: "test-model".to_string(),
-        api_key: "test-key".to_string(),
-        base_url: "https://api.test.com".to_string(),
-        provider_name: "test".to_string(),
-        provider_display_name: "Test".to_string(),
-        logging: LoggingState::new(None).unwrap(),
-        stream_cancel_token: None,
-        current_stream_id: 0,
-        last_retry_time: std::time::Instant::now(),
-        retrying_message_index: None,
-        startup_env_only: false,
-        active_character: None,
-        character_greeting_shown: false,
-    };
-
-    let ui = UiState::new_basic(Theme::dark_default(), true, true, None);
-
-    App {
-        session,
-        ui,
-        picker: PickerController::new(),
-        character_cache: crate::character::cache::CardCache::new(),
-    }
+    let mut app = App::new_test_app(Theme::dark_default(), true, true);
+    app.session.model = "test-model".to_string();
+    app.session.api_key = "test-key".to_string();
+    app.session.base_url = "https://api.test.com".to_string();
+    app.session.provider_name = "test".to_string();
+    app.session.provider_display_name = "Test".to_string();
+    app
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add `App::new_test_app` so benches and tests share the same lightweight app constructor while keeping `new_bench` feature-gated
- update unit tests and `create_test_app` to use the shared helper

## Testing
- `cargo fmt`
- `cargo check`
- `cargo clippy`
- `cargo test`
- `cargo bench --bench render_cache --features bench -- --warm-up-time 0.1 --measurement-time 0.2`


------
https://chatgpt.com/codex/tasks/task_e_68e6e9307b58832b84f5a85c23ed0a16