### PR TITLE
Refactor persona defaults to use structured keys

### DIFF
--- a/src/core/app/actions.rs
+++ b/src/core/app/actions.rs
@@ -870,10 +870,9 @@ fn load_default_persona_if_configured(app: &mut App) {
         return;
     }
 
-    let provider_model_key = format!("{}_{}", app.session.provider_name, app.session.model);
     if let Some(persona_id) = app
         .persona_manager
-        .get_default_for_provider_model(&provider_model_key)
+        .get_default_for_provider_model(&app.session.provider_name, &app.session.model)
     {
         let persona_id = persona_id.to_string(); // Clone to avoid borrow issues
         match app.persona_manager.set_active_persona(&persona_id) {

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -68,9 +68,8 @@ pub async fn new_with_auth(
         persona_manager.set_active_persona(&persona_id)?;
     } else {
         // Load default persona for current provider/model if no CLI persona specified
-        let provider_model_key = format!("{}_{}", session.provider_name, session.model);
         if let Some(default_persona_id) =
-            persona_manager.get_default_for_provider_model(&provider_model_key)
+            persona_manager.get_default_for_provider_model(&session.provider_name, &session.model)
         {
             let default_persona_id = default_persona_id.to_string(); // Clone to avoid borrow issues
             if let Err(e) = persona_manager.set_active_persona(&default_persona_id) {

--- a/src/core/app/picker/mod.rs
+++ b/src/core/app/picker/mod.rs
@@ -1074,11 +1074,8 @@ impl PickerController {
         }
 
         // Get the default persona for the current provider/model
-        let provider_model_key = format!(
-            "{}_{}",
-            session_context.provider_name, session_context.model
-        );
-        let default_persona = persona_manager.get_default_for_provider_model(&provider_model_key);
+        let default_persona = persona_manager
+            .get_default_for_provider_model(&session_context.provider_name, &session_context.model);
 
         let active_character_name = session_context
             .get_character()

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1072,7 +1072,7 @@ mod tests {
         // Initially no default persona - test through PersonaManager (production path)
         let manager = PersonaManager::load_personas(&config).expect("Failed to load personas");
         assert!(manager
-            .get_default_for_provider_model("openai_gpt-4")
+            .get_default_for_provider_model("openai", "gpt-4")
             .is_none());
 
         // Set a default persona
@@ -1085,20 +1085,20 @@ mod tests {
         // Verify it's set through PersonaManager (production path)
         let manager = PersonaManager::load_personas(&config).expect("Failed to load personas");
         assert_eq!(
-            manager.get_default_for_provider_model("openai_gpt-4"),
+            manager.get_default_for_provider_model("openai", "gpt-4"),
             Some("alice-dev")
         );
 
         // Case insensitive provider lookup - test through PersonaManager
         let manager = PersonaManager::load_personas(&config).expect("Failed to load personas");
         assert_eq!(
-            manager.get_default_for_provider_model("openai_gpt-4"),
+            manager.get_default_for_provider_model("OPENAI", "gpt-4"),
             Some("alice-dev")
         );
 
         // Different model should return None
         assert!(manager
-            .get_default_for_provider_model("openai_gpt-3.5-turbo")
+            .get_default_for_provider_model("openai", "gpt-3.5-turbo")
             .is_none());
     }
 
@@ -1123,11 +1123,11 @@ mod tests {
         // Verify they're set through PersonaManager (production path)
         let manager = PersonaManager::load_personas(&config).expect("Failed to load personas");
         assert_eq!(
-            manager.get_default_for_provider_model("openai_gpt-4"),
+            manager.get_default_for_provider_model("openai", "gpt-4"),
             Some("alice-dev")
         );
         assert_eq!(
-            manager.get_default_for_provider_model("openai_gpt-4o"),
+            manager.get_default_for_provider_model("openai", "gpt-4o"),
             Some("bob-student")
         );
 
@@ -1137,10 +1137,10 @@ mod tests {
         // Verify it's gone but the other remains through PersonaManager (production path)
         let manager = PersonaManager::load_personas(&config).expect("Failed to load personas");
         assert!(manager
-            .get_default_for_provider_model("openai_gpt-4")
+            .get_default_for_provider_model("openai", "gpt-4")
             .is_none());
         assert_eq!(
-            manager.get_default_for_provider_model("openai_gpt-4o"),
+            manager.get_default_for_provider_model("openai", "gpt-4o"),
             Some("bob-student")
         );
     }
@@ -1161,7 +1161,7 @@ mod tests {
         // Verify it's set through PersonaManager (production path)
         let manager = PersonaManager::load_personas(&config).expect("Failed to load personas");
         assert_eq!(
-            manager.get_default_for_provider_model("openai_gpt-4"),
+            manager.get_default_for_provider_model("openai", "gpt-4"),
             Some("alice-dev")
         );
 
@@ -1174,7 +1174,7 @@ mod tests {
         // Also verify through PersonaManager that no defaults exist
         let manager = PersonaManager::load_personas(&config).expect("Failed to load personas");
         assert!(manager
-            .get_default_for_provider_model("openai_gpt-4")
+            .get_default_for_provider_model("openai", "gpt-4")
             .is_none());
     }
 
@@ -1194,7 +1194,7 @@ mod tests {
         // Verify it's set through PersonaManager (production path)
         let manager = PersonaManager::load_personas(&config).expect("Failed to load personas");
         assert_eq!(
-            manager.get_default_for_provider_model("openai_gpt-4"),
+            manager.get_default_for_provider_model("openai", "gpt-4"),
             Some("alice-dev")
         );
 
@@ -1208,7 +1208,7 @@ mod tests {
         // Verify it's updated through PersonaManager (production path)
         let manager = PersonaManager::load_personas(&config).expect("Failed to load personas");
         assert_eq!(
-            manager.get_default_for_provider_model("openai_gpt-4"),
+            manager.get_default_for_provider_model("openai", "gpt-4"),
             Some("bob-student")
         );
     }

--- a/src/core/persona_integration_tests.rs
+++ b/src/core/persona_integration_tests.rs
@@ -309,7 +309,7 @@ mod integration_tests {
             PersonaManager::load_personas(&config).expect("Failed to load personas");
 
         // Verify default is loaded
-        let default = persona_manager.get_default_for_provider_model("openai_gpt-4");
+        let default = persona_manager.get_default_for_provider_model("openai", "gpt-4");
         assert!(default.is_some());
         assert_eq!(default.unwrap(), "alice-dev");
     }
@@ -331,7 +331,7 @@ mod integration_tests {
         // Verify default is set
         assert_eq!(
             persona_manager
-                .get_default_for_provider_model("openai_gpt-4")
+                .get_default_for_provider_model("openai", "gpt-4")
                 .unwrap(),
             "bob-student"
         );
@@ -422,13 +422,13 @@ mod integration_tests {
             PersonaManager::load_personas(&loaded_config).expect("Failed to load personas");
         assert_eq!(
             persona_manager
-                .get_default_for_provider_model("openai_gpt-4")
+                .get_default_for_provider_model("openai", "gpt-4")
                 .unwrap(),
             "alice-dev"
         );
         assert_eq!(
             persona_manager
-                .get_default_for_provider_model("anthropic_claude-3-opus")
+                .get_default_for_provider_model("anthropic", "claude-3-opus")
                 .unwrap(),
             "bob-student"
         );


### PR DESCRIPTION
## Summary
- store persona defaults in a structured provider/model key and normalize providers
- update persona lookup call sites to supply provider and model separately
- expand persona tests to cover mixed-case providers and underscore identifiers

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e891314654832bbc32174e9595d7a4