### PR TITLE
feat: add presets system for reusable instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,49 @@ Personas and character cards work together seamlessly:
 - Both support `{{user}}` and `{{char}}` variable substitutions
 - The persona's bio is added to the system prompt before the character's instructions
 
+## Presets
+
+Presets let you inject reusable system instructions into the first and last system messages that Chabeau sends to the model. They are ideal for lightweight tone or formatting tweaks that you want to toggle quickly.
+
+### Configure Presets
+
+Add presets to your `config.toml`:
+
+```toml
+[[presets]]
+id = "focus"
+pre = """
+You are collaborating with {{user}}. Keep responses focused and direct.
+"""
+post = """
+Before finishing, list any follow-up actions for {{char}}.
+"""
+
+[[presets]]
+id = "explain"
+pre = """
+Explain concepts for a curious student.
+"""
+post = """
+End with a reflective question for {{user}}.
+"""
+```
+
+- `pre` text is wrapped in blank lines and prepended to the very first system message.
+- `post` text is wrapped in blank lines and appended to the final system message. If no system message exists at either position, Chabeau creates one automatically.
+- Presets support the same `{{user}}` and `{{char}}` substitutions as personas and character cards.
+
+Assign defaults per provider/model with `default-presets`:
+
+```toml
+[default-presets.openai]
+"gpt-4o" = "focus"
+```
+
+### Use Presets in Chat
+
+Launch with `--preset focus`, or pick interactively with `/preset`. The picker includes a sticky "Turn off preset" option to clear the active preset.
+
 ## Appearance and Rendering
 
 ### Themes

--- a/src/character/tests_integration.rs
+++ b/src/character/tests_integration.rs
@@ -172,8 +172,12 @@ mod integration_tests {
 
         // Show greeting for character A
         {
-            let mut conversation =
-                ConversationController::new(&mut app.session, &mut app.ui, &app.persona_manager);
+            let mut conversation = ConversationController::new(
+                &mut app.session,
+                &mut app.ui,
+                &app.persona_manager,
+                &app.preset_manager,
+            );
             conversation.show_character_greeting_if_needed();
         }
 
@@ -191,8 +195,12 @@ mod integration_tests {
 
         // Show greeting for character B
         {
-            let mut conversation =
-                ConversationController::new(&mut app.session, &mut app.ui, &app.persona_manager);
+            let mut conversation = ConversationController::new(
+                &mut app.session,
+                &mut app.ui,
+                &app.persona_manager,
+                &app.preset_manager,
+            );
             conversation.show_character_greeting_if_needed();
         }
 
@@ -333,8 +341,12 @@ mod integration_tests {
 
         // Show greeting
         {
-            let mut conversation =
-                ConversationController::new(&mut app.session, &mut app.ui, &app.persona_manager);
+            let mut conversation = ConversationController::new(
+                &mut app.session,
+                &mut app.ui,
+                &app.persona_manager,
+                &app.preset_manager,
+            );
             conversation.show_character_greeting_if_needed();
         }
 
@@ -346,8 +358,12 @@ mod integration_tests {
 
         // User sends first message
         let api_messages = {
-            let mut conversation =
-                ConversationController::new(&mut app.session, &mut app.ui, &app.persona_manager);
+            let mut conversation = ConversationController::new(
+                &mut app.session,
+                &mut app.ui,
+                &app.persona_manager,
+                &app.preset_manager,
+            );
             conversation.add_user_message("What's the weather?".to_string())
         };
 
@@ -488,8 +504,12 @@ mod integration_tests {
 
         // Should work without errors
         let api_messages = {
-            let mut conversation =
-                ConversationController::new(&mut app.session, &mut app.ui, &app.persona_manager);
+            let mut conversation = ConversationController::new(
+                &mut app.session,
+                &mut app.ui,
+                &app.persona_manager,
+                &app.preset_manager,
+            );
             conversation.add_user_message("Test".to_string())
         };
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub enum CommandResult {
     OpenThemePicker,
     OpenCharacterPicker,
     OpenPersonaPicker,
+    OpenPresetPicker,
 }
 
 pub fn process_input(app: &mut App, input: &str) -> CommandResult {
@@ -335,6 +336,35 @@ pub(super) fn handle_persona(app: &mut App, invocation: CommandInvocation<'_>) -
                     app.conversation()
                         .set_status(format!("Persona error: {}", e));
                     CommandResult::Continue
+                }
+            }
+        }
+    }
+}
+
+pub(super) fn handle_preset(app: &mut App, invocation: CommandInvocation<'_>) -> CommandResult {
+    let parts: Vec<&str> = invocation.input.split_whitespace().collect();
+    match parts.len() {
+        1 => CommandResult::OpenPresetPicker,
+        _ => {
+            let preset_id = parts[1];
+            if preset_id.eq_ignore_ascii_case("off") || preset_id == "[turn_off_preset]" {
+                app.preset_manager.clear_active_preset();
+                app.conversation()
+                    .set_status("Preset deactivated".to_string());
+                CommandResult::Continue
+            } else {
+                match app.preset_manager.set_active_preset(preset_id) {
+                    Ok(()) => {
+                        app.conversation()
+                            .set_status(format!("Preset activated: {}", preset_id));
+                        CommandResult::Continue
+                    }
+                    Err(e) => {
+                        app.conversation()
+                            .set_status(format!("Preset error: {}", e));
+                        CommandResult::Continue
+                    }
                 }
             }
         }

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -171,4 +171,19 @@ const COMMANDS: &[Command] = &[
         extra_help: &[],
         handler: super::handle_persona,
     },
+    Command {
+        name: "preset",
+        usages: &[
+            CommandUsage {
+                syntax: "/preset",
+                description: "Pick a preset from available presets with filtering and sorting.",
+            },
+            CommandUsage {
+                syntax: "/preset <id>",
+                description: "Activate the specified preset for this session.",
+            },
+        ],
+        extra_help: &[],
+        handler: super::handle_preset,
+    },
 ];

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,5 +6,6 @@ pub mod message;
 pub mod persona;
 #[cfg(test)]
 pub mod persona_integration_tests;
+pub mod preset;
 pub mod providers;
 pub mod text_wrapping;

--- a/src/core/persona_integration_tests.rs
+++ b/src/core/persona_integration_tests.rs
@@ -371,8 +371,12 @@ mod integration_tests {
 
         // Add a user message and verify display name is used
         {
-            let mut conversation =
-                ConversationController::new(&mut app.session, &mut app.ui, &app.persona_manager);
+            let mut conversation = ConversationController::new(
+                &mut app.session,
+                &mut app.ui,
+                &app.persona_manager,
+                &app.preset_manager,
+            );
             conversation.add_user_message("Hello!".to_string());
         }
 
@@ -460,8 +464,12 @@ mod integration_tests {
 
         // Step 3: Add user message with persona active
         {
-            let mut conversation =
-                ConversationController::new(&mut app.session, &mut app.ui, &app.persona_manager);
+            let mut conversation = ConversationController::new(
+                &mut app.session,
+                &mut app.ui,
+                &app.persona_manager,
+                &app.preset_manager,
+            );
             conversation.add_user_message("What's your experience?".to_string());
         }
 
@@ -480,8 +488,12 @@ mod integration_tests {
 
         // Step 5: Add another message with new persona
         {
-            let mut conversation =
-                ConversationController::new(&mut app.session, &mut app.ui, &app.persona_manager);
+            let mut conversation = ConversationController::new(
+                &mut app.session,
+                &mut app.ui,
+                &app.persona_manager,
+                &app.preset_manager,
+            );
             conversation.add_user_message("I'm learning AI.".to_string());
         }
 

--- a/src/core/preset.rs
+++ b/src/core/preset.rs
@@ -1,0 +1,315 @@
+use crate::api::ChatMessage;
+use crate::core::config::{Config, Preset};
+use crate::core::persona::PersonaManager;
+use std::collections::HashMap;
+
+/// Manages preset state and operations
+pub struct PresetManager {
+    presets: Vec<Preset>,
+    active_preset: Option<Preset>,
+    defaults: HashMap<(String, String), String>,
+}
+
+impl PresetManager {
+    /// Create a new PresetManager and load presets from configuration
+    pub fn load_presets(config: &Config) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut defaults = HashMap::new();
+        for (provider, models) in &config.default_presets {
+            for (model, preset_id) in models {
+                defaults.insert((provider.to_lowercase(), model.clone()), preset_id.clone());
+            }
+        }
+
+        Ok(Self {
+            presets: config.presets.clone(),
+            active_preset: None,
+            defaults,
+        })
+    }
+
+    /// Get the list of available presets
+    pub fn list_presets(&self) -> &Vec<Preset> {
+        &self.presets
+    }
+
+    /// Find a preset by its ID
+    pub fn find_preset_by_id(&self, id: &str) -> Option<&Preset> {
+        self.presets.iter().find(|preset| preset.id == id)
+    }
+
+    /// Set the active preset by ID
+    pub fn set_active_preset(&mut self, preset_id: &str) -> Result<(), String> {
+        match self.find_preset_by_id(preset_id) {
+            Some(preset) => {
+                self.active_preset = Some(preset.clone());
+                Ok(())
+            }
+            None => {
+                let available_ids: Vec<&str> = self
+                    .presets
+                    .iter()
+                    .map(|preset| preset.id.as_str())
+                    .collect();
+                Err(format!(
+                    "Preset '{}' not found. Available presets: {}",
+                    preset_id,
+                    available_ids.join(", ")
+                ))
+            }
+        }
+    }
+
+    /// Clear the active preset (deactivate)
+    pub fn clear_active_preset(&mut self) {
+        self.active_preset = None;
+    }
+
+    /// Get the currently active preset
+    pub fn get_active_preset(&self) -> Option<&Preset> {
+        self.active_preset.as_ref()
+    }
+
+    /// Apply preset instructions to the provided messages
+    /// Adds or augments system messages at the beginning/end after persona substitutions
+    pub fn apply_to_messages(
+        &self,
+        messages: &mut Vec<ChatMessage>,
+        persona_manager: &PersonaManager,
+        char_name: Option<&str>,
+    ) {
+        let Some(active_preset) = &self.active_preset else {
+            return;
+        };
+
+        let pre_text = active_preset.pre.trim();
+        let post_text = active_preset.post.trim();
+
+        let substituted_pre = if pre_text.is_empty() {
+            None
+        } else {
+            let substituted = persona_manager.apply_substitutions(pre_text, char_name);
+            let trimmed = substituted.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        };
+
+        let substituted_post = if post_text.is_empty() {
+            None
+        } else {
+            let substituted = persona_manager.apply_substitutions(post_text, char_name);
+            let trimmed = substituted.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        };
+
+        if substituted_pre.is_none() && substituted_post.is_none() {
+            return;
+        }
+
+        if substituted_pre.is_some()
+            && messages
+                .first()
+                .map(|msg| msg.role != "system")
+                .unwrap_or(true)
+        {
+            messages.insert(
+                0,
+                ChatMessage {
+                    role: "system".to_string(),
+                    content: String::new(),
+                },
+            );
+        }
+
+        if substituted_post.is_some()
+            && messages
+                .last()
+                .map(|msg| msg.role != "system")
+                .unwrap_or(true)
+        {
+            messages.push(ChatMessage {
+                role: "system".to_string(),
+                content: String::new(),
+            });
+        }
+
+        if let Some(pre) = substituted_pre {
+            if let Some(first) = messages.first_mut() {
+                if first.content.trim().is_empty() {
+                    first.content = pre;
+                } else {
+                    first.content = format!("{pre}\n\n{}", first.content);
+                }
+            }
+        }
+
+        if let Some(post) = substituted_post {
+            if let Some(last) = messages.last_mut() {
+                if last.content.trim().is_empty() {
+                    last.content = post;
+                } else {
+                    last.content = format!("{}\n\n{post}", last.content);
+                }
+            }
+        }
+    }
+
+    /// Get the default preset for a provider/model combination
+    pub fn get_default_for_provider_model(&self, provider: &str, model: &str) -> Option<&str> {
+        let key = (provider.to_lowercase(), model.to_string());
+        self.defaults.get(&key).map(|s| s.as_str())
+    }
+
+    /// Set the default preset for a provider/model combination and persist to config
+    pub fn set_default_for_provider_model_persistent(
+        &mut self,
+        provider: &str,
+        model: &str,
+        preset_id: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let key = (provider.to_lowercase(), model.to_string());
+        self.defaults.insert(key, preset_id.to_string());
+
+        let provider = provider.to_string();
+        let model = model.to_string();
+        let preset_id = preset_id.to_string();
+
+        Config::mutate(move |config| {
+            config.set_default_preset(provider, model, preset_id);
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    /// Unset the default preset for a provider/model combination and persist to config
+    pub fn unset_default_for_provider_model_persistent(
+        &mut self,
+        provider: &str,
+        model: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let key = (provider.to_lowercase(), model.to_string());
+        self.defaults.remove(&key);
+
+        let provider = provider.to_string();
+        let model = model.to_string();
+
+        Config::mutate(move |config| {
+            config.unset_default_preset(&provider, &model);
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::{Persona, Preset};
+
+    fn create_test_config() -> Config {
+        Config {
+            personas: vec![Persona {
+                id: "tester".to_string(),
+                display_name: "Tester".to_string(),
+                bio: Some("You are speaking with {{user}}.".to_string()),
+            }],
+            presets: vec![Preset {
+                id: "focus".to_string(),
+                pre: "Focus on {{user}}'s requirements.".to_string(),
+                post: "Confirm actions with {{char}}.".to_string(),
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn create_messages() -> Vec<ChatMessage> {
+        vec![ChatMessage {
+            role: "user".to_string(),
+            content: "Hello".to_string(),
+        }]
+    }
+
+    #[test]
+    fn test_set_and_clear_active_preset() {
+        let config = create_test_config();
+        let mut manager = PresetManager::load_presets(&config).expect("load presets");
+
+        assert!(manager.get_active_preset().is_none());
+        manager.set_active_preset("focus").expect("set preset");
+        assert_eq!(
+            manager.get_active_preset().map(|p| p.id.as_str()),
+            Some("focus")
+        );
+
+        manager.clear_active_preset();
+        assert!(manager.get_active_preset().is_none());
+    }
+
+    #[test]
+    fn test_apply_to_messages_inserts_system_messages() {
+        let config = create_test_config();
+        let mut manager = PresetManager::load_presets(&config).expect("load presets");
+        manager.set_active_preset("focus").expect("activate preset");
+
+        let mut persona_manager = PersonaManager::load_personas(&config).expect("load personas");
+        persona_manager
+            .set_active_persona("tester")
+            .expect("set persona");
+
+        let mut messages = create_messages();
+        manager.apply_to_messages(&mut messages, &persona_manager, Some("HelperBot"));
+
+        assert!(messages.first().unwrap().role == "system");
+        assert!(messages.last().unwrap().role == "system");
+        assert!(messages[0]
+            .content
+            .contains("Focus on Tester\'s requirements."));
+        assert!(messages
+            .last()
+            .unwrap()
+            .content
+            .contains("Confirm actions with HelperBot."));
+    }
+
+    #[test]
+    fn test_apply_to_messages_skips_when_empty() {
+        let mut config = create_test_config();
+        config.presets[0].pre.clear();
+        config.presets[0].post.clear();
+
+        let mut manager = PresetManager::load_presets(&config).expect("load presets");
+        manager.set_active_preset("focus").expect("activate preset");
+
+        let persona_manager = PersonaManager::load_personas(&config).expect("load personas");
+
+        let mut messages = create_messages();
+        manager.apply_to_messages(&mut messages, &persona_manager, None);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, "user");
+    }
+
+    #[test]
+    fn test_get_default_for_provider_model() {
+        let mut config = create_test_config();
+        config
+            .default_presets
+            .entry("openai".to_string())
+            .or_default()
+            .insert("gpt-4".to_string(), "focus".to_string());
+
+        let manager = PresetManager::load_presets(&config).expect("load presets");
+        assert_eq!(
+            manager.get_default_for_provider_model("OpenAI", "gpt-4"),
+            Some("focus")
+        );
+    }
+}

--- a/src/ui/chat_loop/mod.rs
+++ b/src/ui/chat_loop/mod.rs
@@ -237,7 +237,8 @@ async fn route_keyboard_event(
                 || app.theme_picker_state().is_some()
                 || app.provider_picker_state().is_some()
                 || app.character_picker_state().is_some()
-                || app.persona_picker_state().is_some();
+                || app.persona_picker_state().is_some()
+                || app.preset_picker_state().is_some();
             KeyContext::from_ui_mode(&app.ui.mode, picker_open)
         })
         .await;
@@ -412,6 +413,7 @@ pub async fn run_chat(
     env_only: bool,
     character: Option<String>,
     persona: Option<String>,
+    preset: Option<String>,
 ) -> Result<(), Box<dyn Error>> {
     let app = bootstrap_app(
         model.clone(),
@@ -420,6 +422,7 @@ pub async fn run_chat(
         env_only,
         character,
         persona,
+        preset,
     )
     .await?;
 

--- a/src/ui/chat_loop/setup.rs
+++ b/src/ui/chat_loop/setup.rs
@@ -24,7 +24,8 @@ pub async fn bootstrap_app(
     provider: Option<String>,
     env_only: bool,
     character: Option<String>,
-    _persona: Option<String>,
+    persona: Option<String>,
+    preset: Option<String>,
 ) -> Result<AppHandle, Box<dyn std::error::Error>> {
     let config = Config::load()?;
     let auth_manager = AuthManager::new();
@@ -119,7 +120,8 @@ pub async fn bootstrap_app(
                 env_only,
                 pre_resolved_session,
                 character: character.clone(),
-                persona: _persona,
+                persona,
+                preset,
             },
             &config,
         )

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -154,6 +154,9 @@ pub fn ui(f: &mut Frame, app: &mut App) {
             Some(crate::core::app::PickerMode::Persona) => {
                 "Select a persona (Esc=cancel • Ctrl+C=quit)"
             }
+            Some(crate::core::app::PickerMode::Preset) => {
+                "Select a preset (Esc=cancel • Ctrl+C=quit)"
+            }
             _ => "Make a selection (Esc=cancel • Ctrl+C=quit)",
         }
     } else if app.ui.file_prompt().is_some() {
@@ -444,6 +447,10 @@ fn generate_picker_help_text(app: &App) -> String {
             .unwrap_or(""),
         Some(crate::core::app::PickerMode::Persona) => app
             .persona_picker_state()
+            .map(|state| state.search_filter.as_str())
+            .unwrap_or(""),
+        Some(crate::core::app::PickerMode::Preset) => app
+            .preset_picker_state()
             .map(|state| state.search_filter.as_str())
             .unwrap_or(""),
         _ => "",


### PR DESCRIPTION
- Add PresetManager for loading and applying preset configurations
- Implement preset picker UI with search, filtering, and defaults
- Support {{user}} and {{char}} variable substitutions in presets
- Add CLI --preset flag and /preset command for activation
- Integrate presets into conversation flow after persona processing