### PR TITLE
Fix case-insensitive custom provider management

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -895,12 +895,18 @@ mod tests {
             })
             .expect("custom provider persisted");
 
-            let manager = AuthManager::new_with_keyring(false);
+            let mut manager = AuthManager::new_with_keyring(false);
             let (resolved, is_custom) = manager
-                .resolve_deauth_target("MyCustom")
+                .resolve_deauth_target("MYCUSTOM")
                 .expect("provider should resolve");
             assert_eq!(resolved, "mycustom");
             assert!(is_custom);
+
+            manager
+                .remove_custom_provider("MYCUSTOM")
+                .expect("custom provider removed");
+            assert!(manager.get_custom_provider("mycustom").is_none());
+            assert!(manager.get_custom_provider("MYCUSTOM").is_none());
         });
     }
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -477,11 +477,14 @@ impl Config {
     }
 
     pub fn remove_custom_provider(&mut self, id: &str) {
-        self.custom_providers.retain(|p| p.id != id);
+        self.custom_providers
+            .retain(|p| !p.id.eq_ignore_ascii_case(id));
     }
 
     pub fn get_custom_provider(&self, id: &str) -> Option<&CustomProvider> {
-        self.custom_providers.iter().find(|p| p.id == id)
+        self.custom_providers
+            .iter()
+            .find(|p| p.id.eq_ignore_ascii_case(id))
     }
 
     pub fn list_custom_providers(&self) -> Vec<&CustomProvider> {
@@ -844,6 +847,11 @@ mod tests {
         assert_eq!(provider.base_url, "https://api.example.com/v1");
         assert_eq!(provider.mode, Some("anthropic".to_string()));
 
+        // Case-insensitive lookup works
+        let uppercase_lookup = loaded_config.get_custom_provider("MYAPI");
+        assert!(uppercase_lookup.is_some());
+        assert_eq!(uppercase_lookup.unwrap().id, "myapi");
+
         // Test listing custom providers
         let providers = loaded_config.list_custom_providers();
         assert_eq!(providers.len(), 1);
@@ -851,8 +859,9 @@ mod tests {
 
         // Test removing custom provider
         let mut config = loaded_config;
-        config.remove_custom_provider("myapi");
+        config.remove_custom_provider("MYAPI");
         assert!(config.get_custom_provider("myapi").is_none());
+        assert!(config.get_custom_provider("MYAPI").is_none());
         assert_eq!(config.list_custom_providers().len(), 0);
     }
 


### PR DESCRIPTION
## Summary
- normalize custom provider lookups and removals in the config to be case-insensitive
- ensure the auth manager deauth flow handles mixed-case custom IDs and cleans them up
- extend unit tests to cover case-insensitive custom provider resolution and removal

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e9d90c0310832bab7d59eb0b6024d6