### PR TITLE
Add character service for shared character caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Chabeau uses a modular design with focused components:
   - `card.rs` – Character card data structures and v2 spec parsing
   - `loader.rs` – Card file loading (JSON and PNG with metadata extraction)
   - `cache.rs` – In-memory caching with invalidation
+  - `service.rs` – Shared character cache and resolution helpers for the TUI and CLI
   - `import.rs` – Import command and validation logic
 - `api/` – API types and models
   - `mod.rs` – API data structures

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -2,6 +2,7 @@ pub mod cache;
 pub mod card;
 pub mod import;
 pub mod loader;
+pub mod service;
 
 #[cfg(test)]
 mod test_helpers;
@@ -12,3 +13,4 @@ mod tests_integration;
 pub use card::CharacterCard;
 #[cfg(test)]
 pub use card::CharacterData;
+pub use service::CharacterService;

--- a/src/character/service.rs
+++ b/src/character/service.rs
@@ -1,0 +1,239 @@
+use std::collections::HashMap;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::character::cache::{CachedCardMetadata, CardCache};
+use crate::character::loader::{self, CardLoadError};
+use crate::character::CharacterCard;
+use crate::core::config::Config;
+
+#[derive(Debug)]
+pub enum CharacterServiceError {
+    Cache(String),
+    Load(CardLoadError),
+    Io(std::io::Error),
+    NotFound(String),
+}
+
+impl std::fmt::Display for CharacterServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CharacterServiceError::Cache(msg) => write!(f, "Character cache error: {msg}"),
+            CharacterServiceError::Load(err) => write!(f, "{err}"),
+            CharacterServiceError::Io(err) => write!(f, "I/O error: {err}"),
+            CharacterServiceError::NotFound(name) => {
+                write!(f, "Character '{}' not found in cards directory", name)
+            }
+        }
+    }
+}
+
+impl std::error::Error for CharacterServiceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CharacterServiceError::Cache(_) => None,
+            CharacterServiceError::Load(err) => Some(err),
+            CharacterServiceError::Io(err) => Some(err),
+            CharacterServiceError::NotFound(_) => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CachedCardEntry {
+    card: CharacterCard,
+    modified: Option<SystemTime>,
+}
+
+pub struct CharacterService {
+    cache: CardCache,
+    cards: HashMap<PathBuf, CachedCardEntry>,
+    last_cache_key: Option<String>,
+}
+
+impl CharacterService {
+    pub fn new() -> Self {
+        Self {
+            cache: CardCache::new(),
+            cards: HashMap::new(),
+            last_cache_key: None,
+        }
+    }
+
+    pub fn list_metadata(&mut self) -> Result<Vec<CachedCardMetadata>, CharacterServiceError> {
+        let metadata = self
+            .cache
+            .get_all_metadata()
+            .map_err(|err| CharacterServiceError::Cache(err.to_string()))?;
+
+        let cache_key = self.cache.cache_key().map(|k| k.to_string());
+        if cache_key != self.last_cache_key {
+            self.cards.clear();
+            self.last_cache_key = cache_key;
+        }
+
+        Ok(metadata)
+    }
+
+    pub fn list_metadata_with_paths(
+        &mut self,
+    ) -> Result<Vec<(CachedCardMetadata, PathBuf)>, CharacterServiceError> {
+        let metadata = self.list_metadata()?;
+        let mut result = Vec::with_capacity(metadata.len());
+        for entry in metadata {
+            if let Some(path) = self.cache.path_for(&entry.name) {
+                result.push((entry, path.clone()));
+            }
+        }
+        Ok(result)
+    }
+
+    pub fn resolve(&mut self, input: &str) -> Result<CharacterCard, CharacterServiceError> {
+        let path = Path::new(input);
+        if path.is_file() {
+            return self.load_from_path(path.to_path_buf());
+        }
+
+        self.resolve_by_name(input)
+    }
+
+    pub fn resolve_by_name(&mut self, name: &str) -> Result<CharacterCard, CharacterServiceError> {
+        if let Some(path) = self.try_find_card_path(name)? {
+            return self.load_from_path(path);
+        }
+
+        Err(CharacterServiceError::NotFound(name.to_string()))
+    }
+
+    pub fn load_default_for_session(
+        &mut self,
+        provider: &str,
+        model: &str,
+        config: &Config,
+    ) -> Result<Option<(String, CharacterCard)>, CharacterServiceError> {
+        if let Some(default_character) = config.get_default_character(provider, model) {
+            let name = default_character.to_string();
+            self.resolve_by_name(default_character)
+                .map(|card| Some((name, card)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn load_from_path(&mut self, path: PathBuf) -> Result<CharacterCard, CharacterServiceError> {
+        let modified = match std::fs::metadata(&path) {
+            Ok(metadata) => metadata.modified().ok(),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                return Err(CharacterServiceError::NotFound(path.display().to_string()))
+            }
+            Err(err) => return Err(CharacterServiceError::Io(err)),
+        };
+
+        if let Some(entry) = self.cards.get(path.as_path()) {
+            if entry.modified == modified {
+                return Ok(entry.card.clone());
+            }
+        }
+
+        let card = loader::load_card(&path).map_err(CharacterServiceError::Load)?;
+        let card_clone = card.clone();
+        self.cards.insert(path, CachedCardEntry { card, modified });
+        Ok(card_clone)
+    }
+
+    fn try_find_card_path(&mut self, name: &str) -> Result<Option<PathBuf>, CharacterServiceError> {
+        let cards_dir = loader::get_cards_dir();
+
+        let normalized_lookup = Self::normalize_lookup_key(name);
+
+        for ext in ["json", "png"] {
+            let candidate = cards_dir.join(format!("{name}.{ext}"));
+            if candidate.is_file() {
+                return Ok(Some(candidate));
+            }
+
+            if normalized_lookup != name {
+                let normalized_candidate = cards_dir.join(format!("{normalized_lookup}.{ext}"));
+                if normalized_candidate.is_file() {
+                    return Ok(Some(normalized_candidate));
+                }
+            }
+        }
+
+        let _ = self.list_metadata()?;
+
+        if let Some(path) = self.cache.path_for(name).cloned() {
+            return Ok(Some(path));
+        }
+
+        let lower_lookup = name.to_lowercase();
+        if let Some(path) = self
+            .cache
+            .iter_paths()
+            .find(|(cached_name, _)| {
+                let cached_lower = cached_name.to_lowercase();
+                cached_lower == lower_lookup
+                    || Self::normalize_lookup_key(cached_name) == normalized_lookup
+            })
+            .map(|(_, path)| path.clone())
+        {
+            return Ok(Some(path));
+        }
+
+        Ok(None)
+    }
+
+    fn normalize_lookup_key(name: &str) -> String {
+        name.trim().to_lowercase().replace(' ', "_")
+    }
+}
+
+impl Default for CharacterService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::character::test_helpers::helpers::create_temp_cards_dir_with_cards;
+    use crate::utils::test_utils::TestEnvVarGuard;
+    use std::fs;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn resolves_updates_after_file_change() {
+        let (_dir, cards_dir) = create_temp_cards_dir_with_cards(&[("Alice", "Hello there!")]);
+        let mut env_guard = TestEnvVarGuard::new();
+        env_guard.set_var("CHABEAU_CARDS_DIR", &cards_dir);
+
+        let mut service = CharacterService::new();
+
+        // Initial load
+        let first = service.resolve_by_name("Alice").expect("initial card load");
+        assert_eq!(first.data.first_mes, "Hello there!");
+
+        // Ensure cache hit returns same data before modification
+        let second = service.resolve_by_name("Alice").expect("second card load");
+        assert_eq!(second.data.first_mes, "Hello there!");
+
+        // Modify the card on disk and ensure cache miss reloads updated data
+        thread::sleep(Duration::from_millis(1100));
+        let mut updated = first.clone();
+        updated.data.first_mes = "Updated greeting".to_string();
+        let card_path = cards_dir.join("alice.json");
+        fs::write(&card_path, serde_json::to_string(&updated).unwrap()).unwrap();
+
+        service.list_metadata().expect("metadata reload");
+
+        let third = service
+            .resolve_by_name("Alice")
+            .expect("card after modification");
+        assert_eq!(third.data.first_mes, "Updated greeting");
+
+        drop(env_guard);
+    }
+}

--- a/src/character/tests_integration.rs
+++ b/src/character/tests_integration.rs
@@ -65,11 +65,13 @@ mod integration_tests {
 
         // Step 3: Load character by name (simulating CLI flag)
         let config = Config::default();
+        let mut service = crate::character::CharacterService::new();
         let result = load_character_for_session(
             Some(dest_path.to_str().unwrap()),
             "openai",
             "gpt-4",
             &config,
+            &mut service,
         );
 
         assert!(result.is_ok());
@@ -107,11 +109,13 @@ mod integration_tests {
 
         // Step 3: Load a specific card by name (simulating picker selection)
         let config = Config::default();
+        let mut service = crate::character::CharacterService::new();
         let result = load_character_for_session(
             Some(cards_dir.join("picker1.json").to_str().unwrap()),
             "openai",
             "gpt-4",
             &config,
+            &mut service,
         );
 
         assert!(result.is_ok());
@@ -149,12 +153,14 @@ mod integration_tests {
         );
 
         // Step 3: Start session without CLI flag (should load default)
-        let result = load_character_for_session(None, "openai", "gpt-4", &config);
+        let mut env_guard = TestEnvVarGuard::new();
+        env_guard.set_var("CHABEAU_CARDS_DIR", &cards_dir);
+        let mut service = crate::character::CharacterService::new();
+        let result = load_character_for_session(None, "openai", "gpt-4", &config, &mut service);
 
-        // This will fail because the card is not in the real cards directory
-        // In a real scenario, the card would be found via find_card_by_name
-        // For this test, we verify the config logic works
-        assert!(result.is_ok());
+        let loaded_card = result.expect("default load result");
+        assert!(loaded_card.is_some());
+        assert_eq!(loaded_card.unwrap().data.name, "DefaultChar");
     }
 
     #[test]
@@ -215,11 +221,13 @@ mod integration_tests {
         // Test loading a non-existent card file
 
         let config = Config::default();
+        let mut service = crate::character::CharacterService::new();
         let result = load_character_for_session(
             Some("/nonexistent/path/to/card.json"),
             "openai",
             "gpt-4",
             &config,
+            &mut service,
         );
 
         assert!(result.is_err());
@@ -245,11 +253,13 @@ mod integration_tests {
         temp_file.flush().unwrap();
 
         let config = Config::default();
+        let mut service = crate::character::CharacterService::new();
         let result = load_character_for_session(
             Some(temp_file.path().to_str().unwrap()),
             "openai",
             "gpt-4",
             &config,
+            &mut service,
         );
 
         assert!(result.is_err());
@@ -281,11 +291,13 @@ mod integration_tests {
         temp_file.flush().unwrap();
 
         let config = Config::default();
+        let mut service = crate::character::CharacterService::new();
         let result = load_character_for_session(
             Some(temp_file.path().to_str().unwrap()),
             "openai",
             "gpt-4",
             &config,
+            &mut service,
         );
 
         assert!(result.is_err());
@@ -317,11 +329,13 @@ mod integration_tests {
         temp_file.flush().unwrap();
 
         let config = Config::default();
+        let mut service = crate::character::CharacterService::new();
         let result = load_character_for_session(
             Some(temp_file.path().to_str().unwrap()),
             "openai",
             "gpt-4",
             &config,
+            &mut service,
         );
 
         assert!(result.is_err());
@@ -459,11 +473,13 @@ mod integration_tests {
         );
 
         // Load with CLI override
+        let mut service = crate::character::CharacterService::new();
         let result = load_character_for_session(
             Some(cli_path.to_str().unwrap()),
             "openai",
             "gpt-4",
             &config,
+            &mut service,
         );
 
         assert!(result.is_ok());

--- a/src/cli/character_list.rs
+++ b/src/cli/character_list.rs
@@ -1,26 +1,27 @@
-use crate::character::loader::{get_cards_dir, list_available_cards};
+use crate::character::loader::get_cards_dir;
+use crate::character::CharacterService;
 use crate::core::config::path_display;
 use std::error::Error;
 
-pub async fn list_characters() -> Result<(), Box<dyn Error>> {
+pub async fn list_characters(service: &mut CharacterService) -> Result<(), Box<dyn Error>> {
     let cards_dir = get_cards_dir();
     let cards_dir_display = path_display(&cards_dir);
 
     println!("Available character cards (from {}):\n", cards_dir_display);
 
-    match list_available_cards() {
+    match service.list_metadata_with_paths() {
         Ok(cards) => {
             if cards.is_empty() {
                 println!("  No character cards found.");
                 println!("\n💡 Import character cards with:");
                 println!("   chabeau import <file.json|file.png>");
             } else {
-                for (name, path) in cards {
+                for (metadata, path) in cards {
                     let filename = path
                         .file_name()
                         .and_then(|n| n.to_str())
                         .unwrap_or("unknown");
-                    println!("  • {} ({})", name, filename);
+                    println!("  • {} ({})", metadata.name, filename);
                 }
                 println!("\n💡 Use a character with:");
                 println!("   chabeau -c <character_name>");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -283,8 +283,8 @@ pub(super) fn handle_character(app: &mut App, invocation: CommandInvocation<'_>)
         _ => {
             // Character name provided - load it directly
             let character_name = parts[1..].join(" ");
-            match crate::character::loader::find_card_by_name(&character_name) {
-                Ok((card, _path)) => {
+            match app.character_service.resolve(&character_name) {
+                Ok(card) => {
                     let name = card.data.name.clone();
                     app.session.set_character(card);
                     app.conversation()

--- a/src/core/app/actions.rs
+++ b/src/core/app/actions.rs
@@ -905,19 +905,24 @@ fn selected_picker_id(app: &App) -> Option<String> {
 /// Load default character for current provider/model if one is configured
 fn load_default_character_if_configured(app: &mut App) {
     let cfg = Config::load_test_safe();
-    if let Some(character_name) =
+    if let Some(default_name) =
         cfg.get_default_character(&app.session.provider_name, &app.session.model)
     {
-        match crate::character::loader::find_card_by_name(character_name) {
-            Ok((card, _path)) => {
+        match app.character_service.load_default_for_session(
+            &app.session.provider_name,
+            &app.session.model,
+            &cfg,
+        ) {
+            Ok(Some((_name, card))) => {
                 app.session.set_character(card);
                 // Show character greeting if present
                 app.conversation().show_character_greeting_if_needed();
             }
+            Ok(None) => {}
             Err(e) => {
                 eprintln!(
                     "Warning: Could not load default character '{}': {}",
-                    character_name, e
+                    default_name, e
                 );
             }
         }

--- a/src/core/app/picker/mod.rs
+++ b/src/core/app/picker/mod.rs
@@ -1063,14 +1063,9 @@ impl PickerController {
 
     pub fn open_character_picker(
         &mut self,
-        character_cache: &mut crate::character::cache::CardCache,
+        cards: Vec<crate::character::cache::CachedCardMetadata>,
         session_context: &SessionContext,
     ) -> Result<(), String> {
-        // Load all character metadata (uses cache)
-        let cards = character_cache
-            .get_all_metadata()
-            .map_err(|e| format!("Error loading characters: {}", e))?;
-
         if cards.is_empty() {
             return Err(
                 "No character cards found. Use 'chabeau import <file>' to import cards."
@@ -1384,8 +1379,8 @@ mod tests {
 
     #[test]
     fn test_turn_off_character_entry_added_when_character_active() {
-        use crate::character::cache::CardCache;
         use crate::character::card::{CharacterCard, CharacterData};
+        use crate::character::service::CharacterService;
         use crate::utils::test_utils::{create_test_app, TestEnvVarGuard};
         use std::fs;
         use tempfile::tempdir;
@@ -1410,7 +1405,7 @@ mod tests {
         fs::write(cards_dir.join("test.json"), card_json.to_string()).unwrap();
 
         let mut app = create_test_app();
-        let mut cache = CardCache::new();
+        let mut service = CharacterService::new();
 
         app.session.set_character(CharacterCard {
             spec: "chara_card_v2".to_string(),
@@ -1435,7 +1430,8 @@ mod tests {
         let mut env_guard = TestEnvVarGuard::new();
         env_guard.set_var("CHABEAU_CARDS_DIR", cards_dir.as_os_str());
 
-        let result = app.picker.open_character_picker(&mut cache, &app.session);
+        let cards = service.list_metadata().expect("metadata");
+        let result = app.picker.open_character_picker(cards, &app.session);
 
         assert!(result.is_ok());
 
@@ -1447,7 +1443,7 @@ mod tests {
 
     #[test]
     fn test_turn_off_character_entry_not_added_when_no_character() {
-        use crate::character::cache::CardCache;
+        use crate::character::service::CharacterService;
         use crate::utils::test_utils::{create_test_app, TestEnvVarGuard};
         use std::fs;
         use tempfile::tempdir;
@@ -1472,14 +1468,15 @@ mod tests {
         fs::write(cards_dir.join("test.json"), card_json.to_string()).unwrap();
 
         let mut app = create_test_app();
-        let mut cache = CardCache::new();
+        let mut service = CharacterService::new();
 
         assert!(app.session.active_character.is_none());
 
         let mut env_guard = TestEnvVarGuard::new();
         env_guard.set_var("CHABEAU_CARDS_DIR", cards_dir.as_os_str());
 
-        let result = app.picker.open_character_picker(&mut cache, &app.session);
+        let cards = service.list_metadata().expect("metadata");
+        let result = app.picker.open_character_picker(cards, &app.session);
 
         assert!(result.is_ok());
 
@@ -1491,8 +1488,8 @@ mod tests {
 
     #[test]
     fn test_turn_off_character_stays_at_top_after_sort() {
-        use crate::character::cache::CardCache;
         use crate::character::card::{CharacterCard, CharacterData};
+        use crate::character::service::CharacterService;
         use crate::utils::test_utils::{create_test_app, TestEnvVarGuard};
         use std::fs;
         use tempfile::tempdir;
@@ -1522,7 +1519,7 @@ mod tests {
         }
 
         let mut app = create_test_app();
-        let mut cache = CardCache::new();
+        let mut service = CharacterService::new();
 
         app.session.set_character(CharacterCard {
             spec: "chara_card_v2".to_string(),
@@ -1547,7 +1544,8 @@ mod tests {
         let mut env_guard = TestEnvVarGuard::new();
         env_guard.set_var("CHABEAU_CARDS_DIR", cards_dir.as_os_str());
 
-        let result = app.picker.open_character_picker(&mut cache, &app.session);
+        let cards = service.list_metadata().expect("metadata");
+        let result = app.picker.open_character_picker(cards, &app.session);
 
         assert!(result.is_ok());
 

--- a/src/ui/chat_loop/mod.rs
+++ b/src/ui/chat_loop/mod.rs
@@ -16,6 +16,7 @@ use self::setup::bootstrap_app;
 use crate::core::chat_stream::{ChatStreamService, StreamMessage};
 
 use crate::api::models::fetch_models;
+use crate::character::CharacterService;
 use crate::core::app::ui_state::FilePromptKind;
 use crate::core::app::{
     apply_actions, App, AppAction, AppActionContext, AppActionDispatcher, AppActionEnvelope,
@@ -418,6 +419,7 @@ async fn drain_action_queue(
     true
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_chat(
     model: String,
     log: Option<String>,
@@ -426,6 +428,7 @@ pub async fn run_chat(
     character: Option<String>,
     persona: Option<String>,
     preset: Option<String>,
+    character_service: CharacterService,
 ) -> Result<(), Box<dyn Error>> {
     let app = bootstrap_app(
         model.clone(),
@@ -435,6 +438,7 @@ pub async fn run_chat(
         character,
         persona,
         preset,
+        character_service,
     )
     .await?;
 

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -116,7 +116,9 @@ pub struct TestEnvVarGuard {
 #[cfg(test)]
 impl TestEnvVarGuard {
     pub fn new() -> Self {
-        let lock = TEST_ENV_GUARD.lock().expect("environment mutex poisoned");
+        let lock = TEST_ENV_GUARD
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         Self {
             _lock: lock,
             previous_vars: Vec::new(),


### PR DESCRIPTION
## Summary
- introduce a CharacterService that wraps the card cache, reuses parsed cards, and exposes lookup helpers
- thread the service through App construction, CLI handling, and picker/session workflows so shared state is used everywhere
- update tests and documentation, including focused cache invalidation coverage and CLI validation paths

## Testing
- cargo fmt
- cargo test
- cargo check
- cargo clippy --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68ed3e45c98c832b9bb332e80cd8576b