### PR TITLE
Handle recoverable keyring outages with env fallback

### DIFF
--- a/src/core/keyring.rs
+++ b/src/core/keyring.rs
@@ -1,0 +1,51 @@
+use std::error::Error;
+use std::fmt;
+
+/// Describes failures when attempting to access the system keyring.
+///
+/// Recoverable errors indicate that the credential backend was
+/// temporarily unavailable (for example when the keychain service is
+/// locked or inaccessible). Permanent errors surface the underlying
+/// cause directly so callers can report them to the user.
+#[derive(Debug)]
+pub enum KeyringAccessError {
+    Recoverable(keyring::Error),
+    Permanent(keyring::Error),
+}
+
+impl KeyringAccessError {
+    fn inner(&self) -> &keyring::Error {
+        match self {
+            KeyringAccessError::Recoverable(err) | KeyringAccessError::Permanent(err) => err,
+        }
+    }
+
+    /// Returns true when the error represents a temporary outage of the
+    /// platform keyring backend.
+    pub fn is_recoverable(&self) -> bool {
+        matches!(self, KeyringAccessError::Recoverable(_))
+    }
+}
+
+impl From<keyring::Error> for KeyringAccessError {
+    fn from(err: keyring::Error) -> Self {
+        match err {
+            keyring::Error::PlatformFailure(_) | keyring::Error::NoStorageAccess(_) => {
+                KeyringAccessError::Recoverable(err)
+            }
+            other => KeyringAccessError::Permanent(other),
+        }
+    }
+}
+
+impl fmt::Display for KeyringAccessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inner())
+    }
+}
+
+impl Error for KeyringAccessError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.inner())
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@ pub mod builtin_presets;
 pub mod builtin_providers;
 pub mod chat_stream;
 pub mod config;
+pub mod keyring;
 pub mod message;
 pub mod persona;
 #[cfg(test)]

--- a/src/core/providers.rs
+++ b/src/core/providers.rs
@@ -1,4 +1,5 @@
 use crate::core::config::Config;
+use crate::core::keyring::KeyringAccessError;
 use std::error::Error;
 use std::fmt;
 
@@ -183,7 +184,9 @@ pub fn resolve_session<S: ProviderAuthSource>(
                     ProviderResolutionError::default_provider_missing(default_provider),
                 ));
             }
-            Err(err) => return Err(ResolveSessionError::Source(err)),
+            Err(err) => {
+                return handle_keyring_failure(err, Some(default_provider));
+            }
         }
     }
 
@@ -217,7 +220,30 @@ fn resolve_specific_provider<S: ProviderAuthSource>(
         Ok(None) => Err(ResolveSessionError::Provider(
             ProviderResolutionError::provider_not_configured(provider_name),
         )),
-        Err(err) => Err(ResolveSessionError::Source(err)),
+        Err(err) => handle_keyring_failure(err, Some(provider_name)),
+    }
+}
+
+fn handle_keyring_failure(
+    err: Box<dyn Error>,
+    provider_name: Option<&str>,
+) -> Result<ProviderSession, ResolveSessionError> {
+    match err.downcast::<KeyringAccessError>() {
+        Ok(keyring_err) => {
+            if keyring_err.is_recoverable() {
+                let context = provider_name
+                    .map(|name| format!(" for provider '{name}'"))
+                    .unwrap_or_default();
+                eprintln!(
+                    "⚠️  Unable to access stored credentials{context}: {}. Falling back to environment variables if available.",
+                    keyring_err
+                );
+                resolve_env_session().map_err(ResolveSessionError::Provider)
+            } else {
+                Err(ResolveSessionError::Source(keyring_err))
+            }
+        }
+        Err(original_err) => Err(ResolveSessionError::Source(original_err)),
     }
 }
 
@@ -237,5 +263,132 @@ fn build_session(
         base_url,
         provider_id: metadata.id.to_lowercase(),
         provider_display_name: metadata.display_name,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::{with_test_config_env, TestEnvVarGuard};
+    use std::error::Error as StdError;
+    use std::io;
+
+    struct MockSource {}
+
+    impl ProviderAuthSource for MockSource {
+        fn uses_keyring(&self) -> bool {
+            true
+        }
+
+        fn find_provider_metadata(&self, provider: &str) -> Option<ProviderMetadata> {
+            Some(ProviderMetadata {
+                id: provider.to_string(),
+                display_name: provider.to_string(),
+                base_url: "https://keyring.example".to_string(),
+            })
+        }
+
+        fn get_auth_for_provider(
+            &self,
+            _provider: &str,
+        ) -> Result<Option<(String, String)>, Box<dyn StdError>> {
+            let backend_error = io::Error::new(io::ErrorKind::Other, "mock backend unavailable");
+            let keyring_error = keyring::Error::NoStorageAccess(Box::new(backend_error));
+            Err(Box::new(KeyringAccessError::from(keyring_error)))
+        }
+
+        fn find_first_available_auth(&self) -> Option<(ProviderMetadata, String)> {
+            None
+        }
+    }
+
+    struct PermanentFailureSource;
+
+    impl ProviderAuthSource for PermanentFailureSource {
+        fn uses_keyring(&self) -> bool {
+            true
+        }
+
+        fn find_provider_metadata(&self, provider: &str) -> Option<ProviderMetadata> {
+            Some(ProviderMetadata {
+                id: provider.to_string(),
+                display_name: provider.to_string(),
+                base_url: "https://keyring.example".to_string(),
+            })
+        }
+
+        fn get_auth_for_provider(
+            &self,
+            _provider: &str,
+        ) -> Result<Option<(String, String)>, Box<dyn StdError>> {
+            let keyring_error = keyring::Error::BadEncoding(Vec::new());
+            Err(Box::new(KeyringAccessError::from(keyring_error)))
+        }
+
+        fn find_first_available_auth(&self) -> Option<(ProviderMetadata, String)> {
+            None
+        }
+    }
+
+    #[test]
+    fn recoverable_keyring_failure_uses_env_credentials() {
+        with_test_config_env(|_| {
+            let mut env_guard = TestEnvVarGuard::new();
+            env_guard.set_var("OPENAI_API_KEY", "sk-env");
+            env_guard.set_var("OPENAI_BASE_URL", "https://example.com/v1");
+
+            let mut config = Config::default();
+            config.default_provider = Some("openai".to_string());
+
+            let session = resolve_session(&MockSource {}, &config, None)
+                .expect("recoverable error should fall back to env");
+
+            assert_eq!(session.api_key, "sk-env");
+            assert_eq!(session.base_url, "https://example.com/v1");
+            assert_eq!(session.provider_id, "openai-compatible");
+            assert_eq!(session.provider_display_name, "OpenAI-compatible");
+        });
+    }
+
+    #[test]
+    fn provider_override_falls_back_to_env_on_keyring_failure() {
+        with_test_config_env(|_| {
+            let mut env_guard = TestEnvVarGuard::new();
+            env_guard.set_var("OPENAI_API_KEY", "sk-env");
+            env_guard.set_var("OPENAI_BASE_URL", DEFAULT_OPENAI_BASE_URL);
+
+            let config = Config::default();
+
+            let session = resolve_session(&MockSource {}, &config, Some("openai"))
+                .expect("provider override should use env when keyring fails");
+
+            assert_eq!(session.api_key, "sk-env");
+            assert_eq!(session.base_url, DEFAULT_OPENAI_BASE_URL);
+            assert_eq!(session.provider_id, "openai");
+            assert_eq!(session.provider_display_name, "OpenAI");
+        });
+    }
+
+    #[test]
+    fn permanent_keyring_failure_is_propagated() {
+        with_test_config_env(|_| {
+            let config = Config {
+                default_provider: Some("openai".to_string()),
+                ..Config::default()
+            };
+
+            let err = resolve_session(&PermanentFailureSource, &config, None)
+                .expect_err("permanent failures should bubble up");
+
+            match err {
+                ResolveSessionError::Source(source_err) => {
+                    let keyring_err = source_err
+                        .downcast::<KeyringAccessError>()
+                        .expect("error should be a KeyringAccessError");
+                    assert!(!keyring_err.is_recoverable());
+                }
+                _ => panic!("unexpected error variant"),
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- introduce a shared `KeyringAccessError` type to classify recoverable keyring backend failures
- wrap keyring access in the auth manager and provider resolution so recoverable errors emit warnings and fall back to environment credentials
- add unit tests exercising keyring outage handling and permanent error propagation

## Testing
- cargo fmt
- cargo test
- cargo check
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68eecadd592c832ba41aeb299ad85827