### PR TITLE
fix: respect keyring toggle in store_token

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -123,6 +123,9 @@ impl AuthManager {
         provider_name: &str,
         token: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        if !self.use_keyring {
+            return Ok(());
+        }
         let entry = Entry::new(KEYRING_SERVICE, provider_name)?;
         entry.set_password(token)?;
         Ok(())


### PR DESCRIPTION
## Summary
- short-circuit AuthManager::store_token when keyring usage is disabled

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68eec810d7c8832b96a6e9539d3cfd31