### PR TITLE
Fix config loading failures during auth flows

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -269,7 +269,13 @@ async fn handle_args(args: Args) -> Result<(), Box<dyn Error>> {
 
     match args.command {
         Some(Commands::Auth) => {
-            let mut auth_manager = AuthManager::new();
+            let mut auth_manager = match AuthManager::new() {
+                Ok(manager) => manager,
+                Err(err) => {
+                    eprintln!("❌ Failed to load configuration: {err}");
+                    std::process::exit(1);
+                }
+            };
             if let Err(e) = auth_manager.interactive_auth() {
                 eprintln!("❌ Authentication failed: {e}");
                 std::process::exit(1);
@@ -277,7 +283,13 @@ async fn handle_args(args: Args) -> Result<(), Box<dyn Error>> {
             Ok(())
         }
         Some(Commands::Deauth) => {
-            let mut auth_manager = AuthManager::new();
+            let mut auth_manager = match AuthManager::new() {
+                Ok(manager) => manager,
+                Err(err) => {
+                    eprintln!("❌ Failed to load configuration: {err}");
+                    std::process::exit(1);
+                }
+            };
             if let Err(e) = auth_manager.interactive_deauth(args.provider) {
                 eprintln!("❌ Deauthentication failed: {e}");
                 std::process::exit(1);

--- a/src/cli/model_list.rs
+++ b/src/cli/model_list.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use std::error::Error;
 
 pub async fn list_models(provider: Option<String>) -> Result<(), Box<dyn Error>> {
-    let auth_manager = AuthManager::new();
+    let auth_manager = AuthManager::new()?;
     let config = Config::load()?;
 
     // Use the shared authentication resolution function

--- a/src/cli/provider_list.rs
+++ b/src/cli/provider_list.rs
@@ -8,7 +8,7 @@ use crate::core::config::Config;
 use std::error::Error;
 
 pub async fn list_providers() -> Result<(), Box<dyn Error>> {
-    let auth_manager = AuthManager::new();
+    let auth_manager = AuthManager::new()?;
     let config = Config::load()?;
 
     println!("🔗 Available Providers");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -760,7 +760,7 @@ mod tests {
     #[test]
     fn theme_picker_supports_filtering() {
         let mut app = create_test_app();
-        app.open_theme_picker();
+        app.open_theme_picker().expect("theme picker opens");
 
         // Should store all themes for filtering
         assert!(app
@@ -795,7 +795,7 @@ mod tests {
     #[test]
     fn picker_supports_home_end_navigation_and_metadata() {
         let mut app = create_test_app();
-        app.open_theme_picker();
+        app.open_theme_picker().expect("theme picker opens");
 
         if let Some(picker) = app.picker_state_mut() {
             // Test Home key (move to start)
@@ -826,7 +826,7 @@ mod tests {
         let mut app = create_test_app();
 
         // Open theme picker - should default to A-Z (Name mode)
-        app.open_theme_picker();
+        app.open_theme_picker().expect("theme picker opens");
 
         if let Some(picker) = app.picker_state() {
             // Should default to Name mode (A-Z)

--- a/src/core/app/picker/mod.rs
+++ b/src/core/app/picker/mod.rs
@@ -342,8 +342,11 @@ impl PickerController {
         self.picker_session = None;
     }
 
-    pub fn open_theme_picker(&mut self, ui: &mut UiState) {
-        let cfg = Config::load_test_safe();
+    pub fn open_theme_picker(
+        &mut self,
+        ui: &mut UiState,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let cfg = Config::load_test_safe()?;
 
         let mut items: Vec<PickerItem> = Vec::new();
         let default_theme_id = cfg.theme.clone();
@@ -437,6 +440,7 @@ impl PickerController {
                 session.state.selected = idx;
             }
         }
+        Ok(())
     }
 
     pub fn populate_model_picker_from_response(
@@ -797,8 +801,8 @@ impl PickerController {
     }
 
     pub fn open_provider_picker(&mut self, session_context: &SessionContext) -> Result<(), String> {
-        let auth_manager = AuthManager::new();
-        let cfg = Config::load_test_safe();
+        let auth_manager = AuthManager::new().map_err(|err| err.to_string())?;
+        let cfg = Config::load_test_safe().map_err(|err| err.to_string())?;
         let default_provider = cfg.default_provider.clone();
         let mut items: Vec<PickerItem> = Vec::new();
 
@@ -937,7 +941,7 @@ impl PickerController {
         }
 
         // Get the default character for the current provider/model
-        let cfg = Config::load_test_safe();
+        let cfg = Config::load_test_safe().map_err(|err| err.to_string())?;
         let default_character =
             cfg.get_default_character(&session_context.provider_name, &session_context.model);
 

--- a/src/core/app/session.rs
+++ b/src/core/app/session.rs
@@ -209,7 +209,7 @@ pub(crate) async fn prepare_with_auth(
     } else if env_only {
         resolve_env_session().map_err(|err| Box::new(err) as Box<dyn std::error::Error>)?
     } else {
-        let auth_manager = AuthManager::new();
+        let auth_manager = AuthManager::new()?;
         match resolve_session(&auth_manager, config, provider.as_deref()) {
             Ok(session) => session,
             Err(ResolveSessionError::Provider(err)) => return Err(Box::new(err)),

--- a/src/ui/chat_loop/setup.rs
+++ b/src/ui/chat_loop/setup.rs
@@ -31,7 +31,7 @@ pub async fn bootstrap_app(
     character_service: CharacterService,
 ) -> Result<AppHandle, Box<dyn std::error::Error>> {
     let config = Config::load()?;
-    let auth_manager = AuthManager::new();
+    let auth_manager = AuthManager::new()?;
 
     // Gather providers with stored tokens (ignored in env-only mode)
     let mut token_providers: Vec<String> = Vec::new();


### PR DESCRIPTION
## Summary
- wrap config load errors in a dedicated `ConfigError` that reports the config path
- make `AuthManager::new` and other helpers return `Result` so CLI/TUI entry points surface parse failures
- harden picker and theme flows to propagate configuration errors instead of silently defaulting

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ef3b0433e0832baed87baa008725e4