### PR TITLE
fix: standardize CLI config parse errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,13 @@ mod core;
 mod ui;
 mod utils;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    cli::main()
+fn main() {
+    if let Err(err) = cli::main() {
+        if let Some(config_err) = err.downcast_ref::<crate::core::config::ConfigError>() {
+            eprintln!("❌ Failed to load configuration: {config_err}");
+        } else {
+            eprintln!("Error: {err}");
+        }
+        std::process::exit(1);
+    }
 }


### PR DESCRIPTION
## Summary
- handle CLI startup errors directly in `main` so configuration parse failures use the standardized message

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ef5960e134832bb4ad09f82066275c