### PR TITLE
Reduce picker accessor boilerplate

### DIFF
--- a/src/core/app/actions/picker.rs
+++ b/src/core/app/actions/picker.rs
@@ -663,7 +663,7 @@ mod tests {
     use super::*;
     use crate::character::card::{CharacterCard, CharacterData};
     use crate::core::app::picker::{
-        CharacterPickerState, ModelPickerState, PickerData, PickerMode, PickerSession,
+        CharacterPickerState, ModelPickerState, PickerData, PickerSession,
     };
     use crate::core::config::{Config, Persona, Preset};
     use crate::ui::picker::{PickerItem, PickerState};
@@ -725,7 +725,6 @@ mod tests {
         let picker_state = PickerState::new("Pick Model", items.clone(), 0);
 
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Model,
             state: picker_state,
             data: PickerData::Model(ModelPickerState {
                 search_filter: String::new(),
@@ -762,7 +761,6 @@ mod tests {
 
         let picker_state = PickerState::new("Pick Character", items.clone(), 0);
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Character,
             state: picker_state,
             data: PickerData::Character(CharacterPickerState {
                 search_filter: String::new(),
@@ -800,7 +798,6 @@ mod tests {
 
         let picker_state = PickerState::new("Pick Character", items.clone(), 0);
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Character,
             state: picker_state,
             data: PickerData::Character(CharacterPickerState {
                 search_filter: String::new(),

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -217,27 +217,35 @@ impl App {
     }
 
     pub fn theme_picker_state(&self) -> Option<&ThemePickerState> {
-        self.picker.theme_state()
+        self.picker.session().and_then(PickerSession::theme_state)
     }
 
     pub fn theme_picker_state_mut(&mut self) -> Option<&mut ThemePickerState> {
-        self.picker.theme_state_mut()
+        self.picker
+            .session_mut()
+            .and_then(PickerSession::theme_state_mut)
     }
 
     pub fn model_picker_state(&self) -> Option<&ModelPickerState> {
-        self.picker.model_state()
+        self.picker.session().and_then(PickerSession::model_state)
     }
 
     pub fn model_picker_state_mut(&mut self) -> Option<&mut ModelPickerState> {
-        self.picker.model_state_mut()
+        self.picker
+            .session_mut()
+            .and_then(PickerSession::model_state_mut)
     }
 
     pub fn provider_picker_state(&self) -> Option<&ProviderPickerState> {
-        self.picker.provider_state()
+        self.picker
+            .session()
+            .and_then(PickerSession::provider_state)
     }
 
     pub fn provider_picker_state_mut(&mut self) -> Option<&mut ProviderPickerState> {
-        self.picker.provider_state_mut()
+        self.picker
+            .session_mut()
+            .and_then(PickerSession::provider_state_mut)
     }
 
     pub fn theme_controller(&mut self) -> ThemeController<'_> {
@@ -800,32 +808,40 @@ impl App {
 
     /// Get character picker state accessor
     pub fn character_picker_state(&self) -> Option<&CharacterPickerState> {
-        self.picker.character_state()
+        self.picker
+            .session()
+            .and_then(PickerSession::character_state)
     }
 
     /// Get mutable character picker state accessor
     pub fn character_picker_state_mut(&mut self) -> Option<&mut CharacterPickerState> {
-        self.picker.character_state_mut()
+        self.picker
+            .session_mut()
+            .and_then(PickerSession::character_state_mut)
     }
 
     /// Get persona picker state accessor
     pub fn persona_picker_state(&self) -> Option<&PersonaPickerState> {
-        self.picker.persona_state()
+        self.picker.session().and_then(PickerSession::persona_state)
     }
 
     /// Get mutable persona picker state accessor
     pub fn persona_picker_state_mut(&mut self) -> Option<&mut PersonaPickerState> {
-        self.picker.persona_state_mut()
+        self.picker
+            .session_mut()
+            .and_then(PickerSession::persona_state_mut)
     }
 
     /// Get preset picker state accessor
     pub fn preset_picker_state(&self) -> Option<&PresetPickerState> {
-        self.picker.preset_state()
+        self.picker.session().and_then(PickerSession::preset_state)
     }
 
     /// Get mutable preset picker state accessor
     pub fn preset_picker_state_mut(&mut self) -> Option<&mut PresetPickerState> {
-        self.picker.preset_state_mut()
+        self.picker
+            .session_mut()
+            .and_then(PickerSession::preset_state_mut)
     }
 }
 
@@ -880,7 +896,6 @@ mod tests {
         let mut picker_state = PickerState::new("Pick Model", items.clone(), 0);
         picker_state.sort_mode = crate::ui::picker::SortMode::Name;
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Model,
             state: picker_state,
             data: PickerData::Model(ModelPickerState {
                 search_filter: String::new(),
@@ -950,7 +965,6 @@ mod tests {
         let mut app = create_test_app();
         // Theme picker prefers alphabetical → Name
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Theme,
             state: PickerState::new("Pick Theme", vec![], 0),
             data: PickerData::Theme(ThemePickerState {
                 search_filter: String::new(),
@@ -965,7 +979,6 @@ mod tests {
         ));
         // Provider picker prefers alphabetical → Name
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Provider,
             state: PickerState::new("Pick Provider", vec![], 0),
             data: PickerData::Provider(ProviderPickerState {
                 search_filter: String::new(),
@@ -979,7 +992,6 @@ mod tests {
         ));
         // Model picker with dates → Date
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Model,
             state: PickerState::new("Pick Model", vec![], 0),
             data: PickerData::Model(ModelPickerState {
                 search_filter: String::new(),
@@ -1714,7 +1726,6 @@ Some additional text after the table."#;
         assert!(app.session.active_character.is_some());
 
         app.picker.picker_session = Some(picker::PickerSession {
-            mode: picker::PickerMode::Character,
             state: PickerState::new(
                 "Pick Character",
                 vec![PickerItem {

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -523,7 +523,7 @@ fn inset_rect(r: Rect, dx: u16, dy: u16) -> Rect {
 mod tests {
     use super::*;
     use crate::core::app::{
-        App, CharacterPickerState, ModelPickerState, PickerData, PickerMode, PickerSession,
+        App, CharacterPickerState, ModelPickerState, PickerData, PickerSession,
         ProviderPickerState, ThemePickerState,
     };
     use crate::ui::picker::PickerState;
@@ -542,7 +542,6 @@ mod tests {
     ) {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Model,
             state: picker_state,
             data: PickerData::Model(ModelPickerState {
                 search_filter: search_filter.to_string(),
@@ -561,7 +560,6 @@ mod tests {
     ) {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Theme,
             state: picker_state,
             data: PickerData::Theme(ThemePickerState {
                 search_filter: search_filter.to_string(),
@@ -580,7 +578,6 @@ mod tests {
     ) {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Provider,
             state: picker_state,
             data: PickerData::Provider(ProviderPickerState {
                 search_filter: search_filter.to_string(),
@@ -598,7 +595,6 @@ mod tests {
     ) {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
         app.picker.picker_session = Some(PickerSession {
-            mode: PickerMode::Character,
             state: picker_state,
             data: PickerData::Character(CharacterPickerState {
                 search_filter: search_filter.to_string(),


### PR DESCRIPTION
## Summary
- derive the picker session mode from its data and expose typed accessors for each variant
- update picker controller logic, app wrappers, and tests to call the new typed APIs instead of mode helpers
- collapse the picker accessor macros into a single definition shared by PickerData and PickerSession to reduce boilerplate

## Testing
- cargo fmt
- cargo clippy
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f020faa044832ba5414bb660f8b45c