### PR TITLE
feat: highlight active selection in pickers

### DIFF
--- a/src/core/providers.rs
+++ b/src/core/providers.rs
@@ -292,7 +292,7 @@ mod tests {
             &self,
             _provider: &str,
         ) -> Result<Option<(String, String)>, Box<dyn StdError>> {
-            let backend_error = io::Error::new(io::ErrorKind::Other, "mock backend unavailable");
+            let backend_error = io::Error::other("mock backend unavailable");
             let keyring_error = keyring::Error::NoStorageAccess(Box::new(backend_error));
             Err(Box::new(KeyringAccessError::from(keyring_error)))
         }
@@ -337,8 +337,10 @@ mod tests {
             env_guard.set_var("OPENAI_API_KEY", "sk-env");
             env_guard.set_var("OPENAI_BASE_URL", "https://example.com/v1");
 
-            let mut config = Config::default();
-            config.default_provider = Some("openai".to_string());
+            let config = Config {
+                default_provider: Some("openai".to_string()),
+                ..Default::default()
+            };
 
             let session = resolve_session(&MockSource {}, &config, None)
                 .expect("recoverable error should fall back to env");


### PR DESCRIPTION
## Summary
- highlight the active character, persona, or preset when opening their pickers
- add regression tests ensuring each picker preselects the active item
- address clippy warnings in provider tests

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68f08872b36c832bacc9d136d425ada0