### PR TITLE
Improve chat SSE framing

### DIFF
--- a/src/core/app/actions/mod.rs
+++ b/src/core/app/actions/mod.rs
@@ -9,10 +9,16 @@ use super::App;
 use crate::api::ModelsResponse;
 use crate::core::app::ModelPickerRequest;
 use crate::core::chat_stream::StreamParams;
+use crate::core::message::AppMessageKind;
 
 pub enum AppAction {
     AppendResponseChunk {
         content: String,
+        stream_id: u64,
+    },
+    StreamAppMessage {
+        kind: AppMessageKind,
+        message: String,
         stream_id: u64,
     },
     StreamErrored {
@@ -132,6 +138,7 @@ pub fn apply_actions(
 pub fn apply_action(app: &mut App, action: AppAction, ctx: AppActionContext) -> Option<AppCommand> {
     match action {
         AppAction::AppendResponseChunk { .. }
+        | AppAction::StreamAppMessage { .. }
         | AppAction::StreamErrored { .. }
         | AppAction::StreamCompleted { .. }
         | AppAction::CancelStreaming

--- a/src/ui/chat_loop/mod.rs
+++ b/src/ui/chat_loop/mod.rs
@@ -349,6 +349,13 @@ fn process_stream_updates(
                 coalesced_chunks.push_str(&content);
                 chunk_stream_id = Some(msg_stream_id);
             }
+            StreamMessage::App { kind, content } => {
+                followup_actions.push(AppAction::StreamAppMessage {
+                    kind,
+                    message: content,
+                    stream_id: msg_stream_id,
+                });
+            }
             StreamMessage::Error(err) => {
                 followup_actions.push(AppAction::StreamErrored {
                     message: err,


### PR DESCRIPTION
## Summary
- add a reusable SSE framer that tolerates CRLF separators, blank events, and flushes remaining data on stream end
- update the chat stream pipeline to use the framer and cover it with focused unit tests

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy --all-targets --all-features

------
https://chatgpt.com/codex/tasks/task_e_68f1424d7c94832b8f441281c58ad176