### PR TITLE
Show preset in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ Assign defaults per provider/model with `default-presets`:
 
 Launch with an ID like `--preset focus`, or pick interactively with `/preset`. The picker includes a "Turn off preset" option to clear the active preset.
 
+The status bar shows the current preset when one is active so you can confirm the context you're using at a glance.
+
 ## Appearance and Rendering
 
 ### Themes


### PR DESCRIPTION
## Summary

- refactored the title bar builder to include the active preset after the model or character label while keeping the logging status segment intact.
- hide the preset badge when no preset is active so the status bar stays uncluttered
- update renderer tests and preset docs to reflect the conditional display

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f154c6c550832ba9e4b5a4b5b0ae46