### PR TITLE
Replace png dependency with internal PNG parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,12 +158,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
@@ -271,13 +265,13 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "crc32fast",
  "criterion",
  "directories",
  "futures-util",
  "keyring",
  "memchr",
  "once_cell",
- "png",
  "pulldown-cmark",
  "ratatui",
  "reqwest",
@@ -496,7 +490,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -678,15 +672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,7 +817,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "libc",
  "libgit2-sys",
  "log",
@@ -1147,7 +1132,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -1257,7 +1242,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "libc",
 ]
 
@@ -1394,7 +1379,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
 ]
 
 [[package]]
@@ -1424,7 +1409,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1547,19 +1532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,7 +1570,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -1725,7 +1697,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -1766,7 +1738,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
 ]
 
 [[package]]
@@ -1891,7 +1863,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1904,7 +1876,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -1979,7 +1951,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -1992,7 +1964,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2471,7 +2443,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ unicode-width = "0.2.0"
 unicode-segmentation = "1.11"
 memchr = "2.7"
 once_cell = "1.19"
-png = "0.17"
 base64 = "0.22"
+crc32fast = "1.4"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -2,6 +2,7 @@ pub mod cache;
 pub mod card;
 pub mod import;
 pub mod loader;
+pub mod png_text;
 pub mod service;
 
 #[cfg(test)]

--- a/src/character/png_text.rs
+++ b/src/character/png_text.rs
@@ -1,0 +1,183 @@
+use std::fmt;
+
+use crc32fast::Hasher;
+
+pub const PNG_SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum PngTextError {
+    InvalidSignature,
+    TruncatedChunk,
+    InvalidChunkLength,
+    InvalidCrc { chunk_type: [u8; 4] },
+    MalformedText(&'static str),
+    MissingKeyword(String),
+}
+
+impl fmt::Display for PngTextError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PngTextError::InvalidSignature => write!(f, "file is not a PNG"),
+            PngTextError::TruncatedChunk => write!(f, "unexpected end of PNG data"),
+            PngTextError::InvalidChunkLength => {
+                write!(f, "chunk length exceeds PNG bounds")
+            }
+            PngTextError::InvalidCrc { chunk_type } => {
+                write!(
+                    f,
+                    "chunk {} failed CRC validation",
+                    display_chunk_type(chunk_type)
+                )
+            }
+            PngTextError::MalformedText(reason) => {
+                write!(f, "malformed tEXt chunk: {}", reason)
+            }
+            PngTextError::MissingKeyword(keyword) => {
+                write!(f, "missing '{}' tEXt metadata", keyword)
+            }
+        }
+    }
+}
+
+impl std::error::Error for PngTextError {}
+
+pub fn extract_text(data: &[u8], keyword: &str) -> Result<String, PngTextError> {
+    if data.len() < PNG_SIGNATURE.len() || data[..PNG_SIGNATURE.len()] != PNG_SIGNATURE {
+        return Err(PngTextError::InvalidSignature);
+    }
+
+    let mut offset = PNG_SIGNATURE.len();
+    while offset + 12 <= data.len() {
+        let length = u32::from_be_bytes(data[offset..offset + 4].try_into().unwrap()) as usize;
+        let chunk_type: [u8; 4] = data[offset + 4..offset + 8]
+            .try_into()
+            .expect("slice of length 4");
+        let data_start = offset + 8;
+        let data_end = data_start
+            .checked_add(length)
+            .ok_or(PngTextError::InvalidChunkLength)?;
+        if data_end > data.len() {
+            return Err(PngTextError::TruncatedChunk);
+        }
+        if data_end + 4 > data.len() {
+            return Err(PngTextError::TruncatedChunk);
+        }
+        let chunk_data = &data[data_start..data_end];
+        let crc_bytes: [u8; 4] = data[data_end..data_end + 4]
+            .try_into()
+            .expect("slice of length 4");
+        let actual_crc = u32::from_be_bytes(crc_bytes);
+        let mut hasher = Hasher::new();
+        hasher.update(&chunk_type);
+        hasher.update(chunk_data);
+        let expected_crc = hasher.finalize();
+        if actual_crc != expected_crc {
+            return Err(PngTextError::InvalidCrc { chunk_type });
+        }
+
+        if &chunk_type == b"tEXt" {
+            let Some(null_pos) = chunk_data.iter().position(|&b| b == 0) else {
+                return Err(PngTextError::MalformedText("missing keyword separator"));
+            };
+            let keyword_bytes = &chunk_data[..null_pos];
+            let value_bytes = &chunk_data[null_pos + 1..];
+            let chunk_keyword: String = keyword_bytes.iter().map(|&b| b as char).collect();
+            if chunk_keyword == keyword {
+                let text: String = value_bytes.iter().map(|&b| b as char).collect();
+                return Ok(text);
+            }
+        }
+
+        offset = data_end + 4;
+        if &chunk_type == b"IEND" {
+            break;
+        }
+    }
+
+    Err(PngTextError::MissingKeyword(keyword.to_string()))
+}
+
+fn display_chunk_type(chunk_type: &[u8; 4]) -> String {
+    chunk_type
+        .iter()
+        .map(|&b| {
+            if (32..=126).contains(&b) {
+                b as char
+            } else {
+                '.'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_signature() {
+        let result = extract_text(b"notpng", "chara");
+        assert!(matches!(result, Err(PngTextError::InvalidSignature)));
+    }
+
+    #[test]
+    fn extracts_requested_text() {
+        let png = build_png(Some(b"value"), true);
+        let text = extract_text(&png, "chara").unwrap();
+        assert_eq!(text, "value");
+    }
+
+    #[test]
+    fn reports_missing_keyword() {
+        let png = build_png(None, true);
+        let result = extract_text(&png, "chara");
+        assert!(matches!(result, Err(PngTextError::MissingKeyword(_))));
+    }
+
+    #[test]
+    fn rejects_invalid_crc() {
+        let png = build_png(Some(b"value"), false);
+        let result = extract_text(&png, "chara");
+        assert!(matches!(result, Err(PngTextError::InvalidCrc { .. })));
+    }
+
+    const TEST_IHDR: [u8; 13] = [
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00,
+    ];
+
+    const TEST_IDAT: [u8; 12] = [
+        0x78, 0xDA, 0x63, 0x60, 0x60, 0x60, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01,
+    ];
+
+    fn build_png(chara_payload: Option<&[u8]>, valid_crc: bool) -> Vec<u8> {
+        let mut png = Vec::new();
+        png.extend_from_slice(&PNG_SIGNATURE);
+        png.extend_from_slice(&chunk(*b"IHDR", &TEST_IHDR, true));
+        if let Some(payload) = chara_payload {
+            let mut text_data = Vec::new();
+            text_data.extend_from_slice(b"chara");
+            text_data.push(0);
+            text_data.extend_from_slice(payload);
+            png.extend_from_slice(&chunk(*b"tEXt", &text_data, valid_crc));
+        }
+        png.extend_from_slice(&chunk(*b"IDAT", &TEST_IDAT, true));
+        png.extend_from_slice(&chunk(*b"IEND", &[], true));
+        png
+    }
+
+    fn chunk(chunk_type: [u8; 4], data: &[u8], valid_crc: bool) -> Vec<u8> {
+        let mut out = Vec::with_capacity(12 + data.len());
+        out.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        out.extend_from_slice(&chunk_type);
+        out.extend_from_slice(data);
+        let mut hasher = Hasher::new();
+        hasher.update(&chunk_type);
+        hasher.update(data);
+        let mut crc = hasher.finalize();
+        if !valid_crc {
+            crc ^= 0xFFFF_FFFF;
+        }
+        out.extend_from_slice(&crc.to_be_bytes());
+        out
+    }
+}


### PR DESCRIPTION
## Summary
- add a character::png_text helper that validates PNG signatures and CRCs while extracting `chara` metadata
- refactor PNG card loading/tests to use the new helper and hand-built PNG fixtures instead of `png::Encoder`
- drop the `png` crate dependency in favor of `crc32fast`

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f17c27bb7c832baba18a0d2f0bf729