### PR TITLE
Replace once_cell Lazy usage with std LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,6 @@ dependencies = [
  "futures-util",
  "keyring",
  "memchr",
- "once_cell",
  "pulldown-cmark",
  "ratatui",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ async-trait = "0.1"
 unicode-width = "0.2.0"
 unicode-segmentation = "1.11"
 memchr = "2.7"
-once_cell = "1.19"
 base64 = "0.22"
 crc32fast = "1.4"
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,9 +8,9 @@ pub mod provider_list;
 pub mod theme_list;
 
 use std::error::Error;
+use std::sync::LazyLock;
 
 use clap::{Parser, Subcommand};
-use once_cell::sync::Lazy;
 
 // Import specific items we need
 use crate::auth::AuthManager;
@@ -80,8 +80,8 @@ fn print_version_info() {
 }
 
 // Unified help text used for both short and long help
-// Uses Lazy to compute the cards directory path at runtime
-static HELP_ABOUT: Lazy<String> = Lazy::new(|| {
+// Uses LazyLock to compute the cards directory path at runtime
+static HELP_ABOUT: LazyLock<String> = LazyLock::new(|| {
     let cards_dir = crate::core::config::path_display(crate::character::loader::get_cards_dir());
     format!(
         "Chabeau is a full-screen terminal chat interface for OpenAI‑compatible APIs.\n\n\

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -1,8 +1,8 @@
 use super::CommandResult;
 use crate::core::app::App;
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::LazyLock;
 
 /// Function pointer used by the registry to invoke a command implementation.
 ///
@@ -201,7 +201,7 @@ impl CommandRegistry {
     }
 }
 
-static REGISTRY: Lazy<CommandRegistry> = Lazy::new(CommandRegistry::new);
+static REGISTRY: LazyLock<CommandRegistry> = LazyLock::new(CommandRegistry::new);
 
 /// Provides read-only access to the registered command metadata.
 pub fn all_commands() -> &'static [Command] {

--- a/src/core/builtin_providers.rs
+++ b/src/core/builtin_providers.rs
@@ -3,8 +3,8 @@
 //! This module handles loading and managing built-in provider configurations
 //! from the builtins/models.toml file at build time.
 
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BuiltinProvider {
@@ -33,7 +33,7 @@ impl BuiltinProvider {
 
 const CONFIG_CONTENT: &str = include_str!("../builtins/models.toml");
 
-static BUILTIN_PROVIDERS: Lazy<Vec<BuiltinProvider>> = Lazy::new(|| {
+static BUILTIN_PROVIDERS: LazyLock<Vec<BuiltinProvider>> = LazyLock::new(|| {
     let config: BuiltinProvidersConfig =
         toml::from_str(CONFIG_CONTENT).expect("Failed to parse builtins/models.toml");
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,5 +1,4 @@
 use directories::ProjectDirs;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error as StdError;
@@ -7,7 +6,7 @@ use std::fmt;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::time::SystemTime;
 use tempfile::NamedTempFile;
 
@@ -147,11 +146,12 @@ struct ConfigOrchestrator {
     state: Mutex<ConfigCacheState>,
 }
 
-static CONFIG_ORCHESTRATOR: Lazy<ConfigOrchestrator> =
-    Lazy::new(|| ConfigOrchestrator::new(Config::get_config_path()));
+static CONFIG_ORCHESTRATOR: LazyLock<ConfigOrchestrator> =
+    LazyLock::new(|| ConfigOrchestrator::new(Config::get_config_path()));
 
 #[cfg(test)]
-static TEST_ORCHESTRATOR: Lazy<Mutex<Option<ConfigOrchestrator>>> = Lazy::new(|| Mutex::new(None));
+static TEST_ORCHESTRATOR: LazyLock<Mutex<Option<ConfigOrchestrator>>> =
+    LazyLock::new(|| Mutex::new(None));
 
 #[derive(Debug)]
 pub enum ConfigError {

--- a/src/ui/osc_backend.rs
+++ b/src/ui/osc_backend.rs
@@ -397,11 +397,9 @@ mod tests {
     use crate::ui::span::LinkMeta;
     use std::cell::RefCell;
     use std::rc::Rc;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, LazyLock, Mutex};
 
-    use once_cell::sync::Lazy;
-
-    static TEST_RENDER_STATE_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+    static TEST_RENDER_STATE_GUARD: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     fn cell_with_symbol(symbol: &str) -> Cell {
         let mut cell = Cell::default();

--- a/src/ui/osc_state.rs
+++ b/src/ui/osc_state.rs
@@ -1,8 +1,6 @@
-use std::ops::RangeInclusive;
-use std::sync::{Arc, Mutex};
-
-use once_cell::sync::Lazy;
 use ratatui::{layout::Rect, text::Line};
+use std::ops::RangeInclusive;
+use std::sync::{Arc, LazyLock, Mutex};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -20,8 +18,8 @@ pub struct OscRenderState {
     pub spans: Vec<OscSpan>,
 }
 
-static OSC_RENDER_STATE: Lazy<Mutex<OscRenderState>> =
-    Lazy::new(|| Mutex::new(OscRenderState::default()));
+static OSC_RENDER_STATE: LazyLock<Mutex<OscRenderState>> =
+    LazyLock::new(|| Mutex::new(OscRenderState::default()));
 
 pub fn set_render_state(state: OscRenderState) {
     if let Ok(mut guard) = OSC_RENDER_STATE.lock() {

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -7,8 +7,6 @@ use crate::core::message::Message;
 #[cfg(test)]
 use crate::ui::theme::Theme;
 #[cfg(test)]
-use once_cell::sync::Lazy;
-#[cfg(test)]
 use std::collections::VecDeque;
 #[cfg(test)]
 use std::env;
@@ -17,15 +15,15 @@ use std::ffi::{OsStr, OsString};
 #[cfg(test)]
 use std::path::Path;
 #[cfg(test)]
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{LazyLock, Mutex, MutexGuard};
 #[cfg(test)]
 use tempfile::TempDir;
 
 #[cfg(test)]
-static TEST_CONFIG_ENV_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static TEST_CONFIG_ENV_GUARD: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[cfg(test)]
-static TEST_ENV_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static TEST_ENV_GUARD: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[cfg(test)]
 pub struct TestConfigEnv {


### PR DESCRIPTION
## Summary
- replace once_cell::sync::Lazy with std::sync::LazyLock across CLI, config, UI, and test helpers
- update built-in provider and command registries to use std lazy initialization helpers
- remove the once_cell dependency from Cargo.toml

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy --all-targets

------
https://chatgpt.com/codex/tasks/task_e_68f1b68d1d6c832bb85d905129406ac4