### PR TITLE
Use TestEnvVarGuard in picker model selection test

### DIFF
--- a/src/core/app/actions/picker.rs
+++ b/src/core/app/actions/picker.rs
@@ -667,7 +667,7 @@ mod tests {
     };
     use crate::core::config::{Config, Persona, Preset};
     use crate::ui::picker::{PickerItem, PickerState};
-    use crate::utils::test_utils::create_test_app;
+    use crate::utils::test_utils::{create_test_app, TestEnvVarGuard};
     use std::fs;
     use tempfile::tempdir;
 
@@ -840,7 +840,8 @@ mod tests {
         let card_path = cards_dir.join("alice.json");
         fs::write(&card_path, serde_json::to_string(&test_card).unwrap()).unwrap();
 
-        std::env::set_var("CHABEAU_CONFIG_DIR", temp_dir.path());
+        let mut env_guard = TestEnvVarGuard::new();
+        env_guard.set_var("CHABEAU_CONFIG_DIR", temp_dir.path());
 
         assert!(app.session.active_character.is_none());
 
@@ -849,8 +850,6 @@ mod tests {
 
         assert!(app.session.active_character.is_none());
         assert!(app.persona_manager.get_active_persona().is_none());
-
-        std::env::remove_var("CHABEAU_CONFIG_DIR");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- update the picker model selection test to rely on TestEnvVarGuard when configuring CHABEAU_CONFIG_DIR
- ensure the guard handles cleanup rather than manual environment management

## Testing
- cargo fmt
- cargo test picker
- cargo check
- cargo clippy


------
https://chatgpt.com/codex/tasks/task_e_68f1c02537a4832b87a94f4ecb7dcefd