### PR TITLE
Export CLI module through library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod auth;
 pub mod character;
+pub mod cli;
 pub mod commands;
 pub mod core;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,8 @@
-// Declare all modules
-mod api;
-mod auth;
-mod character;
-mod cli;
-mod commands;
-mod core;
-mod ui;
-mod utils;
+use chabeau::{cli, core};
 
 fn main() {
     if let Err(err) = cli::main() {
-        if let Some(config_err) = err.downcast_ref::<crate::core::config::ConfigError>() {
+        if let Some(config_err) = err.downcast_ref::<core::config::ConfigError>() {
             eprintln!("❌ Failed to load configuration: {config_err}");
         } else {
             eprintln!("Error: {err}");


### PR DESCRIPTION
## Summary
- export the CLI module from the library crate
- update the binary entry point to use the library modules

## Testing
- cargo fmt
- cargo test
- cargo check
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68f2cc9b26e0832ba3efb69e7ba1937c