### PR TITLE
feat: Add `chabeau say` command for single-turn chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .kiro
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ export OPENAI_BASE_URL="https://api.openai.com/v1"  # Optional
 chabeau --env     # Force using env vars even if providers are configured
 ```
 
+### Quick, Single-Turn Chats
+
+For quick, one-off questions without launching the full TUI, use the `say` command:
+
+```bash
+chabeau say "What is the capital of France?"
+```
+
+This command sends a single-turn message to the configured model, streams the response directly to your terminal, and exits. It respects your markdown settings and uses a monochrome theme for clean, readable output.
+
+If you have multiple providers configured but no default set, Chabeau will prompt you to specify a provider with the `-p` flag. The `-p` and other global flags can be placed before or after the prompt.
+
 Environment variable values can make their way into shell histories or other places they shouldn't, so using the keyring is generally advisable.
 
 ## Configuration

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -483,6 +483,33 @@ impl AuthManager {
         self.config.save()?;
         Ok(())
     }
+
+    pub fn get_all_providers_with_auth_status(&self) -> (Vec<(String, String, bool)>, Option<String>) {
+        let mut providers = Vec::new();
+        let mut seen_ids = HashSet::new();
+
+        for provider in &self.providers {
+            if self.config.get_custom_provider(&provider.name).is_some() {
+                continue;
+            }
+            let has_token = self.get_token(&provider.name).unwrap_or(None).is_some();
+            providers.push((
+                provider.name.clone(),
+                provider.display_name.clone(),
+                has_token,
+            ));
+            seen_ids.insert(provider.name.clone());
+        }
+
+        for custom in self.config.list_custom_providers() {
+            if !seen_ids.contains(&custom.id) {
+                let has_token = self.get_token(&custom.id).unwrap_or(None).is_some();
+                providers.push((custom.id.clone(), custom.display_name.clone(), has_token));
+            }
+        }
+
+        (providers, self.config.default_provider.clone())
+    }
 }
 
 impl AuthManager {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@
 pub mod character_list;
 pub mod model_list;
 pub mod provider_list;
+pub mod say;
 pub mod theme_list;
 
 use std::error::Error;
@@ -189,6 +190,11 @@ pub enum Commands {
         /// Force overwrite if card already exists
         #[arg(short = 'f', long)]
         force: bool,
+    },
+    /// Send a single-turn message to a model without launching the TUI
+    Say {
+        /// The prompt to send to the model
+        prompt: Vec<String>,
     },
 }
 
@@ -629,6 +635,18 @@ async fn handle_args(args: Args) -> Result<(), Box<dyn Error>> {
                     std::process::exit(1);
                 }
             }
+        }
+        Some(Commands::Say { prompt }) => {
+            say::run_say(
+                prompt,
+                args.model,
+                args.provider,
+                args.env_only,
+                args.character,
+                args.persona,
+                args.preset,
+            )
+            .await
         }
     }
 }

--- a/src/cli/say.rs
+++ b/src/cli/say.rs
@@ -1,0 +1,173 @@
+//! TUI-less "say" command
+
+use std::error::Error;
+use std::io::{self, Write};
+
+use crate::auth::AuthManager;
+use crate::character::CharacterService;
+use crate::core::app::{self};
+use crate::core::chat_stream::{ChatStreamService, StreamMessage};
+use crate::core::config::data::Config;
+use crate::core::message::{Message, ROLE_ASSISTANT, ROLE_USER};
+use crate::core::providers::{resolve_session, ResolveSessionError};
+use crate::ui::layout::TableOverflowPolicy;
+use crate::ui::markdown::{self, MessageRenderConfig};
+use crate::ui::theme::Theme;
+use ratatui::crossterm::{self, execute};
+use ratatui::crossterm::terminal::{self, Clear, ClearType};
+use ratatui::text::Line;
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_say(
+    prompt: Vec<String>,
+    model: Option<String>,
+    provider: Option<String>,
+    env_only: bool,
+    character: Option<String>,
+    persona: Option<String>,
+    preset: Option<String>,
+) -> Result<(), Box<dyn Error>> {
+    let prompt = prompt.join(" ");
+    if prompt.is_empty() {
+        eprintln!("Usage: chabeau say <prompt>");
+        std::process::exit(1);
+    }
+
+    let config = Config::load()?;
+    let auth_manager = AuthManager::new()?;
+
+    if provider.is_none() && config.default_provider.is_none() {
+        let (providers, _) = auth_manager.get_all_providers_with_auth_status();
+        let configured_providers: Vec<_> = providers
+            .into_iter()
+            .filter(|(_, _, has_token)| *has_token)
+            .map(|(id, _, _)| id)
+            .collect();
+        if configured_providers.len() > 1 {
+            eprintln!("Multiple providers are configured. Please specify a provider with the -p flag.");
+            eprintln!("Available providers: {}", configured_providers.join(", "));
+            std::process::exit(1);
+        }
+    }
+
+    let character_service = CharacterService::new();
+
+    let session = match resolve_session(&auth_manager, &config, provider.as_deref()) {
+        Ok(session) => session,
+        Err(err) => {
+            match err {
+                ResolveSessionError::Provider(provider_err) => {
+                    eprintln!("{}", provider_err);
+                    let fixes = provider_err.quick_fixes();
+                    if !fixes.is_empty() {
+                        eprintln!();
+                        eprintln!("💡 Quick fixes:");
+                        for fix in fixes {
+                            eprintln!("  • {fix}");
+                        }
+                    }
+                    std::process::exit(provider_err.exit_code());
+                }
+                ResolveSessionError::Source(source_err) => {
+                    eprintln!("❌ Error: {}", source_err);
+                    std::process::exit(1);
+                }
+            }
+        }
+    };
+
+    let mut app = app::new_with_auth(
+        app::AppInitConfig {
+            model: model.unwrap_or_else(|| "default".to_string()),
+            log_file: None,
+            provider,
+            env_only,
+            pre_resolved_session: Some(session),
+            character,
+            persona,
+            preset,
+        },
+        &config,
+        character_service,
+    )
+    .await?;
+
+    let messages = vec![Message {
+        role: ROLE_USER.to_string(),
+        content: prompt,
+    }];
+
+    let params = app.conversation().stream_parameters(messages, None);
+
+    let (stream_service, mut rx) = ChatStreamService::new();
+    stream_service.spawn_stream(params);
+
+    let mut full_response = String::new();
+    let use_markdown = config.markdown.unwrap_or(false);
+    let mut stdout = io::stdout();
+    let mut last_line_count = 0;
+
+    loop {
+        match rx.recv().await {
+            Some((StreamMessage::Chunk(content), _)) => {
+                if use_markdown {
+                    full_response.push_str(&content);
+                    let lines = render_markdown_chunk(&full_response)?;
+                    clear_last_lines(&mut stdout, last_line_count)?;
+                    for line in &lines {
+                        println!("{}", line);
+                    }
+                    last_line_count = lines.len();
+                } else {
+                    print!("{}", content);
+                    stdout.flush()?;
+                }
+            }
+            Some((StreamMessage::Error(err), _)) => {
+                // Buffer errors so they don't get overwritten by the markdown render
+                if !use_markdown {
+                    eprintln!();
+                }
+                eprintln!("❌ Error: {}", err);
+                std::process::exit(1);
+            }
+            Some((StreamMessage::End, _)) => {
+                if !use_markdown {
+                    println!();
+                }
+                break;
+            }
+            None => break,
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn render_markdown_chunk(content: &str) -> Result<Vec<Line<'static>>, Box<dyn Error>> {
+    let monochrome_theme = Theme::monochrome();
+    let terminal_width = terminal::size().ok().map(|(w, _)| w as usize);
+    let rendered = markdown::render_message_with_config(
+        &Message {
+            role: ROLE_ASSISTANT.to_string(),
+            content: content.to_string(),
+        },
+        &monochrome_theme,
+        MessageRenderConfig::markdown(false)
+            .with_terminal_width(terminal_width, TableOverflowPolicy::WrapCells),
+    );
+
+    Ok(rendered.lines)
+}
+
+fn clear_last_lines(stdout: &mut io::Stdout, line_count: usize) -> Result<(), Box<dyn Error>> {
+    if line_count > 0 {
+        execute!(
+            stdout,
+            crossterm::cursor::MoveUp(line_count as u16),
+            Clear(ClearType::FromCursorDown)
+        )?;
+    }
+    Ok(())
+}

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -259,6 +259,56 @@ impl Theme {
         }
     }
 
+    pub fn monochrome() -> Self {
+        Theme {
+            background_color: Color::Reset,
+            user_prefix_style: Style::default().add_modifier(Modifier::BOLD),
+            user_text_style: Style::default(),
+            assistant_text_style: Style::default(),
+            system_text_style: Style::default(),
+            error_text_style: Style::default(),
+            app_messages: AppMessageStyles {
+                info: AppMessageStyle {
+                    prefix: "ℹ️  ".to_string(),
+                    prefix_style: Style::default(),
+                    text_style: Style::default(),
+                },
+                warning: AppMessageStyle {
+                    prefix: "⚠️  ".to_string(),
+                    prefix_style: Style::default(),
+                    text_style: Style::default(),
+                },
+                error: AppMessageStyle {
+                    prefix: "⛔  ".to_string(),
+                    prefix_style: Style::default(),
+                    text_style: Style::default(),
+                },
+            },
+            title_style: Style::default(),
+            streaming_indicator_style: Style::default(),
+            selection_highlight_style: Style::default().add_modifier(Modifier::REVERSED),
+            input_border_style: Style::default(),
+            input_title_style: Style::default(),
+            input_text_style: Style::default(),
+            input_cursor_style: Style::default().add_modifier(Modifier::REVERSED),
+            input_cursor_line_style: Style::default(),
+            md_h1: Some(Style::default().add_modifier(Modifier::BOLD)),
+            md_h2: Some(Style::default().add_modifier(Modifier::BOLD)),
+            md_h3: Some(Style::default().add_modifier(Modifier::BOLD)),
+            md_h4: Some(Style::default().add_modifier(Modifier::BOLD)),
+            md_h5: Some(Style::default().add_modifier(Modifier::BOLD)),
+            md_h6: Some(Style::default().add_modifier(Modifier::BOLD)),
+            md_paragraph: Some(Style::default()),
+            md_inline_code: Some(Style::default().add_modifier(Modifier::REVERSED)),
+            md_link: Some(Style::default().add_modifier(Modifier::UNDERLINED)),
+            md_rule: Some(Style::default()),
+            md_blockquote_text: Some(Style::default().add_modifier(Modifier::ITALIC)),
+            md_list_marker: Some(Style::default()),
+            md_codeblock_text: Some(Style::default()),
+            md_codeblock_bg: None,
+        }
+    }
+
     pub fn from_spec(spec: &ThemeSpec) -> Self {
         // Helper parsers
         fn parse_color(s: &str) -> Option<Color> {


### PR DESCRIPTION
This commit introduces a new `chabeau say` command that allows for single-turn, TUI-less conversations.

- It takes a prompt as input and streams the response directly to the terminal.
- If markdown is disabled, the response is streamed as plain text.
- The output is always monochrome.
- The command will exit with an error if multiple providers are configured but no default is set, prompting the user to specify one.

This feature provides a quick and simple way to interact with the model without launching the full TUI.