### PR TITLE
feat: Reformat provider list table

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -484,7 +484,9 @@ impl AuthManager {
         Ok(())
     }
 
-    pub fn get_all_providers_with_auth_status(&self) -> (Vec<(String, String, bool)>, Option<String>) {
+    pub fn get_all_providers_with_auth_status(
+        &self,
+    ) -> (Vec<(String, String, String, bool)>, Option<String>) {
         let mut providers = Vec::new();
         let mut seen_ids = HashSet::new();
 
@@ -496,6 +498,7 @@ impl AuthManager {
             providers.push((
                 provider.name.clone(),
                 provider.display_name.clone(),
+                provider.base_url.clone(),
                 has_token,
             ));
             seen_ids.insert(provider.name.clone());
@@ -504,7 +507,12 @@ impl AuthManager {
         for custom in self.config.list_custom_providers() {
             if !seen_ids.contains(&custom.id) {
                 let has_token = self.get_token(&custom.id).unwrap_or(None).is_some();
-                providers.push((custom.id.clone(), custom.display_name.clone(), has_token));
+                providers.push((
+                    custom.id.clone(),
+                    custom.display_name.clone(),
+                    custom.base_url.clone(),
+                    has_token,
+                ));
             }
         }
 

--- a/src/cli/say.rs
+++ b/src/cli/say.rs
@@ -40,8 +40,8 @@ pub async fn run_say(
         let (providers, _) = auth_manager.get_all_providers_with_auth_status();
         let configured_providers: Vec<_> = providers
             .into_iter()
-            .filter(|(_, _, has_token)| *has_token)
-            .map(|(id, _, _)| id)
+            .filter(|(_, _, _, has_token)| *has_token)
+            .map(|(id, _, _, _)| id)
             .collect();
         if configured_providers.len() > 1 {
             eprintln!("Multiple providers are configured. Please specify a provider with the -p flag.");


### PR DESCRIPTION
This commit reformats the provider list table output from the `chabeau -p` command.

- Adds a "URL" column to the table.
- Marks the default provider with an asterisk (*) in the "Provider" column.
- Adds a heading "Configured Providers" before the table.