### PR TITLE
add OSC8 markers to "say" output (links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ For quick, one-off questions without launching the full TUI, use the `say` comma
 chabeau say "What is the capital of France?"
 ```
 
-This command sends a single-turn message to the configured model, streams the response directly to your terminal, and exits. It respects your markdown settings and uses a monochrome theme for clean, readable output.
+This command sends a single-turn message to the configured model, streams the response directly to your terminal, and exits. It respects your markdown settings, emits OSC8 hyperlinks when your terminal supports them, and uses a monochrome theme for clean, readable output.
 
 If you have multiple providers configured but no default set, Chabeau will prompt you to specify a provider with the `-p` flag. The `-p` and other global flags can be placed before or after the prompt.
 

--- a/src/cli/say.rs
+++ b/src/cli/say.rs
@@ -9,6 +9,7 @@ use crate::core::app::{self};
 use crate::core::chat_stream::{ChatStreamService, StreamMessage};
 use crate::core::config::data::Config;
 use crate::core::providers::{resolve_session, ResolveSessionError};
+use crate::ui::osc;
 use ratatui::crossterm::cursor::{MoveToColumn, MoveUp};
 use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{self, Clear, ClearType};
@@ -98,8 +99,9 @@ pub async fn run_say(
     };
 
     let prefix_lines: Vec<String> = {
-        let lines = app.get_prewrapped_lines_cached(term_width);
-        lines.iter().map(|line| line.to_string()).collect()
+        let metadata = app.get_prewrapped_span_metadata_cached(term_width).clone();
+        let lines = app.get_prewrapped_lines_cached(term_width).clone();
+        osc::encode_lines_with_links_with_underline(&lines, &metadata)
     };
     for line in &prefix_lines {
         println!("{}", line);
@@ -123,11 +125,11 @@ pub async fn run_say(
                     conversation.append_to_response(&content, available_height, term_width);
                 }
 
-                let new_lines: Vec<String> = app
-                    .get_prewrapped_lines_cached(term_width)
-                    .iter()
-                    .map(|line| line.to_string())
-                    .collect();
+                let new_lines: Vec<String> = {
+                    let metadata = app.get_prewrapped_span_metadata_cached(term_width).clone();
+                    let lines = app.get_prewrapped_lines_cached(term_width).clone();
+                    osc::encode_lines_with_links_with_underline(&lines, &metadata)
+                };
 
                 let mut common_prefix_len = 0usize;
                 let max_prefix = previous_lines.len().min(new_lines.len());


### PR DESCRIPTION
## Summary
- emit OSC8 markers in 'say' output
- add an underline-fallback mode to the OSC8 hyperlink encoders so link text remains visibly underlined
- update the `say` streaming output to use the fallback encoder when emitting OSC8 hyperlinks

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_69044d611788832b97d1894c16863d00