### PR TITLE
Fix clippy warnings in provider listing and transcript

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -27,6 +27,14 @@ pub struct Provider {
 
 type ConfiguredProviderEntry = (String, String, bool);
 
+#[derive(Clone, Debug)]
+pub struct ProviderAuthStatus {
+    pub id: String,
+    pub display_name: String,
+    pub base_url: String,
+    pub has_token: bool,
+}
+
 fn map_ui_result<T>(result: Result<T, UiError>) -> Result<T, Box<dyn std::error::Error>> {
     result.map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
 }
@@ -484,9 +492,7 @@ impl AuthManager {
         Ok(())
     }
 
-    pub fn get_all_providers_with_auth_status(
-        &self,
-    ) -> (Vec<(String, String, String, bool)>, Option<String>) {
+    pub fn get_all_providers_with_auth_status(&self) -> (Vec<ProviderAuthStatus>, Option<String>) {
         let mut providers = Vec::new();
         let mut seen_ids = HashSet::new();
 
@@ -495,24 +501,24 @@ impl AuthManager {
                 continue;
             }
             let has_token = self.get_token(&provider.name).unwrap_or(None).is_some();
-            providers.push((
-                provider.name.clone(),
-                provider.display_name.clone(),
-                provider.base_url.clone(),
+            providers.push(ProviderAuthStatus {
+                id: provider.name.clone(),
+                display_name: provider.display_name.clone(),
+                base_url: provider.base_url.clone(),
                 has_token,
-            ));
+            });
             seen_ids.insert(provider.name.clone());
         }
 
         for custom in self.config.list_custom_providers() {
             if !seen_ids.contains(&custom.id) {
                 let has_token = self.get_token(&custom.id).unwrap_or(None).is_some();
-                providers.push((
-                    custom.id.clone(),
-                    custom.display_name.clone(),
-                    custom.base_url.clone(),
+                providers.push(ProviderAuthStatus {
+                    id: custom.id.clone(),
+                    display_name: custom.display_name.clone(),
+                    base_url: custom.base_url.clone(),
                     has_token,
-                ));
+                });
             }
         }
 

--- a/src/cli/provider_list.rs
+++ b/src/cli/provider_list.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use crate::{
-    auth::AuthManager,
+    auth::{AuthManager, ProviderAuthStatus},
     core::message::{Message, ROLE_ASSISTANT},
     ui::{
         layout::TableOverflowPolicy,
@@ -26,11 +26,17 @@ pub async fn list_providers() -> Result<(), Box<dyn Error>> {
     table.push_str("| Provider | Display Name | URL | Authenticated |\n");
     table.push_str("|---|---|---|:---:|\n");
 
-    for (id, display_name, base_url, has_token) in providers {
+    for ProviderAuthStatus {
+        id,
+        display_name,
+        base_url,
+        has_token,
+    } in providers
+    {
         let auth_status = if has_token { "✅" } else { "❌" };
         let provider_id = if default_provider
             .as_ref()
-            .map_or(false, |d| d.eq_ignore_ascii_case(&id))
+            .is_some_and(|d| d.eq_ignore_ascii_case(&id))
         {
             format!("{}*", id)
         } else {

--- a/src/cli/say.rs
+++ b/src/cli/say.rs
@@ -3,7 +3,7 @@
 use std::error::Error;
 use std::io::{self, Write};
 
-use crate::auth::AuthManager;
+use crate::auth::{AuthManager, ProviderAuthStatus};
 use crate::character::CharacterService;
 use crate::core::app::{self};
 use crate::core::chat_stream::{ChatStreamService, StreamMessage};
@@ -37,8 +37,8 @@ pub async fn run_say(
         let (providers, _) = auth_manager.get_all_providers_with_auth_status();
         let configured_providers: Vec<_> = providers
             .into_iter()
-            .filter(|(_, _, _, has_token)| *has_token)
-            .map(|(id, _, _, _)| id)
+            .filter(|ProviderAuthStatus { has_token, .. }| *has_token)
+            .map(|ProviderAuthStatus { id, .. }| id)
             .collect();
         if configured_providers.len() > 1 {
             eprintln!(

--- a/src/ui/chat_loop/event_loop.rs
+++ b/src/ui/chat_loop/event_loop.rs
@@ -528,7 +528,7 @@ pub async fn run_chat(
         app.update(|app| {
             let lines = app.ui.get_prewrapped_lines_cached(last_term_size.width);
             for line in lines {
-                println!("{}", line.to_string());
+                println!("{line}");
             }
         })
         .await;


### PR DESCRIPTION
## Summary
- introduce a ProviderAuthStatus struct to reduce clippy-reported type complexity
- update CLI consumers to use the struct and simplify default provider checks
- drop an unnecessary `to_string()` when printing chat transcript lines

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_690466439ea8832b9ee8a7d9abad43f9