### PR TITLE
Expand compose mode input height based on terminal size

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Chabeau is a full-screen terminal chat interface that connects to various AI API
 - Reusable preset instructions with picker and CLI toggles for quick context switching
 - Extensible theming system that degrades gracefully to terminals with limited color support
 - Secure API key storage in system keyring with config-based provider management
-- Multi-line input (IME-friendly) with compose mode for longer responses
+- Multi-line input (IME-friendly) with compose mode that can expand to half the terminal for longer responses
 - Message retry and message editing
 - On-demand refinements of the last assistant response with `/refine <prompt>`
 - Slash command registry with inline help for faster command discovery

--- a/src/core/app/ui_state.rs
+++ b/src/core/app/ui_state.rs
@@ -243,6 +243,11 @@ impl UiState {
 
     pub fn toggle_compose_mode(&mut self) {
         self.compose_mode = !self.compose_mode;
+
+        if self.last_term_size.width > 0 {
+            let width = self.last_term_size.width;
+            self.recompute_input_layout_after_edit(width);
+        }
     }
 
     pub fn begin_activity(&mut self, kind: ActivityKind) {
@@ -447,7 +452,14 @@ impl UiState {
         if wrapped_lines <= 1 && !self.get_input_text().contains('\n') {
             1
         } else {
-            (wrapped_lines as u16).clamp(2, 6)
+            let max_height = if self.compose_mode {
+                let half_height = self.last_term_size.height / 2;
+                half_height.saturating_sub(2).max(2)
+            } else {
+                6
+            };
+
+            (wrapped_lines as u16).clamp(2, max_height)
         }
     }
 


### PR DESCRIPTION
## Summary
- let compose mode expand the input area up to half of the terminal height using the last known terminal size
- recompute the input layout after toggling compose mode so scroll offsets stay consistent
- document the compose mode expansion in the README

## Testing
- cargo fmt
- cargo check
- cargo test *(fails: utils::scroll::tests::perf_prewrap_short_history exceeded time threshold on this runner)*
- cargo clippy --all-targets

------
https://chatgpt.com/codex/tasks/task_e_690541a68a90832b98595e9a2c97062c