### PR TITLE
tweak focus behavior in Ctrl+B/Ctrl+P and file input modes

### DIFF
--- a/src/builtins/help.md
+++ b/src/builtins/help.md
@@ -16,7 +16,7 @@ Find a bug? Let us know: https://github.com/permacommons/chabeau/issues
 - Ctrl+P: Edit previous messages (select mode)
 - Ctrl+B: Select code blocks (copy `c`, save `s`)
 - Ctrl+L: Clear status message
-- Tab: Switch focus between transcript and input (`›` marks the active area, `·` the inactive) unless the current input starts with `/`, in which case it autocompletes slash commands
+- Tab: Switch focus between transcript and input (`›` marks the active area, `·` the inactive) unless the current input starts with `/`, in which case it autocompletes slash commands. Tab stays on the transcript while you're in message-select (Ctrl+P) or block-select (Ctrl+B) mode until you exit or finish selecting.
 - Ctrl+T: Open in external editor (requires `$EDITOR` to be set)
 - Esc: Interrupt streaming / cancel modes
 - Arrow keys: Move within the focused area; Up/Down scroll when the transcript is focused

--- a/src/ui/chat_loop/keybindings/mod.rs
+++ b/src/ui/chat_loop/keybindings/mod.rs
@@ -102,7 +102,17 @@ pub fn build_mode_aware_registry(
             Box::new(NavigationHandler),
         )
         .register_for_context(
+            KeyContext::FilePrompt,
+            KeyPattern::simple(KeyCode::Home),
+            Box::new(NavigationHandler),
+        )
+        .register_for_context(
             KeyContext::Typing,
+            KeyPattern::simple(KeyCode::End),
+            Box::new(NavigationHandler),
+        )
+        .register_for_context(
+            KeyContext::FilePrompt,
             KeyPattern::simple(KeyCode::End),
             Box::new(NavigationHandler),
         )
@@ -112,7 +122,17 @@ pub fn build_mode_aware_registry(
             Box::new(NavigationHandler),
         )
         .register_for_context(
+            KeyContext::FilePrompt,
+            KeyPattern::simple(KeyCode::PageUp),
+            Box::new(NavigationHandler),
+        )
+        .register_for_context(
             KeyContext::Typing,
+            KeyPattern::simple(KeyCode::PageDown),
+            Box::new(NavigationHandler),
+        )
+        .register_for_context(
+            KeyContext::FilePrompt,
             KeyPattern::simple(KeyCode::PageDown),
             Box::new(NavigationHandler),
         )
@@ -123,7 +143,17 @@ pub fn build_mode_aware_registry(
             Box::new(ArrowKeyHandler),
         )
         .register_for_context(
+            KeyContext::FilePrompt,
+            KeyPattern::simple(KeyCode::Up),
+            Box::new(ArrowKeyHandler),
+        )
+        .register_for_context(
             KeyContext::Typing,
+            KeyPattern::simple(KeyCode::Down),
+            Box::new(ArrowKeyHandler),
+        )
+        .register_for_context(
+            KeyContext::FilePrompt,
             KeyPattern::simple(KeyCode::Down),
             Box::new(ArrowKeyHandler),
         )
@@ -133,7 +163,17 @@ pub fn build_mode_aware_registry(
             Box::new(ArrowKeyHandler),
         )
         .register_for_context(
+            KeyContext::FilePrompt,
+            KeyPattern::simple(KeyCode::Left),
+            Box::new(ArrowKeyHandler),
+        )
+        .register_for_context(
             KeyContext::Typing,
+            KeyPattern::simple(KeyCode::Right),
+            Box::new(ArrowKeyHandler),
+        )
+        .register_for_context(
+            KeyContext::FilePrompt,
             KeyPattern::simple(KeyCode::Right),
             Box::new(ArrowKeyHandler),
         )
@@ -143,7 +183,17 @@ pub fn build_mode_aware_registry(
             Box::new(ArrowKeyHandler),
         )
         .register_for_context(
+            KeyContext::FilePrompt,
+            KeyPattern::with_modifiers(KeyCode::Up, KeyModifiers::SHIFT),
+            Box::new(ArrowKeyHandler),
+        )
+        .register_for_context(
             KeyContext::Typing,
+            KeyPattern::with_modifiers(KeyCode::Down, KeyModifiers::SHIFT),
+            Box::new(ArrowKeyHandler),
+        )
+        .register_for_context(
+            KeyContext::FilePrompt,
             KeyPattern::with_modifiers(KeyCode::Down, KeyModifiers::SHIFT),
             Box::new(ArrowKeyHandler),
         )
@@ -153,7 +203,17 @@ pub fn build_mode_aware_registry(
             Box::new(ArrowKeyHandler),
         )
         .register_for_context(
+            KeyContext::FilePrompt,
+            KeyPattern::with_modifiers(KeyCode::Left, KeyModifiers::SHIFT),
+            Box::new(ArrowKeyHandler),
+        )
+        .register_for_context(
             KeyContext::Typing,
+            KeyPattern::with_modifiers(KeyCode::Right, KeyModifiers::SHIFT),
+            Box::new(ArrowKeyHandler),
+        )
+        .register_for_context(
+            KeyContext::FilePrompt,
             KeyPattern::with_modifiers(KeyCode::Right, KeyModifiers::SHIFT),
             Box::new(ArrowKeyHandler),
         )


### PR DESCRIPTION
Prevent [Tab] in special selection modes, and ensure it works as expected in file input mode