### PR TITLE
refactor: harden input encapsulation

### DIFF
--- a/src/core/app/ui_helpers.rs
+++ b/src/core/app/ui_helpers.rs
@@ -53,7 +53,7 @@ impl App {
         }
 
         let chars: Vec<char> = input.chars().collect();
-        let cursor = self.ui.input_cursor_position.min(chars.len());
+        let cursor = self.ui.get_input_cursor_position().min(chars.len());
 
         if cursor == 0 {
             return false;

--- a/src/core/app/ui_state.rs
+++ b/src/core/app/ui_state.rs
@@ -66,8 +66,8 @@ struct InputLayoutCache {
 #[derive(Debug, Clone)]
 pub struct UiState {
     pub messages: VecDeque<Message>,
-    pub input: String,
-    pub input_cursor_position: usize,
+    input: String,
+    input_cursor_position: usize,
     pub mode: UiMode,
     pub current_response: String,
     pub scroll_offset: u16,
@@ -78,7 +78,7 @@ pub struct UiState {
     pub pulse_start: Instant,
     pub stream_interrupted: bool,
     pub input_scroll_offset: u16,
-    pub textarea: TextArea<'static>,
+    textarea: TextArea<'static>,
     pub theme: Theme,
     pub current_theme_id: Option<String>,
     pub markdown_enabled: bool,
@@ -461,6 +461,31 @@ impl UiState {
 
     pub fn get_input_text(&self) -> &str {
         &self.input
+    }
+
+    pub fn get_input_cursor_position(&self) -> usize {
+        self.input_cursor_position
+    }
+
+    pub fn get_textarea_cursor(&self) -> (usize, usize) {
+        self.textarea.cursor()
+    }
+
+    pub fn get_textarea_line_count(&self) -> usize {
+        self.textarea.lines().len()
+    }
+
+    pub fn get_textarea_line_len(&self, row: usize) -> usize {
+        self.textarea
+            .lines()
+            .get(row)
+            .map(|l| l.chars().count())
+            .unwrap_or(0)
+    }
+
+    pub fn set_cursor_position(&mut self, pos: usize) {
+        self.jump_cursor_to_position(pos);
+        self.input_cursor_preferred_column = None;
     }
 
     pub fn set_input_text(&mut self, text: String) {

--- a/src/ui/chat_loop/keybindings/handlers.rs
+++ b/src/ui/chat_loop/keybindings/handlers.rs
@@ -1122,7 +1122,7 @@ mod tests {
                 .await;
             assert_eq!(result, KeyResult::Handled);
 
-            let cursor = app.read(|app| app.ui.input_cursor_position).await;
+            let cursor = app.read(|app| app.ui.get_input_cursor_position()).await;
             assert_eq!(cursor, 1);
         });
     }
@@ -1149,7 +1149,7 @@ mod tests {
             let (cursor, hscroll) = app
                 .read(|app| {
                     (
-                        app.ui.input_cursor_position,
+                        app.ui.get_input_cursor_position(),
                         app.ui.horizontal_scroll_offset,
                     )
                 })

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -355,7 +355,7 @@ pub fn ui(f: &mut Frame, app: &mut App) {
         if app.ui.is_input_active() && app.ui.is_input_focused() && app.picker_session().is_none() {
             let (line, col) = TextWrapper::calculate_cursor_position_in_wrapped_text(
                 app.ui.get_input_text(),
-                app.ui.input_cursor_position,
+                app.ui.get_input_cursor_position(),
                 &config,
             );
             let visible_line = (line as u16).saturating_sub(app.ui.input_scroll_offset);


### PR DESCRIPTION
- due to the tight coupling of ui_state and tui-textarea during input, prevent direct access to state
- also includes a prewrap performance improvement