### PR TITLE
Refactor: unify markdown and plain rendering paths

### DIFF
--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -29,24 +29,6 @@ Items are removed when completed.
 ### Medium priority
 
 
-2. Consolidate plain vs markdown rendering path selection [PARTIAL]
-- Rationale:
-  - Impact: Reduces branching and drift between plain/markdown paths; improves correctness for wrapping, tables, and scrolling.
-  - Effort: Moderate. Centralizing selection and routing through a single entry point impacts renderer and scroll build paths.
-  - Risk: Low–Moderate. Some code paths become dead; ensure feature parity with wrap, table, and highlight behavior.
-- Actions:
-  - Enforce a single entry point by routing all message rendering through [render_message_with_config()](src/ui/markdown.rs:164) and centralizing mode selection in [MessageRenderConfig.markdown()](src/ui/markdown.rs:105).
-  - Collapse renderer branching by checking the unified config once inside [ui()](src/ui/renderer.rs:33), [ui()](src/ui/renderer.rs:42), [ui()](src/ui/renderer.rs:55), delegating downstream behavior.
-  - Align scroll-build paths to share flags and width logic, preferring the common-with-flags signatures: [ScrollCalculator.build_layout_with_theme_and_flags_and_width()](src/utils/scroll.rs:326), [ScrollCalculator.build_display_lines_up_to_with_flags_and_width()](src/utils/scroll.rs:530) and plain-path handling at [ScrollCalculator.build_display_lines_up_to_with_flags_and_width()](src/utils/scroll.rs:553).
-- References:
-  - [render_message_with_config()](src/ui/markdown.rs:164), [MessageRenderConfig.markdown()](src/ui/markdown.rs:105)
-  - [ui()](src/ui/renderer.rs:33), [ui()](src/ui/renderer.rs:42), [ui()](src/ui/renderer.rs:55)
-  - [ScrollCalculator.build_layout_with_theme_and_flags_and_width()](src/utils/scroll.rs:326)
-  - [ScrollCalculator.build_layout_with_theme_and_selection_and_flags_and_width()](src/utils/scroll.rs:370)
-  - [ScrollCalculator.build_layout_with_codeblock_highlight_and_flags_and_width()](src/utils/scroll.rs:453)
-  - [ScrollCalculator.build_display_lines_up_to_with_flags_and_width()](src/utils/scroll.rs:530), [ScrollCalculator.build_display_lines_up_to_with_flags_and_width()](src/utils/scroll.rs:553)
-  - [wrap_spans_to_width_generic_shared()](src/ui/markdown_wrap.rs:9), [TableRenderer](src/ui/markdown/table.rs:21), [highlight_code_block()](src/utils/syntax.rs:139)
-
 3. Reduce duplication in src/ui/markdown.rs for code block flushing [OPEN]
 - Rationale:
   - Impact: Single source of truth for code-block termination prevents subtle newline/trailing span inconsistencies and highlight glitches.

--- a/src/cli/provider_list.rs
+++ b/src/cli/provider_list.rs
@@ -63,7 +63,7 @@ pub async fn list_providers() -> Result<(), Box<dyn Error>> {
             content,
         },
         &monochrome_theme,
-        MessageRenderConfig::markdown(true)
+        MessageRenderConfig::markdown(true, true)
             .with_terminal_width(terminal_width, TableOverflowPolicy::WrapCells),
     );
 

--- a/src/core/app/tests.rs
+++ b/src/core/app/tests.rs
@@ -298,10 +298,17 @@ fn prewrap_cache_updates_metadata_for_plain_text_last_message() {
     let updated_lines = app.get_prewrapped_lines_cached(width).clone();
     let updated_meta = app.get_prewrapped_span_metadata_cached(width).clone();
     assert_eq!(updated_lines.len(), updated_meta.len());
-    assert!(updated_meta
-        .iter()
-        .flat_map(|kinds| kinds.iter())
-        .all(|kind| kind.is_text()));
+    let mut saw_prefix = false;
+    for kind in updated_meta.iter().flat_map(|kinds| kinds.iter()) {
+        assert!(kind.is_text() || kind.is_prefix());
+        if kind.is_prefix() {
+            saw_prefix = true;
+        }
+    }
+    assert!(
+        saw_prefix,
+        "expected plain text metadata to include a prefix span"
+    );
 }
 
 #[test]

--- a/src/core/persona.rs
+++ b/src/core/persona.rs
@@ -469,14 +469,14 @@ fn test_message_rendering_with_persona_display_name() {
     };
 
     // Test with default "You:"
-    let config_default = MessageRenderConfig::plain();
+    let config_default = MessageRenderConfig::markdown(false, false);
     let rendered_default = render_message_with_config(&message, &theme, config_default);
     let first_line_default = rendered_default.lines.first().unwrap().to_string();
     assert!(first_line_default.starts_with("You: "));
 
     // Test with persona display name
-    let config_persona =
-        MessageRenderConfig::plain().with_user_display_name(Some("Alice".to_string()));
+    let config_persona = MessageRenderConfig::markdown(false, false)
+        .with_user_display_name(Some("Alice".to_string()));
     let rendered_persona = render_message_with_config(&message, &theme, config_persona);
     let first_line_persona = rendered_persona.lines.first().unwrap().to_string();
     assert!(first_line_persona.starts_with("Alice: "));


### PR DESCRIPTION
## Summary
- centralize MessageRenderConfig mode handling and reuse render_message_with_config for plain text
- simplify layout and scroll helpers to consume the unified rendering pipeline and keep metadata consistent
- update persona tests and clean up WISHLIST entry for the completed refactor

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_690c26dc5a74832ba54330515ef8171c