### PR TITLE
Fix assistant edit scroll position update

### DIFF
--- a/src/core/app/actions/input.rs
+++ b/src/core/app/actions/input.rs
@@ -50,6 +50,7 @@ pub(super) fn handle_input_action(
         }
         AppAction::CompleteAssistantEdit { content } => {
             app.complete_assistant_edit(content);
+            update_scroll_after_command(app, ctx);
             None
         }
         _ => unreachable!("non-input action routed to input handler"),


### PR DESCRIPTION
## Summary
- ensure completing an assistant edit updates the transcript scroll position so the revised message is visible

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_690c6a9be1cc832b9829c04935ada76c