### PR TITLE
fix: Focus transcript after /help command to allow scrolling

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,7 @@ use std::io::{BufWriter, Write};
 
 pub enum CommandResult {
     Continue,
+    ContinueWithTranscriptFocus,
     ProcessAsMessage(String),
     OpenModelPicker,
     OpenProviderPicker,
@@ -48,7 +49,7 @@ pub(super) fn handle_help(app: &mut App, _invocation: CommandInvocation<'_>) -> 
     }
     app.conversation()
         .add_app_message(AppMessageKind::Info, help_md);
-    CommandResult::Continue
+    CommandResult::ContinueWithTranscriptFocus
 }
 
 pub(super) fn handle_clear(app: &mut App, _invocation: CommandInvocation<'_>) -> CommandResult {
@@ -535,7 +536,7 @@ mod tests {
     fn help_command_includes_registry_metadata() {
         let mut app = create_test_app();
         let result = process_input(&mut app, "/help");
-        assert!(matches!(result, CommandResult::Continue));
+        assert!(matches!(result, CommandResult::ContinueWithTranscriptFocus));
         let last_message = app.ui.messages.back().expect("help message");
         assert!(last_message
             .content

--- a/src/core/app/actions/input.rs
+++ b/src/core/app/actions/input.rs
@@ -72,6 +72,12 @@ fn handle_process_command(
             update_scroll_after_command(app, ctx);
             None
         }
+        CommandResult::ContinueWithTranscriptFocus => {
+            app.conversation().show_character_greeting_if_needed();
+            app.ui.focus_transcript();
+            update_scroll_after_command(app, ctx);
+            None
+        }
         CommandResult::ProcessAsMessage(message) => {
             Some(streaming::spawn_stream_for_message(app, message, ctx))
         }
@@ -175,5 +181,23 @@ mod tests {
         );
 
         assert!(app.picker_session().is_some());
+    }
+
+    #[test]
+    fn help_command_focuses_transcript() {
+        let mut app = create_test_app();
+        let ctx = default_ctx();
+        app.ui.focus_input();
+
+        let cmd = handle_input_action(
+            &mut app,
+            AppAction::ProcessCommand {
+                input: "/help".into(),
+            },
+            ctx,
+        );
+
+        assert!(cmd.is_none());
+        assert!(app.ui.is_transcript_focused());
     }
 }


### PR DESCRIPTION
The /help command displays help content in the transcript but was leaving focus on the input area, making it difficult for users to scroll through the help content without manually switching focus.

Changes:
- Add CommandResult::ContinueWithTranscriptFocus variant
- Update /help command to return the new variant
- Handle the new variant in input action handler to focus transcript

This allows users to immediately scroll through help content after executing the /help command.