### PR TITLE
Add Claude Web config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -n \"$CLAUDE_CODE_REMOTE\" ]; then sudo apt-get install -y libdbus-1-dev; fi"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I don't particularly like adding tool-specific settings to the repo, but for now, that's the only way to bootstrap Claude Web environments. Hoping to nuke it in future.