### PR TITLE
Set steady bar cursor for text input

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ Custom themes belong in `config.toml` under `[[custom_themes]]`. See [src/builti
 
 Themes can also set a `cursor_color` to change the terminal cursor via OSC 12 when the theme is applied.
 
+Input uses a steady bar cursor inside the chat box so the insertion point stays easy to see while typing.
+
 App messages—Chabeau’s own informational banners, warnings, and errors—use dedicated theme knobs so they’re easy to distinguish from assistant replies. Customize them with the `app_info_*`, `app_warning_*`, and `app_error_*` keys in your theme to control the prefix text, prefix styling, and message styling independently.
 
 ### Markdown and Syntax Highlighting

--- a/src/ui/chat_loop/lifecycle.rs
+++ b/src/ui/chat_loop/lifecycle.rs
@@ -1,6 +1,7 @@
 use std::{error::Error, io, io::Write, sync::Arc};
 
 use ratatui::crossterm::{
+    cursor::SetCursorStyle,
     event::{DisableBracketedPaste, EnableBracketedPaste},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -18,7 +19,12 @@ pub fn setup_terminal(cursor_color: Option<Color>) -> Result<SharedTerminal, Box
     enable_raw_mode()?;
 
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableBracketedPaste,
+        SetCursorStyle::SteadyBar
+    )?;
 
     if let Some(color) = cursor_color {
         queue_cursor_color(&mut stdout, color)?;
@@ -43,6 +49,7 @@ where
     guard.backend_mut().flush()?;
     execute!(
         guard.backend_mut(),
+        SetCursorStyle::DefaultUserShape,
         LeaveAlternateScreen,
         DisableBracketedPaste
     )?;


### PR DESCRIPTION
## Summary
- set the TUI cursor style to a steady bar while the chat UI is active and restore the default shape on exit
- note the steady bar input cursor in the README

## Testing
- cargo fmt
- cargo check
- cargo clippy
- cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed17bc7e8832ba1ca633457446271)