### PR TITLE
feat(mcp): support inspecting requests alongside responses

### DIFF
--- a/src/core/app/actions/mod.rs
+++ b/src/core/app/actions/mod.rs
@@ -35,6 +35,7 @@ pub enum AppAction {
     },
     ToolPromptInspect,
     InspectToolResults,
+    InspectToolResultsToggleView,
     InspectToolResultsStep {
         delta: i32,
     },
@@ -209,6 +210,7 @@ pub fn apply_action(app: &mut App, action: AppAction, ctx: AppActionContext) -> 
         | AppAction::CompleteInPlaceEdit { .. }
         | AppAction::CompleteAssistantEdit { .. }
         | AppAction::InspectToolResults
+        | AppAction::InspectToolResultsToggleView
         | AppAction::InspectToolResultsStep { .. } => input::handle_input_action(app, action, ctx),
 
         AppAction::PickerEscape

--- a/src/core/app/inspect.rs
+++ b/src/core/app/inspect.rs
@@ -31,7 +31,22 @@ impl InspectState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InspectMode {
     Static,
-    ToolResults { index: usize },
+    ToolResults { index: usize, view: ToolInspectView },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolInspectView {
+    Result,
+    Request,
+}
+
+impl ToolInspectView {
+    pub fn toggle(self) -> Self {
+        match self {
+            ToolInspectView::Result => ToolInspectView::Request,
+            ToolInspectView::Request => ToolInspectView::Result,
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -56,11 +71,17 @@ impl InspectController {
         self.state = Some(InspectState::new(title, content));
     }
 
-    pub fn open_tool_results(&mut self, title: String, content: String, index: usize) {
+    pub fn open_tool_results(
+        &mut self,
+        title: String,
+        content: String,
+        index: usize,
+        view: ToolInspectView,
+    ) {
         self.state = Some(InspectState::with_mode(
             title,
             content,
-            InspectMode::ToolResults { index },
+            InspectMode::ToolResults { index, view },
         ));
     }
 
@@ -106,8 +127,14 @@ impl App {
         self.inspect.open(title, content);
     }
 
-    pub fn open_tool_result_inspect(&mut self, title: String, content: String, index: usize) {
-        self.inspect.open_tool_results(title, content, index);
+    pub fn open_tool_result_inspect(
+        &mut self,
+        title: String,
+        content: String,
+        index: usize,
+        view: ToolInspectView,
+    ) {
+        self.inspect.open_tool_results(title, content, index, view);
     }
 
     pub fn close_inspect(&mut self) {

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -36,7 +36,7 @@ pub use actions::{
 };
 #[allow(unused_imports)]
 pub use conversation::ConversationController;
-pub use inspect::{InspectController, InspectMode, InspectState};
+pub use inspect::{InspectController, InspectMode, InspectState, ToolInspectView};
 #[cfg(test)]
 pub use picker::PickerData;
 #[allow(unused_imports)]

--- a/src/core/app/session.rs
+++ b/src/core/app/session.rs
@@ -106,9 +106,11 @@ impl ToolResultStatus {
 pub struct ToolResultRecord {
     pub tool_name: String,
     pub server_name: Option<String>,
+    pub server_id: Option<String>,
     pub status: ToolResultStatus,
     pub content: String,
     pub tool_call_id: Option<String>,
+    pub raw_arguments: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -528,16 +528,28 @@ pub fn ui(f: &mut Frame, app: &mut App) {
 
         let inspect_mode = app.inspect_state().map(|state| state.mode);
         let in_picker = app.picker_session().is_some();
-        let (line1, line2) = match inspect_mode {
-            Some(InspectMode::ToolResults { .. }) => (
-                "Esc=Close • ←/→=Prev/Next • ↑/↓=Scroll • PgUp/PgDn=Faster",
-                "Home/End=Jump",
-            ),
+        let (line1, line2): (String, String) = match inspect_mode {
+            Some(InspectMode::ToolResults { view, .. }) => {
+                let toggle_label = match view {
+                    crate::core::app::ToolInspectView::Result => "Tab=Show request",
+                    crate::core::app::ToolInspectView::Request => "Tab=Show result",
+                };
+                (
+                    format!(
+                        "Esc=Close • {} • ←/→=Prev/Next • ↑/↓=Scroll • PgUp/PgDn=Faster",
+                        toggle_label
+                    ),
+                    "Home/End=Jump".to_string(),
+                )
+            }
             _ if in_picker => (
-                "Esc=Back to picker • ↑/↓=Scroll • PgUp/PgDn=Faster",
-                "Home/End=Jump",
+                "Esc=Back to picker • ↑/↓=Scroll • PgUp/PgDn=Faster".to_string(),
+                "Home/End=Jump".to_string(),
             ),
-            _ => ("Esc=Close • ↑/↓=Scroll • PgUp/PgDn=Faster", "Home/End=Jump"),
+            _ => (
+                "Esc=Close • ↑/↓=Scroll • PgUp/PgDn=Faster".to_string(),
+                "Home/End=Jump".to_string(),
+            ),
         };
         let help_lines = vec![
             Line::from(Span::styled(line1, theme.system_text_style)),


### PR DESCRIPTION
Pressing [Tab] in the MCP inspector lets you toggle between request and response. (IMO the nicest experience for dealing with MCP request payloads of any common TUI.)