### PR TITLE
feat(mcp): YOLO setting to avoid an MCP server's permission prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Chabeau can track MCP servers over HTTP (streamable HTTP) or stdio and surface t
 - Pick a `transport` of `streamable-http` or `stdio`. HTTP transports use `base_url`; stdio transports require `command` and optional `args`/`env`.
 - Chabeau uses a built-in MCP client based on `rust-mcp-schema`; no extra MCP runtime is required.
 - Use `/mcp` to list configured servers; `/mcp <server-id>` connects on demand and writes server details to the transcript (tools, resources, templates, and prompts).
+- Tired of permission prompts? If you dare to live dangerously, use `/yolo <server-id>` to show the per-server YOLO setting, or `/yolo <server-id> on|off` to toggle it (YOLO skips permission prompts for that server).
 - Store bearer tokens with `chabeau mcp token <server>` (tokens are saved in the system keyring under the server id) for HTTP transports; stdio transports read auth from their environment.
 - For transport debugging, run `chabeau --debug-mcp` to write verbose MCP logs to `mcp.log` in the working directory.
 - To suppress MCP for a run even when configured, pass `--disable-mcp` (or `-d`).

--- a/examples/config.toml.sample
+++ b/examples/config.toml.sample
@@ -64,6 +64,7 @@ base_url = "http://localhost:3333"
 transport = "streamable-http"
 enabled = true
 allowed_tools = ["weather.lookup", "time.now"]
+# yolo = true  # Skip permission prompts for this server (use with care).
 # protocol_version = "2024-11-05"
 
 # Configure MCP servers that launch over stdio.
@@ -75,6 +76,7 @@ command = "mcp-server"
 args = ["--mode", "stdio"]
 # env = { MCP_TOKEN = "local-dev" }
 enabled = true
+# yolo = false
 
 # Add custom themes, each in its own [[custom_themes]] block.
 #

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -258,6 +258,25 @@ const COMMANDS: &[Command] = &[
         handler: super::handle_mcp,
     },
     Command {
+        name: "yolo",
+        usages: &[
+            CommandUsage {
+                syntax: "/yolo <server-id>",
+                description: "Show MCP YOLO mode for a server.",
+            },
+            CommandUsage {
+                syntax: "/yolo <server-id> on",
+                description: "Enable MCP YOLO mode for a server.",
+            },
+            CommandUsage {
+                syntax: "/yolo <server-id> off",
+                description: "Disable MCP YOLO mode for a server.",
+            },
+        ],
+        extra_help: &[],
+        handler: super::handle_yolo,
+    },
+    Command {
         name: "log",
         usages: &[CommandUsage {
             syntax: "/log [filename]",

--- a/src/core/app/actions/input.rs
+++ b/src/core/app/actions/input.rs
@@ -568,6 +568,7 @@ mod tests {
                 enabled: Some(true),
                 allowed_tools: None,
                 protocol_version: None,
+                yolo: None,
             });
         app.mcp = crate::mcp::client::McpClientManager::from_config(&app.config);
 

--- a/src/core/app/tests.rs
+++ b/src/core/app/tests.rs
@@ -231,6 +231,7 @@ fn build_stream_params_includes_mcp_tools() {
             allowed_tools: Some(vec!["search".to_string()]),
             protocol_version: None,
             enabled: Some(true),
+            yolo: None,
         });
     app.mcp = crate::mcp::client::McpClientManager::from_config(&app.config);
 
@@ -316,6 +317,7 @@ fn build_stream_params_includes_mcp_resources() {
             allowed_tools: None,
             protocol_version: None,
             enabled: Some(true),
+            yolo: None,
         });
     app.mcp = crate::mcp::client::McpClientManager::from_config(&app.config);
 
@@ -1047,6 +1049,7 @@ fn complete_slash_command_completes_mcp_server() {
         allowed_tools: None,
         protocol_version: None,
         enabled: Some(true),
+        yolo: None,
     });
     app.mcp = crate::mcp::client::McpClientManager::from_config(&app.config);
 
@@ -1059,6 +1062,36 @@ fn complete_slash_command_completes_mcp_server() {
     assert_eq!(
         app.ui.get_input_cursor_position(),
         "/mcp agpedia ".chars().count()
+    );
+}
+
+#[test]
+fn complete_slash_command_completes_yolo_server() {
+    let mut app = create_test_app();
+    app.config.mcp_servers.push(McpServerConfig {
+        id: "agpedia".to_string(),
+        display_name: "Agpedia".to_string(),
+        base_url: Some("https://mcp.example.com".to_string()),
+        command: None,
+        args: None,
+        env: None,
+        transport: Some("streamable-http".to_string()),
+        allowed_tools: None,
+        protocol_version: None,
+        enabled: Some(true),
+        yolo: None,
+    });
+    app.mcp = crate::mcp::client::McpClientManager::from_config(&app.config);
+
+    app.ui.set_input_text("/yolo agp".into());
+    app.ui.set_cursor_position("/yolo agp".chars().count());
+
+    let handled = app.complete_slash_command(80);
+    assert!(handled);
+    assert_eq!(app.ui.get_input_text(), "/yolo agpedia ");
+    assert_eq!(
+        app.ui.get_input_cursor_position(),
+        "/yolo agpedia ".chars().count()
     );
 }
 
@@ -1076,6 +1109,7 @@ fn complete_slash_command_lists_mcp_servers() {
         allowed_tools: None,
         protocol_version: None,
         enabled: Some(true),
+        yolo: None,
     });
     app.config.mcp_servers.push(McpServerConfig {
         id: "alpha".to_string(),
@@ -1088,6 +1122,7 @@ fn complete_slash_command_lists_mcp_servers() {
         allowed_tools: None,
         protocol_version: None,
         enabled: Some(true),
+        yolo: None,
     });
     app.mcp = crate::mcp::client::McpClientManager::from_config(&app.config);
 

--- a/src/core/app/ui_helpers.rs
+++ b/src/core/app/ui_helpers.rs
@@ -203,7 +203,7 @@ impl App {
         command_end: usize,
     ) -> bool {
         let command: String = chars[1..command_end].iter().collect();
-        if !command.eq_ignore_ascii_case("mcp") {
+        if !command.eq_ignore_ascii_case("mcp") && !command.eq_ignore_ascii_case("yolo") {
             return false;
         }
 

--- a/src/core/config/data.rs
+++ b/src/core/config/data.rs
@@ -80,6 +80,8 @@ pub struct McpServerConfig {
     pub allowed_tools: Option<Vec<String>>,
     pub protocol_version: Option<String>,
     pub enabled: Option<bool>,
+    #[serde(default)]
+    pub yolo: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
@@ -229,6 +231,10 @@ impl Config {
 impl McpServerConfig {
     pub fn is_enabled(&self) -> bool {
         self.enabled.unwrap_or(true)
+    }
+
+    pub fn is_yolo(&self) -> bool {
+        self.yolo.unwrap_or(false)
     }
 }
 

--- a/src/core/config/tests.rs
+++ b/src/core/config/tests.rs
@@ -664,6 +664,7 @@ fn test_mcp_server_config_persistence() {
             allowed_tools: Some(vec!["alpha.tool".to_string()]),
             protocol_version: Some("2024-11-05".to_string()),
             enabled: Some(false),
+            yolo: Some(true),
         }],
         ..Default::default()
     };
@@ -686,6 +687,7 @@ fn test_mcp_server_config_persistence() {
     );
     assert_eq!(server.protocol_version.as_deref(), Some("2024-11-05"));
     assert_eq!(server.enabled, Some(false));
+    assert_eq!(server.yolo, Some(true));
 }
 
 #[test]
@@ -708,6 +710,7 @@ fn test_mcp_server_stdio_config_persistence() {
             allowed_tools: None,
             protocol_version: None,
             enabled: Some(true),
+            yolo: None,
         }],
         ..Default::default()
     };

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -1964,6 +1964,7 @@ mod tests {
             allowed_tools: None,
             protocol_version: None,
             enabled: Some(true),
+            yolo: None,
         }
     }
 


### PR DESCRIPTION
Needless to say, I don't recommend using this for servers that can perform destructive actions or exfiltrate files, but it's not unreasonable for research assistants and the like, or for sandboxed environments. Use at your own risk.