### PR TITLE
fix: skip disabled MCP refresh; add toggling to /mcp command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This repository contains Chabeau, an open source (CC-0) chatbot TUI for remote A
 
 ## Commit summaries
 - When asked to draft a commit message, use a conventional commit format. The first line should be 50 characters wide max; subsequent lines 72 characters wide max. Keep it under 5 bullet points. Only summarize uncommitted (staged or working area) changes, not prior versions of those changes (e.g., if you refactored a function, and then refactored it again, only summarize its final state)
+- When constructing commit messages via CLI flags, prefer a single `-m` body with newline-separated bullets (or a heredoc) rather than multiple `-m` flags, to avoid extra blank lines between bullets.
 - When in interactive mode, present commit summaries to the user in a way that is easy to copy and paste with any formatting (e.g., markdown) intact.
 - Do not mention passing tests.
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ Chabeau lets you connect MCP servers (HTTP or stdio) and use their tools/resourc
 - Configure servers in `config.toml` using `[[mcp_servers]]` (see `examples/config.toml.sample`).
 - HTTP servers use `base_url` and need a token: `chabeau mcp token <server-id>`.
 - Stdio servers run a local command with optional `args`/`env`.
-- Use `/mcp` to list servers and `/mcp <server-id>` to view tools/resources/prompts.
+- Use `/mcp` to list servers and `/mcp <server-id>` to view tools/resources/prompts. Toggle with `/mcp <server-id> on|off` (saved to `config.toml`).
+- Disabled servers are not initialized by `/mcp <server-id>` until they are enabled.
 - If a tool needs approval, Chabeau will prompt you. Use Ctrl+O to inspect tool calls, D to decode nested JSON, and C to copy the current request/response payload.
 - Supports MCP tools, resources/templates (via `mcp_read_resource`), prompts, and sampling (`sampling/createMessage`).
 - Not supported yet: context inclusion, tasks, roots, or elicitation.

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -253,6 +253,14 @@ const COMMANDS: &[Command] = &[
                 syntax: "/mcp <server-id>",
                 description: "List MCP tools, resources, templates, and prompts.",
             },
+            CommandUsage {
+                syntax: "/mcp <server-id> on",
+                description: "Enable an MCP server and persist to config.toml.",
+            },
+            CommandUsage {
+                syntax: "/mcp <server-id> off",
+                description: "Disable an MCP server and persist to config.toml.",
+            },
         ],
         extra_help: &[],
         handler: super::handle_mcp,


### PR DESCRIPTION
- avoid /mcp refresh for disabled servers
- show disabled state in /mcp list output
- document disabled behavior in README
- add coverage for disabled server handling