### PR TITLE
docs: refresh architecture for MCP updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,72 +1,105 @@
-# Chabeau Architecture (commit 41e7ee64efbbab7e9be7deb9a81f18002dd7ea3e)
+# Chabeau Architecture (72dfb98beacfaf6511fe2f5ccdc4ec1f51c2be3a)
 
 ## System overview
 Chabeau is a terminal-first chat client that wraps OpenAI-compatible APIs behind a rich TUI. The
-crate is organised as a collection of focused modules that sit on top of Tokio for async orchestration,
-Reqwest for HTTP, and Ratatui for rendering. These dependencies are wired in via the crate manifest and
-kept minimal to ease distribution across platforms.【F:Cargo.toml†L1-L55】
+crate is organized as a collection of focused modules that sit on top of Tokio for async orchestration,
+Reqwest for HTTP, Ratatui for rendering, and rust-mcp-schema for Model Context Protocol (MCP) payloads
+and schema types.【F:Cargo.toml†L1-L55】
 
 ## Runtime entry points and CLI flow
-Execution begins in `src/main.rs`, which delegates immediately to the CLI module and exits with a non-zero
-status on failure so that shell scripting remains predictable.【F:src/main.rs†L1-L12】 The CLI builds a Tokio
-runtime, parses arguments with Clap, and routes subcommands such as `auth`, `deauth`, `set`, and `say`
-without touching the UI stack. Non-command invocations fall through to `handle_args`, which prepares a
-`CharacterService` and either performs management operations or launches the chat loop via `run_chat`.【F:src/cli/mod.rs†L201-L415】【F:src/cli/mod.rs†L287-L329】
+Execution begins in `src/main.rs`, which delegates to the CLI module and exits with a non-zero status
+on failure so that shell scripting remains predictable.【F:src/main.rs†L1-L12】 The CLI builds a Tokio
+runtime, parses arguments with Clap, and routes subcommands such as `auth`, `deauth`, `set`, `say`,
+and MCP token management without touching the UI stack.【F:src/cli/mod.rs†L201-L415】【F:src/cli/mod.rs†L726-L781】
+Global flags like `--debug-mcp` (trace logging) and `--disable-mcp` (session-wide MCP disable) are
+wired into the same entry path, ensuring they apply consistently to both TUI and one-shot `say`
+commands.【F:src/cli/mod.rs†L167-L739】【F:src/cli/say.rs†L267-L333】
 
 ## Chat session bootstrap
 When a chat session is requested the UI bootstrapper resolves configuration and credentials. It loads the
 user's config, consults the keyring-aware `AuthManager`, determines whether a provider picker must be shown,
-and prepares a fully initialised `App` when credentials are available. The bootstrapper also honours
+and prepares a fully initialized `App` when credentials are available. The bootstrapper also honors
 `--env` flows, surfaces provider resolution failures, and triggers model pickers when the selected provider
 lacks a default model.【F:src/ui/chat_loop/setup.rs†L19-L185】
 
 ## Core application state
 The heart of the runtime is the `App` struct, which packages the current session, UI state, pickers, shared
-character service, persona manager, preset manager, and configuration snapshot. This single owner makes it
-easy to mutate session state atomically within the async chat loop.【F:src/core/app/mod.rs†L53-L208】 Session
-metadata is tracked in `SessionContext`, including the active provider, HTTP client, logging sink, streaming
-bookkeeping, refine settings, and any loaded character greeting state so that downstream components can act
-without re-querying configuration.【F:src/core/app/session.rs†L23-L44】 During authenticated startup the app
-also activates personas and presets, falling back to provider/model defaults when no CLI override is present
-and recording any loading failures directly into the conversation transcript for visibility.【F:src/core/app/mod.rs†L81-L163】
+character service, persona manager, preset manager, configuration snapshot, plus the MCP client manager,
+MCP permission store, and inspection controller for tool-call introspection.【F:src/core/app/mod.rs†L53-L208】
+Session metadata is tracked in `SessionContext`, including the active provider, HTTP client, logging sink,
+streaming bookkeeping, tool-call queues, tool payload history, and MCP enablement flags so downstream
+components can act without re-querying configuration.【F:src/core/app/session.rs†L23-L148】
+
+## MCP configuration and authentication
+MCP servers are configured in `config.toml` using `McpServerConfig`, which supports HTTP base URLs, stdio
+commands, allowed tool lists, protocol overrides, payload retention policies, and per-server YOLO settings
+for auto-approval of tool calls.【F:src/core/config/data.rs†L70-L118】 Tokens for HTTP servers are stored in
+the system keyring by `McpTokenStore`, mirroring provider auth behavior while keeping secrets out of
+config files.【F:src/core/mcp_auth.rs†L1-L63】
+
+## MCP client subsystem
+The MCP client layer lives in `src/mcp/`, where `McpClientManager` owns per-server state, cached listings,
+and the active transport implementation.【F:src/mcp/client.rs†L1-L168】 Streamable HTTP and stdio transports
+are supported; stdio launches child processes and streams JSON-RPC frames over stdin/stdout, while HTTP uses
+SSE/streamable responses.【F:src/mcp/client.rs†L18-L209】 A lightweight registry filters enabled servers for
+tool discovery, and a permission store tracks per-tool approval decisions for the current session.【F:src/mcp/registry.rs†L1-L31】【F:src/mcp/permissions.rs†L1-L74】
+
+## Tool-calling and MCP execution pipeline
+When building a stream request, Chabeau injects MCP tool schemas, a built-in MCP preamble, and optional
+resource/template listings so that the model can call tools and request MCP resources. It also adds a tool
+payload retention note, a session tool ledger, and session memory blocks when tool payload retention is
+configured to summarize outputs.【F:src/core/app/streaming.rs†L9-L214】 Tool calls are queued, permission
+prompts are surfaced in the input area, and the execution path supports MCP tools, MCP resource reads,
+and MCP sampling (`sampling/createMessage`) requests with separate permission prompts or YOLO auto-approval.
+Tool results are summarized into the transcript while raw payload retention is governed by per-server policy
+(window/all/turn).【F:src/core/app/actions/streaming.rs†L980-L1611】
+
+## MCP slash commands and prompt invocation
+Slash commands in `commands/mod.rs` provide `/mcp` listings, per-server enable/disable toggles, `/yolo`
+for MCP auto-approval, and MCP prompt invocation (using `/server-id:prompt-id`) with interactive argument
+collection when required.【F:src/commands/mod.rs†L136-L735】 The event loop triggers background refreshes
+for MCP listings as commands are issued, keeping cached tools/resources/prompts up to date without blocking
+input.【F:src/ui/chat_loop/event_loop.rs†L123-L212】
 
 ## UI loop and action system
 The Ratatui event loop wraps the shared `App` inside an `AppHandle` so tasks can borrow it through an async
 mutex. Terminal setup, input polling, and resize handling feed `UiEvent`s into the dispatcher, which resolves
 mode-aware keymaps and emits high-level `AppAction`s. Actions are grouped by concern—streaming, input
 manipulation, picker interaction, and file prompts—and reducers can return `AppCommand`s that request new
-background work such as spawning a stream or loading models. Keybindings are managed by a dedicated registry
-that routes input events to handlers based on the active UI mode.【F:src/ui/chat_loop/mod.rs†L1-L42】【F:src/ui/chat_loop/event_loop.rs†L1-L200】【F:src/ui/chat_loop/keybindings/mod.rs†L1-L300】【F:src/core/app/actions/mod.rs†L1-L194】
+background work such as spawning a stream or running an MCP tool call.【F:src/ui/chat_loop/mod.rs†L1-L42】【F:src/ui/chat_loop/event_loop.rs†L1-L344】【F:src/core/app/actions/mod.rs†L1-L194】
 
-## Streaming pipeline
-Outgoing requests are encapsulated in `StreamParams` and executed by `ChatStreamService`. Each stream runs in
-a Tokio task that posts SSE frames into an unbounded channel, normalises malformed input, reports API errors
-with helpful Markdown summaries, and honours cancellation tokens so that user interrupts stop work promptly.【F:src/core/chat_stream.rs†L9-L349】
+## Tool inspection and decode workflow
+Tool calls and results can be inspected via a full-screen overlay managed by `InspectController`, which
+tracks the current tool index, view (request vs result), and a decoded flag for nested JSON display.
+Input actions allow users to toggle decoded views and navigate between tool records, while the renderer
+adds dedicated inspect chrome and keyboard hints for the overlay.【F:src/core/app/inspect.rs†L1-L155】【F:src/core/app/actions/input.rs†L206-L333】【F:src/ui/renderer.rs†L477-L560】
 
-## Configuration, providers, and authentication
-Persistent settings live in `core::config`, where TOML-backed structs capture defaults for providers, models,
-characters, personas, presets, and text refinement behaviour. These helpers also expose ergonomic display
-strings for config paths.【F:src/core/config/data.rs†L6-L187】 Provider resolution is mediated by the
-`AuthManager`, which merges built-in metadata, user-defined providers, and keyring lookups while allowing
-pure environment-based sessions as a fallback. Rich error types communicate next steps back to the CLI and
-bootstrapper.【F:src/auth/mod.rs†L1-L190】【F:src/core/providers.rs†L6-L200】
+## Tool result summaries and error labeling
+Tool call outcomes are summarized into readable transcript entries that include per-server labels and
+argument summaries. Failed tool calls are categorized into “tool error” vs “tool call failure” to make
+API issues easier to diagnose and are reflected in both summary strings and status labels.【F:src/core/app/session.rs†L84-L140】【F:src/core/app/actions/streaming.rs†L1445-L1635】
+
+## UI rendering and performance safeguards
+Rendering is handled by `ui::renderer`, which composes the chat transcript, pickers, tool prompts, and
+inspection overlays using Ratatui layout primitives.【F:src/ui/renderer.rs†L17-L560】 The event loop adapts
+its polling interval and inserts idle sleeps when no input or animation is occurring, reducing idle CPU
+usage without impacting responsiveness during active sessions.【F:src/ui/chat_loop/event_loop.rs†L1054-L1312】
 
 ## Characters, personas, and presets
 Character cards are cached and resolved by `CharacterService`, which invalidates stale entries when cache keys
 change, supports direct path loads, and falls back to metadata scans when necessary. It also cooperates with
-session bootstrapping to honour per-provider defaults.【F:src/character/service.rs†L49-L189】 Personas and
+session bootstrapping to honor per-provider defaults.【F:src/character/service.rs†L49-L189】 Personas and
 presets are managed by dedicated managers loaded during app construction so that the UI can swap identities
 or prompt templates without reloading config from disk.【F:src/core/app/mod.rs†L81-L148】【F:src/core/persona.rs†L1-L200】【F:src/core/preset.rs†L1-L200】
 
 ## Commands and input routing
 Slash commands share a central registry that distinguishes between messages and control commands. Handlers can
-return `CommandResult` variants instructing the UI to continue, pass the text to the model, toggle UI features, trigger message refinement, or open pickers
-for themes, providers, models, characters, personas, and presets. File and logging commands reuse shared
-controllers so that interactive flows stay consistent across keyboard shortcuts and slash commands.【F:src/commands/mod.rs†L4-L200】
+return `CommandResult` variants instructing the UI to continue, pass the text to the model, toggle UI features,
+trigger message refinement, or open pickers for themes, providers, models, characters, personas, presets, or
+MCP servers/prompts. File and logging commands reuse shared controllers so that interactive flows stay
+consistent across keyboard shortcuts and slash commands.【F:src/commands/mod.rs†L4-L735】
 
-## UI rendering
-Rendering is handled by `ui::renderer`, which composes the chat transcript, pickers, and input area using
-Ratatui layout primitives. It caches wrapped lines for performance, adapts styling when pickers are open, and
-projects mode-specific prompts (e.g., compose, edit, or streaming indicators) into the title bar. Scroll state
-and OSC hyperlink metadata are recomputed only when necessary to keep redraws responsive.【F:src/ui/renderer.rs†L17-L200】
-
+## Streaming pipeline
+Outgoing requests are encapsulated in `StreamParams` and executed by `ChatStreamService`. Each stream runs in
+a Tokio task that posts SSE frames into an unbounded channel, normalizes malformed input, reports API errors
+with helpful Markdown summaries, and honors cancellation tokens so that user interrupts stop work promptly.【F:src/core/chat_stream.rs†L9-L349】

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Once set, press Ctrl+T in the TUI to launch the external editor.
 
 ## Architecture Overview
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for a high-level walkthrough aligned with commit 5d81609a33ce1abeef3ccb976b5387c474221511.
+See [ARCHITECTURE.md](ARCHITECTURE.md) for a high-level walkthrough aligned with the current repository state.
 
 Chabeau uses a modular design with focused components:
 
@@ -461,8 +461,15 @@ Chabeau uses a modular design with focused components:
     - `printing.rs` – CLI-facing config print helpers
     - `tests.rs` – Configuration module tests
   - `keyring.rs` – Secure storage for API keys
-  - `message.rs` – Message data structures
-  - `persona.rs` – Persona management and variable substitution
+- `message.rs` – Message data structures
+- `mcp/` – Model Context Protocol client integration
+  - `client.rs` – MCP transport and connection handling for HTTP and stdio
+  - `events.rs` – MCP server request envelopes
+  - `mod.rs` – MCP module exports and tool name constants
+  - `permissions.rs` – Per-tool permission decision store
+  - `registry.rs` – Enabled MCP server registry
+- `mcp_auth.rs` – Keyring-backed MCP token storage
+- `persona.rs` – Persona management and variable substitution
   - `preset.rs` – System instruction preset management
   - `text_wrapping.rs` – Text wrapping utilities
 - `ui/` – Terminal interface rendering


### PR DESCRIPTION
### Motivation

- Bring the architecture documentation up to date to reflect the implemented Model Context Protocol (MCP) client and related UX/features. 
- Surface how MCP integrates with config, auth, streaming, permission prompts, and inspection so maintainers and contributors can find relevant code paths quickly.

### Description

- Expanded `ARCHITECTURE.md` with new sections covering MCP configuration and authentication, the MCP client subsystem (`src/mcp/`), the tool-calling and MCP execution pipeline (tool schema injection, resource/template exposure, payload retention), slash commands and prompt invocation (`/mcp`, `/yolo`, MCP prompt invocation), tool inspection and decode workflow, and tool result summaries/error labeling. 
- Updated `README.md` architecture overview to list the new `mcp/` module and `mcp_auth.rs` alongside existing modules so the top-level module inventory matches the repo state. 
- Documentation focuses on implemented behavior such as streamable HTTP and stdio transports, keyring-backed MCP tokens, per-tool permission store, queued tool execution with permission gating, session memory/payload retention policies, and UI rendering/idle polling notes.

### Testing

- Ran `cargo fmt` and formatting completed successfully. 
- Ran `cargo check` and the project compiled with the development profile without errors. 
- Ran `cargo test` and the test suite completed successfully (all unit tests and doctests passed). 
- Ran `cargo clippy` with no blocking issues reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f07c0fa64832bb2138032fb9e8232)