### PR TITLE
Add shortcut for copying user messages to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Chabeau is a full-screen terminal chat interface that connects to various AI API
 - Conversation logging with pause/resume; quick `/dump` of contents to a file
 - Syntax highlighting for fenced code blocks (Python, Bash, JavaScript, and more)
 - Inline block selection (Ctrl+B) to copy or save fenced code blocks
+- User message selection (Ctrl+P) to revisit and copy prior prompts
 - Assistant message editing (Ctrl+X) to revise or truncate assistant responses without resending, with compose-mode shortcuts available while refining replies
 - Prettified API error output with Markdown summaries for easier troubleshooting
 

--- a/src/builtins/help.md
+++ b/src/builtins/help.md
@@ -13,7 +13,7 @@ Find a bug? Let us know: https://github.com/permacommons/chabeau/issues
 - Ctrl+N: Re-run the most recent `/refine` prompt
 - Ctrl+D: Exit when input is empty (prints transcript); otherwise [Del]
 - Ctrl+C: Exit immediately (no transcript)
-- Ctrl+P: Edit previous messages (select mode)
+- Ctrl+P: Edit previous messages (select mode; C=copy)
 - Ctrl+X: Edit assistant messages (select mode)
 - Ctrl+B: Select code blocks (copy `c`, save `s`)
 - Ctrl+L: Clear status message

--- a/src/ui/chat_loop/modes.rs
+++ b/src/ui/chat_loop/modes.rs
@@ -267,6 +267,21 @@ pub async fn handle_edit_select_mode_event(
                 }
                 true
             }
+            KeyCode::Char('c') | KeyCode::Char('C') => {
+                if matches!(target, EditSelectTarget::User) {
+                    if let Some(idx) = app.ui.selected_user_message_index() {
+                        if let Some(message) = app.ui.messages.get(idx) {
+                            if message.role == ROLE_USER {
+                                match crate::utils::clipboard::copy_to_clipboard(&message.content) {
+                                    Ok(()) => app.conversation().set_status("Copied message"),
+                                    Err(_e) => app.conversation().set_status("Clipboard error"),
+                                }
+                            }
+                        }
+                    }
+                }
+                true
+            }
 
             _ => false,
         }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -201,7 +201,7 @@ pub fn ui(f: &mut Frame, app: &mut App) {
             }
             _ => {
                 Cow::Borrowed(
-                    "Select user message (↑/↓ • Enter=Edit→Truncate • e=Edit in place • Del=Truncate • Esc=Cancel)",
+                    "Select user message (↑/↓ • Enter=Edit→Truncate • e=Edit in place • Del=Truncate • c=Copy • Esc=Cancel)",
                 )
             }
         }


### PR DESCRIPTION
When cycling through user messages with Ctrl+P, C will now copy the message content to the clipboard.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb13cc4bc832b9bff6aaaac9798c2)