### PR TITLE
Suppress OSC links during modal overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Chabeau is a full-screen terminal chat interface that connects to various AI API
 
 - Full-screen terminal UI with real-time streaming responses
 - Markdown rendering in the chat area (headings, lists, quotes, tables, callouts, horizontal rules, superscript/subscript, inline/fenced code) with clickable OSC 8 hyperlinks
+- Modal pickers and inspectors temporarily suspend hyperlink rendering to keep the screen clean
 - Built-in support for many common providers (OpenAI, OpenRouter, Poe, Anthropic, Venice AI, Groq, Mistral, Cerebras)
 - Support for quick custom configuration of new OpenAI-compatible providers
 - Interactive dialogs for selecting models and providers

--- a/src/cli/settings/error.rs
+++ b/src/cli/settings/error.rs
@@ -36,7 +36,9 @@ impl SettingError {
                 eprintln!("❌ Unknown config key: {key}");
             }
             SettingError::UnknownProvider { input } => {
-                eprintln!("❌ Unknown provider: {input}. Run 'chabeau -p' to list available providers.");
+                eprintln!(
+                    "❌ Unknown provider: {input}. Run 'chabeau -p' to list available providers."
+                );
             }
             SettingError::UnknownTheme { input } => {
                 eprintln!(

--- a/src/cli/settings/handlers/boolean.rs
+++ b/src/cli/settings/handlers/boolean.rs
@@ -42,7 +42,11 @@ impl SettingHandler for BooleanHandler {
         Ok(format!("✅ Set {key} to: {display}"))
     }
 
-    fn unset(&self, _args: Option<&str>, _ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
+    fn unset(
+        &self,
+        _args: Option<&str>,
+        _ctx: &mut SetContext<'_>,
+    ) -> Result<String, SettingError> {
         let set_field = self.set_field;
 
         mutate_config(move |config| {

--- a/src/cli/settings/handlers/mcp.rs
+++ b/src/cli/settings/handlers/mcp.rs
@@ -58,8 +58,7 @@ impl SettingHandler for McpHandler {
         // Check if this is a yolo setting: `mcp <server> yolo on/off`
         if args.len() >= 3 && args[1].eq_ignore_ascii_case("yolo") {
             let value_input = args[2..].join(" ");
-            let yolo =
-                parse_bool(&value_input).ok_or(SettingError::InvalidBoolean(value_input))?;
+            let yolo = parse_bool(&value_input).ok_or(SettingError::InvalidBoolean(value_input))?;
             let display = format_bool(yolo);
             let server_id_owned = server_id.clone();
 
@@ -82,8 +81,7 @@ impl SettingHandler for McpHandler {
 
         // Otherwise it's an enabled setting: `mcp <server> on/off`
         let value_input = args[1..].join(" ");
-        let enabled =
-            parse_bool(&value_input).ok_or(SettingError::InvalidBoolean(value_input))?;
+        let enabled = parse_bool(&value_input).ok_or(SettingError::InvalidBoolean(value_input))?;
         let display = format_bool(enabled);
         let server_id_owned = server_id.clone();
 

--- a/src/cli/settings/handlers/provider_keyed.rs
+++ b/src/cli/settings/handlers/provider_keyed.rs
@@ -54,7 +54,9 @@ impl SettingHandler for DefaultModelHandler {
             Ok(())
         })?;
 
-        Ok(format!("✅ Unset default-model for provider: {provider_msg}"))
+        Ok(format!(
+            "✅ Unset default-model for provider: {provider_msg}"
+        ))
     }
 
     fn format(&self, config: &Config) -> String {

--- a/src/cli/settings/handlers/simple.rs
+++ b/src/cli/settings/handlers/simple.rs
@@ -33,7 +33,11 @@ impl SettingHandler for DefaultProviderHandler {
         Ok(format!("✅ Set default-provider to: {msg}"))
     }
 
-    fn unset(&self, _args: Option<&str>, _ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
+    fn unset(
+        &self,
+        _args: Option<&str>,
+        _ctx: &mut SetContext<'_>,
+    ) -> Result<String, SettingError> {
         mutate_config(|config| {
             config.default_provider = None;
             Ok(())
@@ -78,7 +82,11 @@ impl SettingHandler for ThemeHandler {
         Ok(format!("✅ Set theme to: {msg}"))
     }
 
-    fn unset(&self, _args: Option<&str>, _ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
+    fn unset(
+        &self,
+        _args: Option<&str>,
+        _ctx: &mut SetContext<'_>,
+    ) -> Result<String, SettingError> {
         mutate_config(|config| {
             config.theme = None;
             Ok(())

--- a/src/cli/settings/handlers/string.rs
+++ b/src/cli/settings/handlers/string.rs
@@ -32,7 +32,11 @@ impl SettingHandler for RefineInstructionsHandler {
         Ok(format!("✅ Set refine-instructions to: {display}"))
     }
 
-    fn unset(&self, _args: Option<&str>, _ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
+    fn unset(
+        &self,
+        _args: Option<&str>,
+        _ctx: &mut SetContext<'_>,
+    ) -> Result<String, SettingError> {
         mutate_config(|config| {
             config.refine_instructions = None;
             Ok(())
@@ -97,7 +101,11 @@ impl SettingHandler for RefinePrefixHandler {
         Ok(format!("✅ Set refine-prefix to: {msg}"))
     }
 
-    fn unset(&self, _args: Option<&str>, _ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
+    fn unset(
+        &self,
+        _args: Option<&str>,
+        _ctx: &mut SetContext<'_>,
+    ) -> Result<String, SettingError> {
         mutate_config(|config| {
             config.refine_prefix = None;
             Ok(())

--- a/src/core/config/defaults.rs
+++ b/src/core/config/defaults.rs
@@ -107,5 +107,4 @@ impl Config {
             output
         }
     }
-
 }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -142,10 +142,10 @@ pub fn ui(f: &mut Frame, app: &mut App) {
     let title_text = build_main_title(app, chunks[0].width);
     let block = Block::default().title(Span::styled(title_text, app.ui.theme.title_style));
     let inner_area = block.inner(chunks[0]);
-    let picker_active = app.picker_state().is_some();
+    let suppress_links = suppress_link_rendering(app);
 
     let mut messages_lines = lines.clone();
-    if picker_active {
+    if suppress_links {
         for (line, kinds) in messages_lines.iter_mut().zip(span_metadata.iter()) {
             for (span, kind) in line.spans.iter_mut().zip(kinds.iter()) {
                 if matches!(kind, SpanKind::Link(_)) {
@@ -164,7 +164,7 @@ pub fn ui(f: &mut Frame, app: &mut App) {
 
     f.render_widget(messages_paragraph, chunks[0]);
 
-    if picker_active {
+    if suppress_links {
         set_render_state(OscRenderState::default());
     } else {
         let state = compute_render_state(
@@ -642,6 +642,10 @@ pub fn ui(f: &mut Frame, app: &mut App) {
         let help = Paragraph::new(help_text.as_str()).style(app.ui.theme.system_text_style);
         f.render_widget(help, help_area);
     }
+}
+
+fn suppress_link_rendering(app: &App) -> bool {
+    app.picker_state().is_some() || app.inspect_state().is_some()
 }
 
 fn tool_prompt_insert_index(


### PR DESCRIPTION
**What Changed**
Modal overlays (pickers and inspectors) now consistently suspend OSC hyperlink rendering and underline styling while they are open. This prevents residual link markers from persisting behind the overlay and keeps the terminal display clean and predictable. The suppression rule is centralized in a small helper used by the renderer.

**Impact**
Users no longer see lingering hyperlink markers when any inspector or picker modal is open. UI behavior is more consistent across modal types.
