### PR TITLE
Unify MCP progress with main pulsing activity indicator

### DIFF
--- a/src/core/app/streaming.rs
+++ b/src/core/app/streaming.rs
@@ -23,6 +23,30 @@ impl App {
         self.conversation().cancel_current_stream();
     }
 
+    pub fn begin_mcp_operation(&mut self) -> CancellationToken {
+        let token = CancellationToken::new();
+        self.session.stream_cancel_token = Some(token.clone());
+        self.ui.stream_interrupted = false;
+        self.ui
+            .begin_activity(crate::core::app::ui_state::ActivityKind::McpOperation);
+        token
+    }
+
+    pub fn end_mcp_operation_if_active(&mut self) {
+        if matches!(
+            self.ui.activity_kind(),
+            Some(crate::core::app::ui_state::ActivityKind::McpOperation)
+        ) {
+            self.ui
+                .end_activity(crate::core::app::ui_state::ActivityKind::McpOperation);
+        }
+        self.session.stream_cancel_token = None;
+    }
+
+    pub fn has_interruptible_activity(&self) -> bool {
+        self.ui.is_streaming || self.session.stream_cancel_token.is_some()
+    }
+
     pub fn enable_auto_scroll(&mut self) {
         self.ui.auto_scroll = true;
     }

--- a/src/core/app/ui_state.rs
+++ b/src/core/app/ui_state.rs
@@ -21,6 +21,9 @@ pub enum ActivityKind {
 
     /// Refreshing MCP tools/resources/prompts.
     McpRefresh,
+
+    /// Executing MCP operations such as tool calls and sampling.
+    McpOperation,
 }
 
 /// Type of file operation prompt being displayed.
@@ -466,6 +469,10 @@ impl UiState {
 
     pub fn is_activity_indicator_visible(&self) -> bool {
         self.activity_indicator.is_some()
+    }
+
+    pub fn activity_kind(&self) -> Option<ActivityKind> {
+        self.activity_indicator
     }
 
     pub fn begin_streaming(&mut self) {


### PR DESCRIPTION
Resolves #327

### Motivation
- Replace separate MCP progress/status reporting with the same pulsing activity indicator used for chat streaming so MCP operations are visible in the main UI area and share the same interrupt/cancel semantics.
- Keep MCP permission prompts unchanged while making longer-running MCP work (tool calls, sampling, init waits) use the unified indicator and interruption model.

### Description
- Add a new activity kind `ActivityKind::McpOperation` and expose current activity via `UiState::activity_kind`, and introduce app helpers `begin_mcp_operation`, `end_mcp_operation_if_active`, and `has_interruptible_activity` to manage MCP lifecycle state (`src/core/app/ui_state.rs`, `src/core/app/streaming.rs`).
- Route MCP waiting/status flows to the pulsing indicator by calling `begin_mcp_operation` in `set_status_for_mcp_wait`, `set_status_for_tool_run`, and `set_status_for_sampling_run`, and clear activity on completion with `end_mcp_operation_if_active` (changes in `src/core/app/actions/streaming.rs` and `src/core/app/streaming.rs`).
- Render an `[MCP]` label next to the pulsing indicator when an MCP operation is active, and treat MCP operations as interruptible for the input title hint by using `has_interruptible_activity` in the renderer (`src/ui/renderer.rs`).
- Wire the Escape key to cancel interruptible MCP activity in addition to normal streaming by checking `has_interruptible_activity` and dispatching `AppAction::CancelStreaming` (`src/ui/chat_loop/keybindings/handlers.rs`).
- Make MCP tool and sampling execution cancellation-aware by adding `run_cancellable` and threading the optional `stream_cancel_token` into `spawn_mcp_tool_call` and `spawn_mcp_sampling_call` so user interruption can abort MCP operations early and signal the server (`src/ui/chat_loop/event_loop.rs`).
- Add/update focused unit tests for the new behavior: `activity_indicator_label_marks_mcp_operations`, `escape_handler_cancels_interruptible_mcp_activity`, and `tool_run_uses_activity_indicator_and_clears_on_completion` (`src/ui/renderer.rs`, `src/ui/chat_loop/keybindings/handlers.rs`, `src/core/app/actions/streaming.rs`).
- Document the unified indicator behavior in `README.md`.

### Testing
- Ran formatting with `cargo fmt` (success).
- Built the project with `cargo check` (success).
- Ran the full test suite with `cargo test`, including the new unit tests, where all tests passed (`690 passed; 0 failed` shown locally).
- Ran linting with `cargo clippy` (no blocking warnings for the checked invocation; developer clippy run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9e980610832ba3ce533ceea18ba0)