### PR TITLE
feat(mcp): refresh OAuth grants for HTTP auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Chabeau lets you connect MCP servers (HTTP or stdio) and use their tools/resourc
 - `chabeau mcp add` runs in basic mode and prompts only for required settings; use `-a`/`--advanced` to configure optional fields during add.
 - HTTP servers can use bearer tokens with `chabeau mcp token list [server-id]`, `chabeau mcp token add <server-id>`, and `chabeau mcp token remove <server-id>`.
 - `chabeau mcp add` probes OAuth discovery for HTTP/HTTPS servers and starts browser auth when available. You can also run `chabeau mcp oauth list [server-id]`, `chabeau mcp oauth add <server-id>`, and `chabeau mcp oauth remove <server-id>` directly. Use `chabeau mcp oauth add <server-id> -a` to provide an OAuth client id manually.
+- For OAuth-backed MCP HTTP servers, Chabeau automatically refreshes expiring access tokens when a refresh token is available; if refresh fails, re-run `chabeau mcp oauth add <server-id>`.
 - Stdio servers run a local command with optional `args` and `env`.
 - In the TUI, `/mcp` lists servers and `/mcp <server-id>` shows server info. Toggle with `/mcp <server-id> on|off` (or `chabeau set mcp <server-id> on|off`). To also clear session runtime MCP state, use `/mcp <server-id> forget` instead.
 - If a tool requires approval, Chabeau prompts you; use `/yolo <server-id> on|off` (or `chabeau set mcp <server-id> yolo on|off`) for per-server auto-approve.


### PR DESCRIPTION
### Motivation
- Ensure MCP HTTP authentication stays valid by refreshing expiring OAuth access tokens when a `refresh_token` is available. 
- Keep token handling consistent between initial authorization and later refreshes and provide clear guidance when refresh fails so users can re-authenticate.

### Description
- Add reusable helpers in `src/cli/mod.rs`: `refresh_oauth_access_token` to call the token endpoint with `grant_type=refresh_token`, `refresh_oauth_grant_if_needed` to decide when to refresh and persist updates, `apply_oauth_token_response` to merge token responses into an `McpOAuthGrant`, `oauth_grant_needs_refresh` (60s safety window), and `current_unix_epoch_s` for time handling.
- Refactor `add_oauth_grant_for_server` to use the shared token-response/grant-application helper so initial grant storage and refresh flows share the same persistence logic and bearer token mirroring via `McpTokenStore::set_oauth_grant` and `set_token`.
- Update MCP connect flow in `src/mcp/client.rs` to attempt `refresh_oauth_grant_if_needed` prior to reading the bearer token for HTTP transports and to surface a clear re-auth message when refresh fails while preserving existing fallback behavior.
- Add focused unit tests in `src/cli/mod.rs` for expiry-window logic and token-response/grant merging and add a small README note documenting automatic refresh behavior for OAuth-backed MCP servers.

### Testing
- Ran `cargo fmt` successfully to format changes.
- Ran `cargo check` successfully to validate compilation.
- Ran `cargo test` and all unit tests passed, including the newly added tests for refresh decision and token response handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c1a18c1e8832ba40433f1f88fab2d)