### PR TITLE
refactor: split MCP transport modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,8 +517,12 @@ Chabeau uses a modular design with focused components:
   - `oauth.rs` – Shared MCP OAuth discovery, browser flow, callback handling, and token refresh helpers
 - `message.rs` – Message data structures
 - `mcp/` – Model Context Protocol client integration
-  - `client.rs` – MCP transport and connection handling for HTTP and stdio
+  - `client.rs` – MCP client orchestration, cache updates, and server state
   - `events.rs` – MCP server request envelopes
+  - `transport/` – MCP transport implementations and shared interfaces
+    - `mod.rs` – Shared transport traits, enums, and list-fetch helpers
+    - `stdio.rs` – Stdio transport request/list adapters
+    - `streamable_http.rs` – Streamable HTTP transport list adapters
   - `mod.rs` – MCP module exports and tool name constants
   - `permissions.rs` – Per-tool permission decision store
   - `registry.rs` – Enabled MCP server registry

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2,6 +2,7 @@ pub mod client;
 pub mod events;
 pub mod permissions;
 pub mod registry;
+pub mod transport;
 
 pub const MCP_READ_RESOURCE_TOOL: &str = "mcp_read_resource";
 pub const MCP_LIST_RESOURCES_TOOL: &str = "mcp_list_resources";

--- a/src/mcp/transport/mod.rs
+++ b/src/mcp/transport/mod.rs
@@ -1,0 +1,78 @@
+use crate::core::config::data::McpServerConfig;
+use async_trait::async_trait;
+use rust_mcp_schema::schema_utils::{RequestFromClient, ServerMessage};
+use rust_mcp_schema::{
+    InitializeRequestParams, InitializeResult, ListPromptsResult, ListResourceTemplatesResult,
+    ListResourcesResult, ListToolsResult,
+};
+
+pub mod stdio;
+pub mod streamable_http;
+
+pub const MCP_METHOD_NOT_FOUND: i64 = -32601;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpTransportKind {
+    StreamableHttp,
+    Stdio,
+}
+
+pub enum ListFetch<T> {
+    Ok(T, Option<String>),
+    MethodNotFound(Option<String>),
+    Err(String),
+}
+
+#[async_trait]
+pub trait McpTransport {
+    async fn initialize(
+        &mut self,
+        request: InitializeRequestParams,
+    ) -> Result<InitializeResult, String>;
+
+    async fn send_request(&mut self, request: RequestFromClient) -> Result<ServerMessage, String>;
+
+    async fn list_tools(&mut self) -> ListFetch<ListToolsResult>;
+
+    async fn list_resources(&mut self) -> ListFetch<ListResourcesResult>;
+
+    async fn list_resource_templates(&mut self) -> ListFetch<ListResourceTemplatesResult>;
+
+    async fn list_prompts(&mut self) -> ListFetch<ListPromptsResult>;
+}
+
+pub fn list_fetch_from_response<T>(
+    response: Result<ServerMessage, String>,
+    parse: impl FnOnce(ServerMessage) -> Result<T, String>,
+) -> ListFetch<T> {
+    match response {
+        Ok(message) if is_method_not_found(&message) => ListFetch::MethodNotFound(None),
+        Ok(message) => match parse(message) {
+            Ok(list) => ListFetch::Ok(list, None),
+            Err(err) => ListFetch::Err(err),
+        },
+        Err(err) => ListFetch::Err(err),
+    }
+}
+
+pub fn is_method_not_found(message: &ServerMessage) -> bool {
+    matches!(
+        message,
+        ServerMessage::Error(error) if error.error.code == MCP_METHOD_NOT_FOUND
+    )
+}
+
+impl McpTransportKind {
+    pub fn from_config(config: &McpServerConfig) -> Result<Self, String> {
+        let transport = config
+            .transport
+            .as_deref()
+            .unwrap_or("streamable-http")
+            .to_ascii_lowercase();
+        match transport.as_str() {
+            "streamable-http" | "streamable_http" | "http" => Ok(McpTransportKind::StreamableHttp),
+            "stdio" => Ok(McpTransportKind::Stdio),
+            other => Err(format!("Unsupported MCP transport: {}", other)),
+        }
+    }
+}

--- a/src/mcp/transport/stdio.rs
+++ b/src/mcp/transport/stdio.rs
@@ -1,0 +1,15 @@
+use rust_mcp_schema::schema_utils::{RequestFromClient, ServerMessage};
+
+use super::{list_fetch_from_response, ListFetch};
+
+pub async fn fetch_list<T>(
+    send: impl std::future::Future<Output = Result<ServerMessage, String>>,
+    parse: impl FnOnce(ServerMessage) -> Result<T, String>,
+) -> ListFetch<T> {
+    let response = send.await;
+    list_fetch_from_response(response, parse)
+}
+
+pub fn list_request(request: RequestFromClient) -> RequestFromClient {
+    request
+}

--- a/src/mcp/transport/streamable_http.rs
+++ b/src/mcp/transport/streamable_http.rs
@@ -1,0 +1,10 @@
+use rust_mcp_schema::schema_utils::ServerMessage;
+
+use super::{list_fetch_from_response, ListFetch};
+
+pub fn fetch_list<T>(
+    response: Result<ServerMessage, String>,
+    parse: impl FnOnce(ServerMessage) -> Result<T, String>,
+) -> ListFetch<T> {
+    list_fetch_from_response(response, parse)
+}


### PR DESCRIPTION
### Motivation
- Make MCP transport implementations pluggable and isolate transport-specific code from orchestration logic for maintainability.
- Remove duplication across tool/resource/template/prompt refresh paths by centralizing listing logic and session/cache updates.
- Preserve existing semantics for method-not-found responses and empty-list cache fallbacks while simplifying the refresh code paths.

### Description
- Add a new transport namespace `src/mcp/transport/` with `mod.rs` for shared types and helpers and adapters in `stdio.rs` and `streamable_http.rs` (new files: `src/mcp/transport/mod.rs`, `src/mcp/transport/stdio.rs`, `src/mcp/transport/streamable_http.rs`).
- Refactor `McpClientManager` (`src/mcp/client.rs`) to export and use `McpTransportKind`, move transport helpers into `transport/`, and replace duplicated `refresh_*` implementations with a generic `refresh_listing` pipeline and `fetch_*_listing` helpers.
- Keep `apply_list_fetch` as the centralized cache/session/error updater and map `MethodNotFound` into empty cached lists to preserve previous fallback behavior for tools/resources/resource templates/prompts.
- Update `README.md` architecture notes to document the new `mcp/transport/` layout and clarify `client.rs` responsibilities.

### Testing
- Ran `cargo fmt` which completed successfully.
- Ran `cargo check` which finished successfully.
- Ran `cargo test` and all unit tests passed (`698 passed; 0 failed`).
- Ran `cargo clippy --all-targets --all-features` which completed successfully (only existing warnings unrelated to this refactor were emitted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d2f44a4c0832ba2e4deac62efd9f3)