### PR TITLE
mcp: reuse pooled reqwest Client per server

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Chabeau lets you connect MCP servers (HTTP or stdio) and use their tools/resourc
 - Manage servers from the CLI: `chabeau mcp list`, `chabeau mcp add`, `chabeau mcp add -a`, `chabeau mcp edit <server-id>`, and `chabeau mcp remove <server-id>`.
 - `chabeau mcp add` runs in basic mode and prompts only for required settings; use `-a`/`--advanced` to configure optional fields during add.
 - HTTP servers can use bearer tokens with `chabeau mcp token list [server-id]`, `chabeau mcp token add <server-id>`, and `chabeau mcp token remove <server-id>`.
+- Streamable HTTP transport reuses pooled HTTP connections across MCP initialize/list/tool calls for lower request overhead.
 - `chabeau mcp add` probes OAuth discovery for HTTP/HTTPS servers and starts browser auth when available. You can also run `chabeau mcp oauth list [server-id]`, `chabeau mcp oauth add <server-id>`, and `chabeau mcp oauth remove <server-id>` directly. Use `chabeau mcp oauth add <server-id> -a` to provide an OAuth client id manually.
 - For OAuth-backed MCP HTTP servers, Chabeau automatically refreshes expiring access tokens when a refresh token is available; if refresh fails, re-run `chabeau mcp oauth add <server-id>`.
 - Stdio servers run a local command with optional `args` and `env`.


### PR DESCRIPTION
### Motivation
- Reduce per-request overhead by reusing a single configured `reqwest::Client` per MCP server instead of calling `reqwest::Client::new()` on every HTTP call.
- Keep request-specific state (Authorization header, `mcp-session-id`, protocol version) attached per request while improving connection pooling and timeouts.
- Validate session persistence and repeated list calls behave identically after switching to a shared client.

### Description
- Add a per-server `http_client: Option<reqwest::Client>` field to `McpServerState` and propagate it into `McpToolCallContext`, `McpPromptContext`, and `McpServerRequestContext` so contexts can reuse the shared client instance.
- Introduce `build_mcp_http_client()` to construct a shared `reqwest::Client` with explicit connect/request timeouts and connection pool tuning constants (idle timeout and max idle per host).
- Replace ad-hoc `reqwest::Client::new()` calls with lookups to the shared client via `McpClientManager::ensure_http_client` or `StreamableHttpContext::http_client()`, and pass the client into the streamable HTTP listener bootstrap (now `spawn_streamable_http_listener(client, ...)`).
- Preserve per-request header behavior by attaching `Authorization`, `mcp-session-id`, and `MCP-Protocol-Version` on each request as before.
- Extend the existing end-to-end streamable HTTP test (`streamable_http_end_to_end_handles_json_and_sse_responses`) to cover a second repeated list call and verify session-id update and persistence in the manager.
- Add a short README note that the Streamable HTTP transport reuses pooled HTTP connections.

### Testing
- Ran `cargo fmt` successfully.
- Ran the updated unit/integration suite with `cargo test`, including the extended `mcp::client::tests::streamable_http_end_to_end_handles_json_and_sse_responses`, and all tests passed (`700 passed; 0 failed`).
- Ran `cargo check` and `cargo clippy -- -D warnings` with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6d3d8828832b9f5e025b817fc5d3)