### PR TITLE
Reorganize app actions into domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Chabeau uses a modular design with focused components:
   - `registry.rs` – Static command metadata registry
 - `core/` – Core application components
   - `app/` – Application state and controllers
-    - `actions/` – Internal action definitions and dispatcher for chat loop updates
+    - `actions/` – Internal action definitions grouped by domain plus dispatcher routing
     - `app.rs` – Main `App` struct and event loop integration
     - `conversation.rs` – Conversation controller for chat flow, retries, and streaming helpers
     - `mod.rs` – App struct and module exports

--- a/src/core/app/actions/file_prompt.rs
+++ b/src/core/app/actions/file_prompt.rs
@@ -1,22 +1,22 @@
 use std::fs;
 use std::path::Path;
 
-use super::{input, App, AppAction, AppActionContext, AppCommand};
+use super::{input, App, AppActionContext, AppCommand, FilePromptAction};
 
 pub(super) fn handle_file_prompt_action(
     app: &mut App,
-    action: AppAction,
+    action: FilePromptAction,
     ctx: AppActionContext,
 ) -> Option<AppCommand> {
     match action {
-        AppAction::CompleteFilePromptDump {
+        FilePromptAction::CompleteDump {
             filename,
             overwrite,
         } => {
             handle_file_prompt_dump(app, filename, overwrite, ctx);
             None
         }
-        AppAction::CompleteFilePromptSaveBlock {
+        FilePromptAction::CompleteSaveBlock {
             filename,
             content,
             overwrite,
@@ -24,7 +24,6 @@ pub(super) fn handle_file_prompt_action(
             handle_file_prompt_save_block(app, filename, content, overwrite, ctx);
             None
         }
-        _ => unreachable!("non-file prompt action routed to file prompt handler"),
     }
 }
 

--- a/src/core/app/actions/mcp_prompt.rs
+++ b/src/core/app/actions/mcp_prompt.rs
@@ -1,16 +1,13 @@
-use super::{input, App, AppAction, AppActionContext, AppCommand};
+use super::{input, App, AppActionContext, AppCommand, McpPromptAction};
 use crate::core::app::session::McpPromptRequest;
 
 pub(super) fn handle_mcp_prompt_action(
     app: &mut App,
-    action: AppAction,
+    action: McpPromptAction,
     ctx: AppActionContext,
 ) -> Option<AppCommand> {
     match action {
-        AppAction::CompleteMcpPromptArg { value } => {
-            handle_complete_mcp_prompt_arg(app, value, ctx)
-        }
-        _ => unreachable!("non-mcp prompt action routed to mcp prompt handler"),
+        McpPromptAction::CompleteArg { value } => handle_complete_mcp_prompt_arg(app, value, ctx),
     }
 }
 

--- a/src/core/app/actions/picker.rs
+++ b/src/core/app/actions/picker.rs
@@ -1,67 +1,67 @@
-use super::{input, App, AppAction, AppActionContext, AppCommand};
+use super::{input, App, AppActionContext, AppCommand, PickerAction};
 use crate::core::app::picker::PickerMode;
 use crate::core::config::data::Config;
 use crate::core::message::AppMessageKind;
 
 pub(super) fn handle_picker_action(
     app: &mut App,
-    action: AppAction,
+    action: PickerAction,
     ctx: AppActionContext,
 ) -> Option<AppCommand> {
     match action {
-        AppAction::PickerEscape => {
+        PickerAction::PickerEscape => {
             handle_picker_escape(app, ctx);
             None
         }
-        AppAction::PickerMoveUp => {
+        PickerAction::PickerMoveUp => {
             handle_picker_movement(app, PickerMovement::Up);
             None
         }
-        AppAction::PickerMoveDown => {
+        PickerAction::PickerMoveDown => {
             handle_picker_movement(app, PickerMovement::Down);
             None
         }
-        AppAction::PickerMoveToStart => {
+        PickerAction::PickerMoveToStart => {
             handle_picker_movement(app, PickerMovement::Start);
             None
         }
-        AppAction::PickerMoveToEnd => {
+        PickerAction::PickerMoveToEnd => {
             handle_picker_movement(app, PickerMovement::End);
             None
         }
-        AppAction::PickerCycleSortMode => {
+        PickerAction::PickerCycleSortMode => {
             handle_picker_cycle_sort_mode(app);
             None
         }
-        AppAction::PickerApplySelection { persistent } => {
+        PickerAction::PickerApplySelection { persistent } => {
             handle_picker_apply_selection(app, persistent, ctx)
         }
-        AppAction::PickerUnsetDefault => handle_picker_unset_default(app, ctx),
-        AppAction::PickerBackspace => {
+        PickerAction::PickerUnsetDefault => handle_picker_unset_default(app, ctx),
+        PickerAction::PickerBackspace => {
             handle_picker_backspace(app);
             None
         }
-        AppAction::PickerTypeChar { ch } => {
+        PickerAction::PickerTypeChar { ch } => {
             handle_picker_type_char(app, ch);
             None
         }
-        AppAction::PickerInspectSelection => {
+        PickerAction::PickerInspectSelection => {
             handle_picker_inspect(app, ctx);
             None
         }
-        AppAction::PickerInspectScroll { lines } => {
+        PickerAction::PickerInspectScroll { lines } => {
             app.scroll_inspect(lines);
             None
         }
-        AppAction::PickerInspectScrollToStart => {
+        PickerAction::PickerInspectScrollToStart => {
             app.scroll_inspect_to_start();
             None
         }
-        AppAction::PickerInspectScrollToEnd => {
+        PickerAction::PickerInspectScrollToEnd => {
             app.scroll_inspect_to_end();
             None
         }
-        AppAction::ModelPickerLoaded {
+        PickerAction::ModelPickerLoaded {
             default_model_for_provider,
             models_response,
         } => {
@@ -72,12 +72,11 @@ pub(super) fn handle_picker_action(
             }
             None
         }
-        AppAction::ModelPickerLoadFailed { error } => {
+        PickerAction::ModelPickerLoadFailed { error } => {
             app.fail_model_picker_request();
             input::set_status_message(app, format!("Model picker error: {}", error), ctx);
             None
         }
-        _ => unreachable!("non-picker action routed to picker handler"),
     }
 }
 
@@ -770,11 +769,11 @@ mod tests {
         let original_color = app.ui.theme.background_color;
 
         app.open_theme_picker().expect("theme picker opens");
-        handle_picker_action(&mut app, AppAction::PickerMoveDown, ctx);
+        handle_picker_action(&mut app, PickerAction::PickerMoveDown, ctx);
 
         assert_ne!(app.ui.theme.background_color, original_color);
 
-        handle_picker_action(&mut app, AppAction::PickerEscape, ctx);
+        handle_picker_action(&mut app, PickerAction::PickerEscape, ctx);
 
         assert_eq!(app.ui.theme.background_color, original_color);
         assert!(app.picker_session().is_none());
@@ -820,7 +819,7 @@ mod tests {
             }),
         });
 
-        handle_picker_action(&mut app, AppAction::PickerEscape, ctx);
+        handle_picker_action(&mut app, PickerAction::PickerEscape, ctx);
 
         assert_eq!(app.session.provider_name, "old-prov");
         assert_eq!(app.session.provider_display_name, "Old Provider");
@@ -858,7 +857,7 @@ mod tests {
         assert!(app.picker_session().is_some());
         handle_picker_action(
             &mut app,
-            AppAction::PickerApplySelection { persistent: false },
+            PickerAction::PickerApplySelection { persistent: false },
             ctx,
         );
         assert!(app.picker_session().is_none());

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -33,6 +33,7 @@ mod ui_helpers;
 
 pub use actions::{
     apply_actions, AppAction, AppActionContext, AppActionDispatcher, AppActionEnvelope, AppCommand,
+    FilePromptAction, InputAction, McpPromptAction, PickerAction, PromptAction, StreamingAction,
 };
 #[allow(unused_imports)]
 pub use conversation::ConversationController;


### PR DESCRIPTION
### 1) App actions reorganized into explicit domains

- Replaced the prior flat `AppAction` surface with a domain-wrapper structure:
  - `AppAction::Streaming(StreamingAction)`
  - `AppAction::Input(InputAction)`
  - `AppAction::Picker(PickerAction)`
  - `AppAction::Prompt(PromptAction)`
- Defined domain enums with the prior  variant set moved into the appropriate domain bucket (stream  lifecycle/tool events, input/status/editing/inspect controls, picker  navigation/selection/load outcomes).
- Added `From<...> for AppAction` conversions plus generic `dispatch_many` support (`I::Item: Into<AppAction>`) to keep call-site migration low churn and allow mixed action lists where needed.

### 2) Prompt actions further refactored into subdomains

- `PromptAction` was split into nested subdomains:
  - `PromptAction::File(FilePromptAction)`
  - `PromptAction::Mcp(McpPromptAction)`
- Added dedicated `From<FilePromptAction>` and `From<McpPromptAction>` conversions to `AppAction`.

### 3) Top-level reducer routing simplified and hardened

- `apply_action` now routes only by top-level domain, then by prompt subdomain for prompt actions.
- Prompt file actions are routed directly to `file_prompt`, and MCP prompt actions directly to `mcp_prompt`, eliminating cross-branch fallthrough logic.

### 4) Action handler modules updated to typed domain inputs

- `streaming.rs` now receives `StreamingAction` directly and matches only streaming variants.
- `input.rs` now receives `InputAction` directly and delegates message/refine behavior to streaming helpers as needed.
- `picker.rs` now receives `PickerAction` directly.
- `file_prompt.rs` now accepts only `FilePromptAction` (no prompt cross-variant handling).
- `mcp_prompt.rs` now accepts only `McpPromptAction` (single-variant, focused handler).

### 5) Chat loop call sites were migrated to domain actions

- `event_loop.rs` now dispatches domain actions (e.g., model picker load outcomes as `PickerAction`, MCP init/stream updates as `StreamingAction`).
- `keybindings/handlers.rs` now dispatches domain-typed actions for clear/inspect/compose/escape/cancel/interrupt behavior, using `Into<AppAction>` where mixed vectors are built.
- `modes.rs` now dispatches:
  - picker flows as `PickerAction`,
  - external editor outcomes via mixed `AppAction` vectors,
  - prompt completions as `McpPromptAction::CompleteArg` and `FilePromptAction::{CompleteDump, CompleteSaveBlock}`.

### 6) Exports and docs updated

- Re-exported the new action types from `core::app` for caller convenience (`FilePromptAction`, `McpPromptAction`, and domain enums).
- Updated README architecture text to describe domain-grouped actions with prompt subdomains.

### 7) Tests in affected paths adjusted to nested action patterns

- Example: mode test assertions now match nested prompt shapes (`AppAction::Prompt(PromptAction::File(FilePromptAction::CompleteDump { .. }))`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d76a68dd0832b94a7557327a89e21)