### PR TITLE
Refactor input actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,8 @@ Chabeau uses a modular design with focused components:
   - `registry.rs` – Static command metadata registry
 - `core/` – Core application components
   - `app/` – Application state and controllers
-    - `actions/` – Internal action definitions grouped by domain plus dispatcher routing
+    - `actions/` – Internal action definitions grouped by domain (streaming, input, picker, prompt) plus dispatcher routing
+      - `input/` – Input subdomains for compose, command, inspect, and status actions
     - `app.rs` – Main `App` struct and event loop integration
     - `conversation.rs` – Conversation controller for chat flow, retries, and streaming helpers
     - `mod.rs` – App struct and module exports

--- a/src/core/app/actions/input/command.rs
+++ b/src/core/app/actions/input/command.rs
@@ -1,0 +1,188 @@
+use super::set_status_message;
+use super::{update_scroll_after_command, App, AppActionContext, AppCommand, CommandAction};
+use crate::commands::{process_input, CommandResult};
+use crate::core::app::actions::streaming;
+use crate::core::app::StreamingAction;
+
+pub(super) fn handle_command_action(
+    app: &mut App,
+    action: CommandAction,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    match action {
+        CommandAction::ProcessCommand { input } => handle_process_command(app, input, ctx),
+        CommandAction::CompleteInPlaceEdit { index, new_text } => {
+            app.complete_in_place_edit(index, new_text);
+            None
+        }
+        CommandAction::CompleteAssistantEdit { content } => {
+            app.complete_assistant_edit(content);
+            update_scroll_after_command(app, ctx);
+            None
+        }
+    }
+}
+
+fn handle_process_command(
+    app: &mut App,
+    input: String,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    if input.trim().is_empty() {
+        return None;
+    }
+
+    match process_input(app, &input) {
+        CommandResult::Continue => {
+            app.conversation().show_character_greeting_if_needed();
+            update_scroll_after_command(app, ctx);
+            None
+        }
+        CommandResult::ContinueWithTranscriptFocus => {
+            app.conversation().show_character_greeting_if_needed();
+            app.ui.focus_transcript();
+            update_scroll_after_command(app, ctx);
+            None
+        }
+        CommandResult::ProcessAsMessage(message) => {
+            streaming::spawn_stream_for_message(app, message, ctx)
+        }
+        CommandResult::OpenModelPicker => match app.prepare_model_picker_request() {
+            Ok(request) => Some(AppCommand::LoadModelPicker(request)),
+            Err(err) => {
+                set_status_message(app, format!("Model picker error: {}", err), ctx);
+                None
+            }
+        },
+        CommandResult::OpenProviderPicker => {
+            app.open_provider_picker();
+            None
+        }
+        CommandResult::OpenThemePicker => {
+            if let Err(err) = app.open_theme_picker() {
+                set_status_message(app, format!("Theme picker error: {}", err), ctx);
+            }
+            None
+        }
+        CommandResult::OpenCharacterPicker => {
+            app.open_character_picker();
+            None
+        }
+        CommandResult::OpenPersonaPicker => {
+            app.open_persona_picker();
+            None
+        }
+        CommandResult::OpenPresetPicker => {
+            app.open_preset_picker();
+            None
+        }
+        CommandResult::Refine(prompt) => {
+            let action = StreamingAction::RefineLastMessage { prompt };
+            streaming::handle_streaming_action(app, action, ctx)
+        }
+        CommandResult::RunMcpPrompt(request) => Some(AppCommand::RunMcpPrompt(request)),
+        CommandResult::RefreshMcp { server_id } => {
+            app.ui.focus_transcript();
+            update_scroll_after_command(app, ctx);
+            Some(AppCommand::RefreshMcp { server_id })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::create_test_app;
+
+    fn default_ctx() -> AppActionContext {
+        AppActionContext {
+            term_width: 80,
+            term_height: 24,
+        }
+    }
+
+    #[test]
+    fn process_command_submits_message() {
+        let mut app = create_test_app();
+        let ctx = default_ctx();
+        let cmd = handle_command_action(
+            &mut app,
+            CommandAction::ProcessCommand {
+                input: "hello there".into(),
+            },
+            ctx,
+        );
+
+        assert!(matches!(cmd, Some(AppCommand::SpawnStream(_))));
+    }
+
+    #[test]
+    fn process_command_opens_theme_picker() {
+        let mut app = create_test_app();
+        let ctx = default_ctx();
+
+        let _ = handle_command_action(
+            &mut app,
+            CommandAction::ProcessCommand {
+                input: "/theme".into(),
+            },
+            ctx,
+        );
+
+        assert!(app.picker_session().is_some());
+    }
+
+    #[test]
+    fn help_command_focuses_transcript() {
+        let mut app = create_test_app();
+        let ctx = default_ctx();
+        app.ui.focus_input();
+
+        let cmd = handle_command_action(
+            &mut app,
+            CommandAction::ProcessCommand {
+                input: "/help".into(),
+            },
+            ctx,
+        );
+
+        assert!(cmd.is_none());
+        assert!(app.ui.is_transcript_focused());
+    }
+
+    #[test]
+    fn mcp_command_focuses_transcript() {
+        let mut app = create_test_app();
+        let ctx = default_ctx();
+        app.ui.focus_input();
+        app.config
+            .mcp_servers
+            .push(crate::core::config::data::McpServerConfig {
+                id: "alpha".to_string(),
+                display_name: "Alpha MCP".to_string(),
+                transport: None,
+                base_url: Some("https://mcp.example.com".to_string()),
+                command: None,
+                args: None,
+                env: None,
+                enabled: Some(true),
+                allowed_tools: None,
+                protocol_version: None,
+                tool_payloads: None,
+                tool_payload_window: None,
+                yolo: None,
+            });
+        app.mcp = crate::mcp::client::McpClientManager::from_config(&app.config);
+
+        let cmd = handle_command_action(
+            &mut app,
+            CommandAction::ProcessCommand {
+                input: "/mcp alpha".into(),
+            },
+            ctx,
+        );
+
+        assert!(matches!(cmd, Some(AppCommand::RefreshMcp { .. })));
+        assert!(app.ui.is_transcript_focused());
+    }
+}

--- a/src/core/app/actions/input/compose.rs
+++ b/src/core/app/actions/input/compose.rs
@@ -1,0 +1,42 @@
+use super::{App, AppActionContext, AppCommand, ComposeAction};
+
+pub(super) fn handle_compose_action(
+    app: &mut App,
+    action: ComposeAction,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    match action {
+        ComposeAction::ToggleComposeMode => {
+            app.toggle_compose_mode();
+            None
+        }
+        ComposeAction::CancelFilePrompt => {
+            app.cancel_file_prompt();
+            None
+        }
+        ComposeAction::CancelMcpPromptInput => {
+            app.ui.cancel_mcp_prompt_input();
+            None
+        }
+        ComposeAction::CancelInPlaceEdit => {
+            if app.has_in_place_edit() {
+                app.cancel_in_place_edit();
+                app.clear_input();
+            }
+            None
+        }
+        ComposeAction::ClearInput => {
+            app.clear_input();
+            if ctx.term_width > 0 {
+                app.recompute_input_layout_after_edit(ctx.term_width);
+            }
+            None
+        }
+        ComposeAction::InsertIntoInput { text } => {
+            if !text.is_empty() {
+                app.insert_into_input(&text, ctx.term_width);
+            }
+            None
+        }
+    }
+}

--- a/src/core/app/actions/input/mod.rs
+++ b/src/core/app/actions/input/mod.rs
@@ -1,0 +1,98 @@
+mod command;
+mod compose;
+mod inspect;
+mod status;
+
+use super::{App, AppAction, AppActionContext, AppCommand};
+
+pub(crate) use status::set_status_message;
+
+pub enum InputAction {
+    Compose(ComposeAction),
+    Command(CommandAction),
+    Inspect(InspectAction),
+    Status(StatusAction),
+}
+
+pub enum ComposeAction {
+    ToggleComposeMode,
+    CancelFilePrompt,
+    CancelMcpPromptInput,
+    CancelInPlaceEdit,
+    ClearInput,
+    InsertIntoInput { text: String },
+}
+
+pub enum CommandAction {
+    ProcessCommand { input: String },
+    CompleteInPlaceEdit { index: usize, new_text: String },
+    CompleteAssistantEdit { content: String },
+}
+
+pub enum InspectAction {
+    Open,
+    ToggleView,
+    Step { delta: i32 },
+    Copy,
+    ToggleDecode,
+}
+
+pub enum StatusAction {
+    SetStatus { message: String },
+    ClearStatus,
+}
+
+pub(super) fn handle_input_action(
+    app: &mut App,
+    action: InputAction,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    match action {
+        InputAction::Compose(action) => compose::handle_compose_action(app, action, ctx),
+        InputAction::Command(action) => command::handle_command_action(app, action, ctx),
+        InputAction::Inspect(action) => inspect::handle_inspect_action(app, action, ctx),
+        InputAction::Status(action) => status::handle_status_action(app, action, ctx),
+    }
+}
+
+pub(super) fn update_scroll_after_command(app: &mut App, ctx: AppActionContext) {
+    if ctx.term_width == 0 || ctx.term_height == 0 {
+        return;
+    }
+
+    let input_area_height = app.input_area_height(ctx.term_width);
+    let mut conversation = app.conversation();
+    let available_height =
+        conversation.calculate_available_height(ctx.term_height, input_area_height);
+    conversation.update_scroll_position(available_height, ctx.term_width);
+}
+
+impl From<ComposeAction> for InputAction {
+    fn from(value: ComposeAction) -> Self {
+        Self::Compose(value)
+    }
+}
+
+impl From<CommandAction> for InputAction {
+    fn from(value: CommandAction) -> Self {
+        Self::Command(value)
+    }
+}
+
+impl From<InspectAction> for InputAction {
+    fn from(value: InspectAction) -> Self {
+        Self::Inspect(value)
+    }
+}
+
+impl From<StatusAction> for InputAction {
+    fn from(value: StatusAction) -> Self {
+        Self::Status(value)
+    }
+}
+
+impl From<InputAction> for AppAction {
+    fn from(value: InputAction) -> Self {
+        Self::Input(value)
+    }
+}

--- a/src/core/app/actions/input/status.rs
+++ b/src/core/app/actions/input/status.rs
@@ -1,0 +1,29 @@
+use super::{App, AppActionContext, AppCommand, StatusAction};
+
+pub(super) fn handle_status_action(
+    app: &mut App,
+    action: StatusAction,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    match action {
+        StatusAction::SetStatus { message } => {
+            set_status_message(app, message, ctx);
+            None
+        }
+        StatusAction::ClearStatus => {
+            app.clear_status();
+            None
+        }
+    }
+}
+
+pub(crate) fn set_status_message(app: &mut App, message: String, ctx: AppActionContext) {
+    app.conversation().set_status(message);
+    if ctx.term_width > 0 && ctx.term_height > 0 {
+        let input_area_height = app.input_area_height(ctx.term_width);
+        let mut conversation = app.conversation();
+        let available_height =
+            conversation.calculate_available_height(ctx.term_height, input_area_height);
+        conversation.update_scroll_position(available_height, ctx.term_width);
+    }
+}

--- a/src/core/app/actions/mod.rs
+++ b/src/core/app/actions/mod.rs
@@ -4,6 +4,7 @@ mod mcp_prompt;
 mod picker;
 mod streaming;
 
+pub use input::{CommandAction, ComposeAction, InputAction, InspectAction, StatusAction};
 pub(crate) use streaming::{parse_resource_list_kind, ResourceListKind};
 
 use tokio::sync::mpsc;
@@ -73,25 +74,6 @@ pub enum StreamingAction {
     RetryLastMessage,
 }
 
-pub enum InputAction {
-    InspectToolResults,
-    InspectToolResultsToggleView,
-    InspectToolResultsStep { delta: i32 },
-    InspectToolResultsCopy,
-    InspectToolResultsToggleDecode,
-    ClearStatus,
-    ToggleComposeMode,
-    CancelFilePrompt,
-    CancelMcpPromptInput,
-    CancelInPlaceEdit,
-    SetStatus { message: String },
-    ClearInput,
-    InsertIntoInput { text: String },
-    ProcessCommand { input: String },
-    CompleteInPlaceEdit { index: usize, new_text: String },
-    CompleteAssistantEdit { content: String },
-}
-
 pub enum PickerAction {
     PickerEscape,
     PickerMoveUp,
@@ -146,12 +128,6 @@ pub enum McpPromptAction {
 impl From<StreamingAction> for AppAction {
     fn from(value: StreamingAction) -> Self {
         Self::Streaming(value)
-    }
-}
-
-impl From<InputAction> for AppAction {
-    fn from(value: InputAction) -> Self {
-        Self::Input(value)
     }
 }
 

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -33,7 +33,8 @@ mod ui_helpers;
 
 pub use actions::{
     apply_actions, AppAction, AppActionContext, AppActionDispatcher, AppActionEnvelope, AppCommand,
-    FilePromptAction, InputAction, McpPromptAction, PickerAction, PromptAction, StreamingAction,
+    CommandAction, ComposeAction, FilePromptAction, InputAction, InspectAction, McpPromptAction,
+    PickerAction, PromptAction, StatusAction, StreamingAction,
 };
 #[allow(unused_imports)]
 pub use conversation::ConversationController;


### PR DESCRIPTION
- Introduced a new `InputAction` sum type that wraps four input subdomains:
  - `ComposeAction`
  - `CommandAction`
  - `InspectAction`
  - `StatusAction`. 
- Split the former monolithic input handler into focused modules under `src/core/app/actions/input/`:
  - `mod.rs` (types, routing, conversions),
  - `compose.rs` (clear/insert/toggle/cancel edit flows),
  - `command.rs` (`ProcessCommand` + command-derived mutations),
  - `inspect.rs` (tool inspect open/toggle/step/copy/decode),
  - `status.rs` (`SetStatus`/`ClearStatus`). 
- Added conversion impls to keep dispatch usage concise while preserving domain boundaries:
  - `From<ComposeAction|CommandAction|InspectAction|StatusAction> for InputAction`
  - `From<InputAction> for AppAction`. 
- Kept `AppAction::Input(...)` as the outer action domain and preserved `apply_action` routing behavior (`AppAction::Input(action)` still forwards to `input::handle_input_action(...)`). 
- Migrated requested chat-loop call sites to dispatch via `InputAction` wrapping:
  - `src/ui/chat_loop/keybindings/handlers.rs`,
  - `src/ui/chat_loop/modes.rs`,
  - `src/ui/chat_loop/event_loop.rs`. 
- Updated app exports and architecture docs to reflect the new input module layout. 