### PR TITLE
refactor(mcp): split client into focused modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,13 @@ Chabeau uses a modular design with focused components:
   - `oauth.rs` – Shared MCP OAuth discovery, browser flow, callback handling, and token refresh helpers
 - `message.rs` – Message data structures
 - `mcp/` – Model Context Protocol client integration
-  - `client.rs` – MCP client orchestration, cache updates, and server state
+  - `client/` – MCP client orchestration, transport plumbing, protocol parsing, and operations
+    - `mod.rs` – Public MCP client manager API, state, and shared context types
+    - `operations.rs` – MCP `execute_*` entry points and shared request flow helpers
+    - `protocol.rs` – MCP response parsing and protocol-version helpers
+    - `transport_http.rs` – Streamable HTTP session and request/message dispatch helpers
+    - `transport_stdio.rs` – Stdio request/result/error dispatch helpers
+    - `tests.rs` – MCP client manager integration-style unit tests
   - `events.rs` – MCP server request envelopes
   - `transport/` – MCP transport implementations and shared interfaces
     - `mod.rs` – Shared transport traits, enums, and list-fetch helpers

--- a/src/mcp/client/operations.rs
+++ b/src/mcp/client/operations.rs
@@ -1,0 +1,183 @@
+use super::protocol::{
+    parse_call_tool, parse_get_prompt, parse_list_resource_templates, parse_list_resources,
+    parse_read_resource,
+};
+use super::transport_http;
+use super::transport_stdio;
+use super::{McpPromptContext, McpServerRequestContext, McpToolCallContext};
+use crate::core::app::session::{McpPromptRequest, ToolCallRequest};
+use crate::mcp::transport::McpTransportKind;
+use rust_mcp_schema::schema_utils::{
+    ClientMessage, FromMessage, MessageFromClient, RequestFromClient, ResultFromClient,
+    ServerMessage,
+};
+use rust_mcp_schema::{
+    CallToolRequestParams, CallToolResult, GetPromptRequestParams, GetPromptResult,
+    ListResourceTemplatesResult, ListResourcesResult, PaginatedRequestParams,
+    ReadResourceRequestParams, ReadResourceResult, RequestId, RpcError,
+};
+use tracing::debug;
+
+async fn execute_transport_request<T, C>(
+    context: &mut C,
+    request: RequestFromClient,
+    parse: fn(ServerMessage) -> Result<T, String>,
+) -> Result<T, String>
+where
+    C: OperationContext,
+{
+    let response = match context.transport_kind() {
+        McpTransportKind::Stdio => transport_stdio::send_request(context.client(), request).await?,
+        McpTransportKind::StreamableHttp => {
+            transport_http::ensure_session_context(context).await?;
+            transport_http::send_request_with_context(context, request).await?
+        }
+    };
+    parse(response)
+}
+
+trait OperationContext: super::StreamableHttpContext {
+    fn transport_kind(&self) -> McpTransportKind;
+    fn client(&self) -> Option<std::sync::Arc<super::StdioClient>>;
+}
+
+impl OperationContext for McpToolCallContext {
+    fn transport_kind(&self) -> McpTransportKind {
+        self.transport_kind
+    }
+
+    fn client(&self) -> Option<std::sync::Arc<super::StdioClient>> {
+        self.client.clone()
+    }
+}
+
+impl OperationContext for McpPromptContext {
+    fn transport_kind(&self) -> McpTransportKind {
+        self.transport_kind
+    }
+
+    fn client(&self) -> Option<std::sync::Arc<super::StdioClient>> {
+        self.client.clone()
+    }
+}
+
+pub async fn execute_tool_call(
+    context: &mut McpToolCallContext,
+    request: &ToolCallRequest,
+) -> Result<CallToolResult, String> {
+    let mut params = CallToolRequestParams::new(&request.tool_name);
+    if let Some(arguments) = request.arguments.clone() {
+        params = params.with_arguments(arguments);
+    }
+    execute_transport_request(
+        context,
+        RequestFromClient::CallToolRequest(params),
+        parse_call_tool,
+    )
+    .await
+}
+
+pub async fn execute_resource_read(
+    context: &mut McpToolCallContext,
+    uri: &str,
+) -> Result<ReadResourceResult, String> {
+    let params = ReadResourceRequestParams {
+        meta: None,
+        uri: uri.to_string(),
+    };
+    execute_transport_request(
+        context,
+        RequestFromClient::ReadResourceRequest(params),
+        parse_read_resource,
+    )
+    .await
+}
+
+pub async fn execute_resource_list(
+    context: &mut McpToolCallContext,
+    cursor: Option<String>,
+) -> Result<ListResourcesResult, String> {
+    let params = cursor.map(|cursor| PaginatedRequestParams {
+        cursor: Some(cursor),
+        meta: None,
+    });
+    execute_transport_request(
+        context,
+        RequestFromClient::ListResourcesRequest(params),
+        parse_list_resources,
+    )
+    .await
+}
+
+pub async fn execute_resource_template_list(
+    context: &mut McpToolCallContext,
+    cursor: Option<String>,
+) -> Result<ListResourceTemplatesResult, String> {
+    let params = cursor.map(|cursor| PaginatedRequestParams {
+        cursor: Some(cursor),
+        meta: None,
+    });
+    execute_transport_request(
+        context,
+        RequestFromClient::ListResourceTemplatesRequest(params),
+        parse_list_resource_templates,
+    )
+    .await
+}
+
+pub async fn execute_prompt(
+    context: &mut McpPromptContext,
+    request: &McpPromptRequest,
+) -> Result<GetPromptResult, String> {
+    let params = GetPromptRequestParams {
+        name: request.prompt_name.clone(),
+        arguments: (!request.arguments.is_empty()).then_some(request.arguments.clone()),
+        meta: None,
+    };
+    execute_transport_request(
+        context,
+        RequestFromClient::GetPromptRequest(params),
+        parse_get_prompt,
+    )
+    .await
+}
+
+pub async fn send_client_result(
+    context: &mut McpServerRequestContext,
+    request_id: RequestId,
+    result: ResultFromClient,
+) -> Result<(), String> {
+    debug!(server_id = %context.server_id, request_id = ?request_id, transport = ?context.transport_kind, "Sending MCP client result");
+    match context.transport_kind {
+        McpTransportKind::Stdio => {
+            transport_stdio::send_result(context.client.clone(), request_id, result).await
+        }
+        McpTransportKind::StreamableHttp => {
+            let message = ClientMessage::from_message(
+                MessageFromClient::ResultFromClient(result),
+                Some(request_id),
+            )
+            .map_err(|err| err.to_string())?;
+            transport_http::send_server_result_message(context, message).await
+        }
+    }
+}
+
+pub async fn send_client_error(
+    context: &mut McpServerRequestContext,
+    request_id: RequestId,
+    error: RpcError,
+) -> Result<(), String> {
+    debug!(server_id = %context.server_id, request_id = ?request_id, transport = ?context.transport_kind, "Sending MCP client error");
+    match context.transport_kind {
+        McpTransportKind::Stdio => {
+            transport_stdio::send_error(context.client.clone(), request_id, error).await
+        }
+        McpTransportKind::StreamableHttp => {
+            let message =
+                ClientMessage::from_message(MessageFromClient::Error(error), Some(request_id))
+                    .map_err(|err| err.to_string())?;
+            transport_http::send_server_result_message(context, message).await
+        }
+    }
+}

--- a/src/mcp/client/protocol.rs
+++ b/src/mcp/client/protocol.rs
@@ -1,0 +1,128 @@
+use super::{format_rpc_error, format_unexpected_server_message};
+use crate::core::config::data::McpServerConfig;
+use rust_mcp_schema::schema_utils::ServerMessage;
+use rust_mcp_schema::{
+    CallToolResult, GetPromptResult, InitializeResult, ListPromptsResult,
+    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, ReadResourceResult,
+    LATEST_PROTOCOL_VERSION,
+};
+use serde_json::Value;
+
+pub(crate) fn requested_protocol_version(config: &McpServerConfig) -> String {
+    config
+        .protocol_version
+        .clone()
+        .unwrap_or_else(|| LATEST_PROTOCOL_VERSION.to_string())
+}
+
+pub(crate) fn effective_protocol_version(
+    config: &McpServerConfig,
+    negotiated_version: Option<&str>,
+) -> String {
+    match negotiated_version {
+        Some(version) if !version.trim().is_empty() => version.to_string(),
+        _ => requested_protocol_version(config),
+    }
+}
+
+pub(crate) fn parse_initialize_result(message: ServerMessage) -> Result<InitializeResult, String> {
+    let value = parse_response_value(message)?;
+    let result =
+        serde_json::from_value::<InitializeResult>(value).map_err(|err| err.to_string())?;
+    if result.protocol_version.trim().is_empty() {
+        return Err("Unexpected initialize response.".to_string());
+    }
+    Ok(result)
+}
+
+pub(crate) fn parse_list_tools(message: ServerMessage) -> Result<ListToolsResult, String> {
+    parse_response(message)
+}
+
+pub(crate) fn parse_list_resources(message: ServerMessage) -> Result<ListResourcesResult, String> {
+    parse_response(message)
+}
+
+pub(crate) fn parse_list_resource_templates(
+    message: ServerMessage,
+) -> Result<ListResourceTemplatesResult, String> {
+    parse_response(message)
+}
+
+pub(crate) fn parse_list_prompts(message: ServerMessage) -> Result<ListPromptsResult, String> {
+    parse_response(message)
+}
+
+pub(crate) fn parse_get_prompt(message: ServerMessage) -> Result<GetPromptResult, String> {
+    parse_response(message)
+}
+
+pub(crate) fn parse_read_resource(message: ServerMessage) -> Result<ReadResourceResult, String> {
+    parse_response(message)
+}
+
+pub(crate) fn parse_call_tool(message: ServerMessage) -> Result<CallToolResult, String> {
+    parse_response(message)
+}
+
+fn parse_response<T: serde::de::DeserializeOwned>(message: ServerMessage) -> Result<T, String> {
+    let value = parse_response_value(message)?;
+    serde_json::from_value::<T>(value).map_err(|err| err.to_string())
+}
+
+pub(crate) fn parse_response_value(message: ServerMessage) -> Result<Value, String> {
+    match message {
+        ServerMessage::Response(response) => {
+            serde_json::to_value(&response.result).map_err(|err| err.to_string())
+        }
+        ServerMessage::Error(error) => Err(format_rpc_error(&error.error)),
+        other => Err(format_unexpected_server_message(&other)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::data::McpServerConfig;
+
+    #[test]
+    fn parse_initialize_rejects_blank_protocol_version() {
+        let message = serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+            "capabilities": {},
+            "protocolVersion": " ",
+            "serverInfo": {"name": "x", "version": "1.0.0"}
+            }
+        }))
+        .expect("message should parse");
+
+        assert!(parse_initialize_result(message).is_err());
+    }
+
+    #[test]
+    fn effective_protocol_prefers_negotiated() {
+        let config = McpServerConfig {
+            id: "alpha".to_string(),
+            display_name: "Alpha".to_string(),
+            base_url: None,
+            command: None,
+            args: None,
+            env: None,
+            transport: None,
+            allowed_tools: None,
+            protocol_version: Some("2025-01-01".to_string()),
+            enabled: Some(true),
+            tool_payloads: None,
+            tool_payload_window: None,
+            yolo: None,
+        };
+
+        assert_eq!(
+            effective_protocol_version(&config, Some("2025-11-25")),
+            "2025-11-25"
+        );
+        assert_eq!(effective_protocol_version(&config, None), "2025-01-01");
+    }
+}

--- a/src/mcp/client/tests.rs
+++ b/src/mcp/client/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rust_mcp_schema::LATEST_PROTOCOL_VERSION;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -172,10 +173,13 @@ fn effective_protocol_version_prefers_negotiated_value() {
     config.protocol_version = Some("2025-01-01".to_string());
 
     assert_eq!(
-        effective_protocol_version(&config, Some("2025-11-25")),
+        protocol::effective_protocol_version(&config, Some("2025-11-25")),
         "2025-11-25"
     );
-    assert_eq!(effective_protocol_version(&config, None), "2025-01-01");
+    assert_eq!(
+        protocol::effective_protocol_version(&config, None),
+        "2025-01-01"
+    );
 }
 
 fn sample_tool(name: String) -> rust_mcp_schema::Tool {
@@ -487,14 +491,14 @@ async fn streamable_http_end_to_end_handles_json_and_sse_responses() {
         .send_streamable_http_request("alpha", RequestFromClient::ListResourcesRequest(None))
         .await
         .expect("SSE request should succeed");
-    let value = parse_response_value(message).expect("response value should parse");
+    let value = protocol::parse_response_value(message).expect("response value should parse");
     assert_eq!(value.get("ok").and_then(|item| item.as_bool()), Some(true));
 
     let message = manager
         .send_streamable_http_request("alpha", RequestFromClient::ListResourcesRequest(None))
         .await
         .expect("second SSE request should succeed");
-    let value = parse_response_value(message).expect("response value should parse");
+    let value = protocol::parse_response_value(message).expect("response value should parse");
     assert_eq!(value.get("ok").and_then(|item| item.as_bool()), Some(true));
 
     server_task

--- a/src/mcp/client/transport_http.rs
+++ b/src/mcp/client/transport_http.rs
@@ -1,0 +1,225 @@
+use super::{
+    apply_streamable_http_client_post_headers, apply_streamable_http_protocol_version_header,
+    client_details_for, is_event_stream_content_type, read_sse_response_messages,
+    require_http_base_url, McpServerRequestContext, StreamableHttpContext,
+};
+use rust_mcp_schema::schema_utils::{
+    ClientMessage, FromMessage, MessageFromClient, NotificationFromClient, RequestFromClient,
+    ServerMessage,
+};
+use rust_mcp_schema::RequestId;
+use tracing::debug;
+
+pub(crate) async fn ensure_session_context<C: StreamableHttpContext>(
+    context: &mut C,
+) -> Result<(), String> {
+    if context.session_id().is_some() {
+        return Ok(());
+    }
+
+    let client_details = client_details_for(context.config());
+    let response = send_request_with_context(
+        context,
+        RequestFromClient::InitializeRequest(client_details),
+    )
+    .await?;
+    let initialize = super::protocol::parse_initialize_result(response)?;
+    context.set_negotiated_protocol_version(Some(initialize.protocol_version));
+
+    if context.session_id().is_none() {
+        return Err("Missing session id on initialize response.".to_string());
+    }
+
+    send_notification(
+        context,
+        NotificationFromClient::InitializedNotification(None),
+    )
+    .await
+}
+
+pub(crate) async fn send_request_with_context<C: StreamableHttpContext>(
+    context: &mut C,
+    request: RequestFromClient,
+) -> Result<ServerMessage, String> {
+    let request_id = context.next_request_id();
+    let message = ClientMessage::from_message(
+        MessageFromClient::RequestFromClient(request),
+        Some(RequestId::Integer(request_id)),
+    )
+    .map_err(|err| err.to_string())?;
+    send_message(context, message).await
+}
+
+pub(crate) async fn send_server_result_message(
+    context: &mut McpServerRequestContext,
+    message: ClientMessage,
+) -> Result<(), String> {
+    send_client_message_with_context(context, message).await
+}
+
+async fn send_notification<C: StreamableHttpContext>(
+    context: &mut C,
+    notification: NotificationFromClient,
+) -> Result<(), String> {
+    let message = ClientMessage::from_message(
+        MessageFromClient::NotificationFromClient(notification),
+        None,
+    )
+    .map_err(|err| err.to_string())?;
+    send_client_message_with_context(context, message).await
+}
+
+async fn send_client_message_with_context<C: StreamableHttpContext>(
+    context: &mut C,
+    message: ClientMessage,
+) -> Result<(), String> {
+    let payload = serde_json::to_string(&message).map_err(|err| err.to_string())?;
+    let client = context
+        .http_client()
+        .ok_or_else(|| "MCP HTTP client not connected.".to_string())?;
+    let base_url = require_http_base_url(context.config())?;
+    let protocol_version = context.effective_protocol_version();
+    let mut request = apply_streamable_http_protocol_version_header(
+        apply_streamable_http_client_post_headers(client.post(base_url)),
+        Some(protocol_version.as_str()),
+    )
+    .body(payload);
+
+    if let Some(auth) = context.auth_header() {
+        request = request.header("Authorization", auth);
+    }
+    if let Some(session_id) = context.session_id() {
+        request = request.header("mcp-session-id", session_id);
+    }
+
+    let response = request.send().await.map_err(|err| err.to_string())?;
+    if !response.status().is_success() {
+        return Err(format!("HTTP error: {}", response.status()));
+    }
+    if let Some(session_id) = response
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.to_string())
+    {
+        context.set_session_id(Some(session_id));
+    }
+
+    Ok(())
+}
+
+async fn send_message<C: StreamableHttpContext>(
+    context: &mut C,
+    message: ClientMessage,
+) -> Result<ServerMessage, String> {
+    let payload = serde_json::to_string(&message).map_err(|err| err.to_string())?;
+    let client = context
+        .http_client()
+        .ok_or_else(|| "MCP HTTP client not connected.".to_string())?;
+    let base_url = require_http_base_url(context.config())?;
+    debug!(server_id = %context.config().id, url = %base_url, "Sending MCP HTTP request");
+    let protocol_version = context.effective_protocol_version();
+    let mut request = apply_streamable_http_protocol_version_header(
+        apply_streamable_http_client_post_headers(client.post(base_url)),
+        Some(protocol_version.as_str()),
+    )
+    .body(payload);
+
+    if let Some(auth) = context.auth_header() {
+        request = request.header("Authorization", auth);
+    }
+    if let Some(session_id) = context.session_id() {
+        request = request.header("mcp-session-id", session_id);
+    }
+
+    let response = request.send().await.map_err(|err| err.to_string())?;
+    if !response.status().is_success() {
+        return Err(format!("HTTP error: {}", response.status()));
+    }
+
+    let session_id = response
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.to_string());
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    let server_message = if is_event_stream_content_type(&content_type) {
+        read_sse_response_messages(response, &context.config().id, None).await?
+    } else {
+        let body = response.bytes().await.map_err(|err| err.to_string())?;
+        serde_json::from_slice::<ServerMessage>(&body).map_err(|err| err.to_string())?
+    };
+
+    if let Some(session_id) = session_id {
+        context.set_session_id(Some(session_id));
+    }
+    Ok(server_message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::data::McpServerConfig;
+
+    #[test]
+    fn ensure_session_requires_http_client() {
+        struct Dummy {
+            config: McpServerConfig,
+            session: Option<String>,
+        }
+        impl StreamableHttpContext for Dummy {
+            fn config(&self) -> &McpServerConfig {
+                &self.config
+            }
+            fn auth_header(&self) -> Option<&String> {
+                None
+            }
+            fn session_id(&self) -> Option<&String> {
+                self.session.as_ref()
+            }
+            fn http_client(&self) -> Option<&reqwest::Client> {
+                None
+            }
+            fn set_session_id(&mut self, session_id: Option<String>) {
+                self.session = session_id;
+            }
+            fn next_request_id(&mut self) -> i64 {
+                0
+            }
+            fn negotiated_protocol_version(&self) -> Option<&str> {
+                None
+            }
+            fn set_negotiated_protocol_version(&mut self, _protocol_version: Option<String>) {}
+        }
+
+        let mut ctx = Dummy {
+            config: McpServerConfig {
+                id: "alpha".to_string(),
+                display_name: "Alpha".to_string(),
+                base_url: Some("https://example.com".to_string()),
+                command: None,
+                args: None,
+                env: None,
+                transport: Some("streamable-http".to_string()),
+                allowed_tools: None,
+                protocol_version: None,
+                enabled: Some(true),
+                tool_payloads: None,
+                tool_payload_window: None,
+                yolo: None,
+            },
+            session: None,
+        };
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let err = rt
+            .block_on(ensure_session_context(&mut ctx))
+            .expect_err("expected error");
+        assert_eq!(err, "MCP HTTP client not connected.");
+    }
+}

--- a/src/mcp/client/transport_stdio.rs
+++ b/src/mcp/client/transport_stdio.rs
@@ -1,0 +1,49 @@
+use super::StdioClient;
+use rust_mcp_schema::schema_utils::{RequestFromClient, ResultFromClient, ServerMessage};
+use rust_mcp_schema::{RequestId, RpcError};
+use std::sync::Arc;
+
+pub(crate) async fn send_request(
+    client: Option<Arc<StdioClient>>,
+    request: RequestFromClient,
+) -> Result<ServerMessage, String> {
+    let Some(client) = client else {
+        return Err("MCP client not connected.".to_string());
+    };
+    client.send_request(request).await
+}
+
+pub(crate) async fn send_result(
+    client: Option<Arc<StdioClient>>,
+    request_id: RequestId,
+    result: ResultFromClient,
+) -> Result<(), String> {
+    let Some(client) = client else {
+        return Err("MCP client not connected.".to_string());
+    };
+    client.send_result(request_id, result).await
+}
+
+pub(crate) async fn send_error(
+    client: Option<Arc<StdioClient>>,
+    request_id: RequestId,
+    error: RpcError,
+) -> Result<(), String> {
+    let Some(client) = client else {
+        return Err("MCP client not connected.".to_string());
+    };
+    client.send_error(request_id, error).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stdio_requires_connected_client() {
+        let err = send_request(None, RequestFromClient::PingRequest(None))
+            .await
+            .expect_err("expected missing client error");
+        assert_eq!(err, "MCP client not connected.");
+    }
+}


### PR DESCRIPTION
## Summary
Refactors the MCP client internals into focused modules while preserving
existing behavior. Request execution, protocol parsing, and transport-specific
dispatch are now separated, so the manager no longer mixes orchestration with
wire-format and transport logic.

## Why
The previous single-file client implementation made protocol evolution and
transport changes harder to reason about and test. This structure reduces
coupling between orchestration and IO details, making follow-up MCP work safer
and easier to review.

## What changed
- Introduced dedicated modules for operations, protocol parsing, streamable
  HTTP transport, and stdio transport under `src/mcp/client/`.
- Kept the public manager API in `client/mod.rs` and re-exported operation
  entry points used by the rest of the app.
- Centralized protocol-version selection and response parsing helpers.
- Updated MCP client tests to reference the extracted protocol helpers.
- Updated architecture notes in `README.md` to reflect the new MCP client
  layout.

## Impact and risk
- No intended user-facing behavior change.
- Lower maintenance risk for MCP transport/protocol updates due to clearer
  boundaries and smaller testable units.
- Main risk is integration regressions in request routing; current tests were
  updated alongside the refactor.
