### PR TITLE
refactor(mcp): extract transport client internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,14 +523,14 @@ Chabeau uses a modular design with focused components:
     - `mod.rs` – Public MCP client manager API, state, and shared context types
     - `operations.rs` – MCP `execute_*` entry points and shared request flow helpers
     - `protocol.rs` – MCP response parsing and protocol-version helpers
-    - `transport_http.rs` – Streamable HTTP session and request/message dispatch helpers
-    - `transport_stdio.rs` – Stdio request/result/error dispatch helpers
+    - `transport_http.rs` – Streamable HTTP session lifecycle, request exchange interface, and event listener helpers
+    - `transport_stdio.rs` – Stdio transport client lifecycle, request dispatch, and server I/O readers
     - `tests.rs` – MCP client manager integration-style unit tests
   - `events.rs` – MCP server request envelopes
   - `transport/` – MCP transport implementations and shared interfaces
     - `mod.rs` – Shared transport traits, enums, and list-fetch helpers
     - `stdio.rs` – Stdio transport request/list adapters
-    - `streamable_http.rs` – Streamable HTTP transport list adapters
+    - `streamable_http.rs` – Streamable HTTP list adapters plus shared SSE buffering/parsing utilities
   - `mod.rs` – MCP module exports and tool name constants
   - `permissions.rs` – Per-tool permission decision store
   - `registry.rs` – Enabled MCP server registry

--- a/src/mcp/client/operations.rs
+++ b/src/mcp/client/operations.rs
@@ -30,15 +30,15 @@ where
         McpTransportKind::Stdio => transport_stdio::send_request(context.client(), request).await?,
         McpTransportKind::StreamableHttp => {
             transport_http::ensure_session_context(context).await?;
-            transport_http::send_request_with_context(context, request).await?
+            transport_http::send_request_with_context(context, request, None).await?
         }
     };
     parse(response)
 }
 
-trait OperationContext: super::StreamableHttpContext {
+trait OperationContext: transport_http::StreamableHttpContext {
     fn transport_kind(&self) -> McpTransportKind;
-    fn client(&self) -> Option<std::sync::Arc<super::StdioClient>>;
+    fn client(&self) -> Option<std::sync::Arc<super::transport_stdio::StdioClient>>;
 }
 
 impl OperationContext for McpToolCallContext {
@@ -46,7 +46,7 @@ impl OperationContext for McpToolCallContext {
         self.transport_kind
     }
 
-    fn client(&self) -> Option<std::sync::Arc<super::StdioClient>> {
+    fn client(&self) -> Option<std::sync::Arc<super::transport_stdio::StdioClient>> {
         self.client.clone()
     }
 }
@@ -56,7 +56,7 @@ impl OperationContext for McpPromptContext {
         self.transport_kind
     }
 
-    fn client(&self) -> Option<std::sync::Arc<super::StdioClient>> {
+    fn client(&self) -> Option<std::sync::Arc<super::transport_stdio::StdioClient>> {
         self.client.clone()
     }
 }

--- a/src/mcp/client/tests.rs
+++ b/src/mcp/client/tests.rs
@@ -278,18 +278,6 @@ async fn paginate_tools_list_stops_when_first_page_is_full() {
     let calls = state.lock().await.calls.clone();
     assert_eq!(calls, vec![None]);
 }
-#[test]
-fn event_stream_content_type_parser_handles_parameters_and_case() {
-    assert!(is_event_stream_content_type("text/event-stream"));
-    assert!(is_event_stream_content_type(
-        "Text/Event-Stream; charset=UTF-8"
-    ));
-    assert!(is_event_stream_content_type(
-        "text/event-stream ; version=1"
-    ));
-    assert!(!is_event_stream_content_type("application/json"));
-}
-
 async fn read_http_request(
     stream: &mut tokio::net::TcpStream,
 ) -> Result<(String, Vec<(String, String)>, Vec<u8>), String> {

--- a/src/mcp/client/transport_stdio.rs
+++ b/src/mcp/client/transport_stdio.rs
@@ -1,7 +1,352 @@
-use super::StdioClient;
-use rust_mcp_schema::schema_utils::{RequestFromClient, ResultFromClient, ServerMessage};
-use rust_mcp_schema::{RequestId, RpcError};
+use super::{
+    protocol, require_stdio_command, stdio_args, stdio_env, STDIO_REQUEST_TIMEOUT_SECONDS,
+    STDIO_SAMPLING_TIMEOUT_MULTIPLIER,
+};
+use crate::core::config::data::McpServerConfig;
+use crate::mcp::events::McpServerRequest;
+use rust_mcp_schema::schema_utils::{
+    ClientMessage, FromMessage, MessageFromClient, NotificationFromClient, RequestFromClient,
+    ResultFromClient, ServerMessage,
+};
+use rust_mcp_schema::{InitializeRequestParams, InitializeResult, RequestId, RpcError};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{ChildStdin, Command};
+use tokio::sync::{mpsc, oneshot, Mutex, Notify, RwLock};
+use tracing::debug;
+
+pub(crate) struct StdioClient {
+    stdin: Mutex<ChildStdin>,
+    pending: Arc<Mutex<HashMap<RequestId, oneshot::Sender<ServerMessage>>>>,
+    next_request_id: AtomicI64,
+    server_details: RwLock<Option<rust_mcp_schema::InitializeResult>>,
+    server_id: String,
+    request_tx: Option<mpsc::UnboundedSender<McpServerRequest>>,
+    activity_notify: Arc<Notify>,
+    inflight_server_requests: Arc<AtomicI64>,
+}
+
+impl StdioClient {
+    pub(crate) async fn connect(
+        server_id: String,
+        config: &McpServerConfig,
+        request_tx: Option<mpsc::UnboundedSender<McpServerRequest>>,
+    ) -> Result<Arc<Self>, String> {
+        let command = require_stdio_command(config)?;
+        let args = stdio_args(config);
+        debug!(command = %command, args = ?args, "Starting MCP stdio server");
+        let mut cmd = Command::new(command);
+        cmd.args(args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        if let Some(env) = stdio_env(config) {
+            cmd.envs(env);
+        }
+
+        let mut child = cmd.spawn().map_err(|err| err.to_string())?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "Unable to retrieve stdin.".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "Unable to retrieve stdout.".to_string())?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| "Unable to retrieve stderr.".to_string())?;
+
+        let pending: Arc<Mutex<HashMap<RequestId, oneshot::Sender<ServerMessage>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let client = Arc::new(Self {
+            stdin: Mutex::new(stdin),
+            pending: pending.clone(),
+            next_request_id: AtomicI64::new(0),
+            server_details: RwLock::new(None),
+            server_id,
+            request_tx,
+            activity_notify: Arc::new(Notify::new()),
+            inflight_server_requests: Arc::new(AtomicI64::new(0)),
+        });
+
+        Self::spawn_stdout_reader(
+            pending.clone(),
+            stdout,
+            client.server_id.clone(),
+            client.request_tx.clone(),
+            client.activity_notify.clone(),
+            client.inflight_server_requests.clone(),
+        );
+        Self::spawn_stderr_drain(stderr);
+
+        tokio::spawn(async move {
+            let _ = child.wait().await;
+            let mut pending = pending.lock().await;
+            pending.clear();
+        });
+
+        Ok(client)
+    }
+
+    pub(crate) async fn initialize(
+        &self,
+        details: InitializeRequestParams,
+    ) -> Result<InitializeResult, String> {
+        let response = self
+            .send_request(RequestFromClient::InitializeRequest(details))
+            .await?;
+        let result = protocol::parse_initialize_result(response)?;
+        *self.server_details.write().await = Some(result.clone());
+        self.send_notification(NotificationFromClient::InitializedNotification(None))
+            .await?;
+        Ok(result)
+    }
+
+    pub(crate) async fn send_request(
+        &self,
+        request: RequestFromClient,
+    ) -> Result<ServerMessage, String> {
+        let request_id = self.next_request_id();
+        debug!(request_id = ?request_id, "Sending MCP stdio request");
+        let message = ClientMessage::from_message(
+            MessageFromClient::RequestFromClient(request),
+            Some(request_id.clone()),
+        )
+        .map_err(|err| err.to_string())?;
+
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut pending = self.pending.lock().await;
+            pending.insert(request_id.clone(), tx);
+        }
+
+        self.send_client_message(&message).await?;
+
+        let wait_timeout = self.timeout_for_wait();
+        match tokio::time::timeout(wait_timeout, rx).await {
+            Ok(Ok(message)) => Ok(message),
+            Ok(Err(_)) => {
+                self.pending.lock().await.remove(&request_id);
+                Err("MCP stdio response channel closed.".to_string())
+            }
+            Err(_) => {
+                self.pending.lock().await.remove(&request_id);
+                Err("Timed out waiting for MCP stdio response.".to_string())
+            }
+        }
+    }
+
+    pub(crate) async fn send_result(
+        &self,
+        request_id: RequestId,
+        result: ResultFromClient,
+    ) -> Result<(), String> {
+        debug!(
+            server_id = %self.server_id,
+            request_id = ?request_id,
+            "Preparing MCP stdio result"
+        );
+        let message = ClientMessage::from_message(
+            MessageFromClient::ResultFromClient(result),
+            Some(request_id.clone()),
+        )
+        .map_err(|err| err.to_string())?;
+        let result = self.send_client_message(&message).await;
+        if result.is_ok() {
+            let inflight = self.decrement_inflight();
+            debug!(
+                request_id = ?request_id,
+                inflight_server_requests = inflight,
+                "Sent MCP stdio result"
+            );
+            self.activity_notify.notify_waiters();
+        }
+        result
+    }
+
+    pub(crate) async fn send_error(
+        &self,
+        request_id: RequestId,
+        error: RpcError,
+    ) -> Result<(), String> {
+        debug!(
+            server_id = %self.server_id,
+            request_id = ?request_id,
+            "Preparing MCP stdio error response"
+        );
+        let message =
+            ClientMessage::from_message(MessageFromClient::Error(error), Some(request_id.clone()))
+                .map_err(|err| err.to_string())?;
+        let result = self.send_client_message(&message).await;
+        if result.is_ok() {
+            let inflight = self.decrement_inflight();
+            debug!(
+                request_id = ?request_id,
+                inflight_server_requests = inflight,
+                "Sent MCP stdio error response"
+            );
+            self.activity_notify.notify_waiters();
+        }
+        result
+    }
+
+    async fn send_notification(&self, notification: NotificationFromClient) -> Result<(), String> {
+        let message = ClientMessage::from_message(
+            MessageFromClient::NotificationFromClient(notification),
+            None,
+        )
+        .map_err(|err| err.to_string())?;
+        self.send_client_message(&message).await
+    }
+
+    async fn send_client_message(&self, message: &ClientMessage) -> Result<(), String> {
+        let lock_timeout = tokio::time::Duration::from_secs(10);
+        let write_timeout = tokio::time::Duration::from_secs(10);
+        let payload = serde_json::to_string(message).map_err(|err| err.to_string())?;
+        let mut stdin = match tokio::time::timeout(lock_timeout, self.stdin.lock()).await {
+            Ok(stdin) => stdin,
+            Err(_) => return Err("Timed out waiting for MCP stdio stdin lock.".to_string()),
+        };
+
+        tokio::time::timeout(write_timeout, stdin.write_all(payload.as_bytes()))
+            .await
+            .map_err(|_| "Timed out writing MCP stdio client message.".to_string())?
+            .map_err(|err| err.to_string())?;
+        tokio::time::timeout(write_timeout, stdin.write_all(b"\n"))
+            .await
+            .map_err(|_| "Timed out writing MCP stdio newline.".to_string())?
+            .map_err(|err| err.to_string())?;
+        tokio::time::timeout(write_timeout, stdin.flush())
+            .await
+            .map_err(|_| "Timed out flushing MCP stdio client message.".to_string())?
+            .map_err(|err| err.to_string())?;
+        Ok(())
+    }
+
+    fn timeout_for_wait(&self) -> tokio::time::Duration {
+        let inflight = self.inflight_server_requests.load(Ordering::SeqCst);
+        let multiplier = if inflight > 0 {
+            STDIO_SAMPLING_TIMEOUT_MULTIPLIER
+        } else {
+            1
+        };
+        tokio::time::Duration::from_secs(STDIO_REQUEST_TIMEOUT_SECONDS * multiplier)
+    }
+
+    fn decrement_inflight(&self) -> i64 {
+        let mut current = self.inflight_server_requests.load(Ordering::SeqCst);
+        while current > 0 {
+            match self.inflight_server_requests.compare_exchange(
+                current,
+                current - 1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return current - 1,
+                Err(next) => current = next,
+            }
+        }
+        current
+    }
+
+    fn next_request_id(&self) -> RequestId {
+        let id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
+        RequestId::Integer(id)
+    }
+
+    fn spawn_stdout_reader(
+        pending: Arc<Mutex<HashMap<RequestId, oneshot::Sender<ServerMessage>>>>,
+        stdout: tokio::process::ChildStdout,
+        server_id: String,
+        request_tx: Option<mpsc::UnboundedSender<McpServerRequest>>,
+        activity_notify: Arc<Notify>,
+        inflight_server_requests: Arc<AtomicI64>,
+    ) {
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                let value = match serde_json::from_str::<serde_json::Value>(&line) {
+                    Ok(value) => value,
+                    Err(_) => continue,
+                };
+                if let Some(items) = value.as_array() {
+                    for item in items {
+                        if let Ok(message) = serde_json::from_value::<ServerMessage>(item.clone()) {
+                            Self::dispatch_message(
+                                &pending,
+                                message,
+                                &server_id,
+                                request_tx.as_ref(),
+                                &activity_notify,
+                                &inflight_server_requests,
+                            )
+                            .await;
+                        }
+                    }
+                } else if let Ok(message) = serde_json::from_value::<ServerMessage>(value) {
+                    Self::dispatch_message(
+                        &pending,
+                        message,
+                        &server_id,
+                        request_tx.as_ref(),
+                        &activity_notify,
+                        &inflight_server_requests,
+                    )
+                    .await;
+                }
+            }
+        });
+    }
+
+    fn spawn_stderr_drain(stderr: tokio::process::ChildStderr) {
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stderr).lines();
+            while let Ok(Some(_)) = reader.next_line().await {}
+        });
+    }
+
+    async fn dispatch_message(
+        pending: &Arc<Mutex<HashMap<RequestId, oneshot::Sender<ServerMessage>>>>,
+        message: ServerMessage,
+        server_id: &str,
+        request_tx: Option<&mpsc::UnboundedSender<McpServerRequest>>,
+        activity_notify: &Notify,
+        inflight_server_requests: &AtomicI64,
+    ) {
+        match &message {
+            ServerMessage::Response(response) => {
+                if let Some(tx) = pending.lock().await.remove(&response.id) {
+                    let _ = tx.send(message);
+                }
+            }
+            ServerMessage::Error(error) => {
+                if let Some(id) = error.id.as_ref() {
+                    if let Some(tx) = pending.lock().await.remove(id) {
+                        let _ = tx.send(message);
+                    }
+                }
+            }
+            ServerMessage::Request(request) => {
+                let _ = inflight_server_requests.fetch_add(1, Ordering::SeqCst);
+                activity_notify.notify_waiters();
+                if let Some(tx) = request_tx {
+                    let _ = tx.send(McpServerRequest {
+                        server_id: server_id.to_string(),
+                        request: request.clone(),
+                    });
+                }
+            }
+            ServerMessage::Notification(_) => {
+                activity_notify.notify_waiters();
+            }
+        }
+    }
+}
 
 pub(crate) async fn send_request(
     client: Option<Arc<StdioClient>>,

--- a/src/mcp/transport/streamable_http.rs
+++ b/src/mcp/transport/streamable_http.rs
@@ -1,3 +1,4 @@
+use futures_util::StreamExt;
 use rust_mcp_schema::schema_utils::ServerMessage;
 
 use super::{list_fetch_from_response, ListFetch};
@@ -7,4 +8,148 @@ pub fn fetch_list<T>(
     parse: impl FnOnce(ServerMessage) -> Result<T, String>,
 ) -> ListFetch<T> {
     list_fetch_from_response(response, parse)
+}
+
+#[derive(Default)]
+pub struct SseLineBuffer {
+    buffer: Vec<u8>,
+}
+
+impl SseLineBuffer {
+    pub fn push(&mut self, chunk: &[u8]) -> Vec<String> {
+        self.buffer.extend_from_slice(chunk);
+        self.drain_lines(false)
+    }
+
+    pub fn finish(&mut self) -> Vec<String> {
+        self.drain_lines(true)
+    }
+
+    fn drain_lines(&mut self, flush: bool) -> Vec<String> {
+        let mut lines = Vec::new();
+        let mut search_index = 0;
+
+        while let Some(relative_pos) = self.buffer[search_index..].iter().position(|b| *b == b'\n')
+        {
+            let newline_index = search_index + relative_pos;
+            let mut line_end = newline_index;
+            if line_end > search_index && self.buffer[line_end - 1] == b'\r' {
+                line_end -= 1;
+            }
+
+            let line_bytes = &self.buffer[search_index..line_end];
+            if let Ok(text) = std::str::from_utf8(line_bytes) {
+                let trimmed = text.trim();
+                if !trimmed.is_empty() {
+                    lines.push(trimmed.to_string());
+                }
+            }
+
+            search_index = newline_index + 1;
+        }
+
+        if flush {
+            if let Ok(text) = std::str::from_utf8(&self.buffer[search_index..]) {
+                let trimmed = text.trim();
+                if !trimmed.is_empty() {
+                    lines.push(trimmed.to_string());
+                }
+            }
+            self.buffer.clear();
+        } else if search_index > 0 {
+            self.buffer.drain(..search_index);
+        }
+
+        lines
+    }
+}
+
+pub fn is_event_stream_content_type(content_type: &str) -> bool {
+    content_type
+        .split(';')
+        .next()
+        .map(str::trim)
+        .is_some_and(|value| value.eq_ignore_ascii_case("text/event-stream"))
+}
+
+pub fn sse_data_payload(line: &str) -> Option<&str> {
+    line.strip_prefix("data:").map(str::trim)
+}
+
+pub async fn next_sse_server_message(
+    response: reqwest::Response,
+    mut on_message: impl FnMut(&ServerMessage),
+) -> Result<ServerMessage, String> {
+    let mut stream = response.bytes_stream();
+    let mut buffer = SseLineBuffer::default();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|err| err.to_string())?;
+        for line in buffer.push(&chunk) {
+            if let Some(message) = decode_sse_line(&line)? {
+                on_message(&message);
+                if matches!(
+                    message,
+                    ServerMessage::Response(_) | ServerMessage::Error(_)
+                ) {
+                    return Ok(message);
+                }
+            }
+        }
+    }
+
+    for line in buffer.finish() {
+        if let Some(message) = decode_sse_line(&line)? {
+            on_message(&message);
+            if matches!(
+                message,
+                ServerMessage::Response(_) | ServerMessage::Error(_)
+            ) {
+                return Ok(message);
+            }
+        }
+    }
+
+    Err("Empty event-stream response.".to_string())
+}
+
+fn decode_sse_line(line: &str) -> Result<Option<ServerMessage>, String> {
+    let Some(payload) = sse_data_payload(line) else {
+        return Ok(None);
+    };
+
+    if payload.is_empty() {
+        return Ok(None);
+    }
+
+    serde_json::from_str::<ServerMessage>(payload)
+        .map(Some)
+        .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sse_buffer_handles_partial_lines() {
+        let mut buffer = SseLineBuffer::default();
+        assert!(buffer.push(b"data: one").is_empty());
+        assert_eq!(buffer.push(b"\n\n"), vec!["data: one"]);
+        assert!(buffer.finish().is_empty());
+    }
+
+    #[test]
+    fn detects_event_stream_content_type() {
+        assert!(is_event_stream_content_type(
+            "text/event-stream; charset=utf-8"
+        ));
+        assert!(!is_event_stream_content_type("application/json"));
+    }
+
+    #[test]
+    fn extracts_sse_payload() {
+        assert_eq!(sse_data_payload("data: {\"id\":1}"), Some("{\"id\":1}"));
+        assert_eq!(sse_data_payload("event: ping"), None);
+    }
 }


### PR DESCRIPTION
## Summary
This refactor pulls transport-specific MCP client logic out of the
central client manager into focused transport modules, while keeping
runtime behavior the same.

## What changed
- moved stdio client lifecycle, request/response routing, and server
  I/O readers into `transport_stdio`
- moved streamable HTTP SSE buffering/parsing helpers into
  `mcp::transport::streamable_http`
- updated HTTP request flow to use shared transport context helpers for
  session initialization and request exchange
- preserved negotiated protocol version explicitly in server state and
  reused it across tool, prompt, and server-request contexts
- refreshed README MCP module descriptions to match the new boundaries

## Why
The previous `mcp/client/mod.rs` concentrated transport mechanics,
session handling, and SSE parsing in one place. Splitting these concerns
improves maintainability and makes future transport-specific changes
safer and more localized.

## Impact
- no intended user-facing behavior change
- lower coupling between MCP manager and transport internals
- clearer ownership for stdio vs streamable HTTP protocol mechanics
