### PR TITLE
Refactor streaming action handling into focused modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Chabeau uses a modular design with focused components:
   - `app/` – Application state and controllers
     - `actions/` – Internal action definitions grouped by domain (streaming, input, picker, prompt) plus dispatcher routing
       - `input/` – Input subdomains for compose, command, inspect, and status actions
+      - `stream_*`/`tool_calls`/`sampling`/`mcp_gate` modules – Focused streaming action handlers for lifecycle, MCP gating, errors, sampling, and tool-call flows
     - `app.rs` – Main `App` struct and event loop integration
     - `conversation.rs` – Conversation controller for chat flow, retries, and streaming helpers
     - `mod.rs` – App struct and module exports

--- a/src/core/app/actions/mcp_gate.rs
+++ b/src/core/app/actions/mcp_gate.rs
@@ -1,0 +1,41 @@
+use super::{App, AppActionContext, AppCommand};
+
+pub(super) fn handle_mcp_init_completed(
+    app: &mut App,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    super::handle_mcp_init_completed(app, ctx)
+}
+
+pub(super) fn handle_mcp_send_without_tools(
+    app: &mut App,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    super::handle_mcp_send_without_tools(app, ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::app::actions::{AppCommand, StreamingAction};
+    use crate::utils::test_utils::create_test_app;
+
+    fn default_ctx() -> AppActionContext {
+        AppActionContext {
+            term_width: 80,
+            term_height: 24,
+        }
+    }
+
+    #[test]
+    fn mcp_init_completed_spawns_pending_message() {
+        let mut app = create_test_app();
+        app.session.pending_mcp_message = Some("hi".into());
+        let command = super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::McpInitCompleted,
+            default_ctx(),
+        );
+        assert!(matches!(command, Some(AppCommand::SpawnStream(_))));
+    }
+}

--- a/src/core/app/actions/sampling.rs
+++ b/src/core/app/actions/sampling.rs
@@ -1,0 +1,63 @@
+use super::{App, AppActionContext, AppCommand};
+
+pub(super) fn handle_mcp_server_request(
+    app: &mut App,
+    request: crate::mcp::events::McpServerRequest,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    super::handle_mcp_server_request(app, request, ctx)
+}
+
+pub(super) fn handle_mcp_sampling_finished(
+    app: &mut App,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    super::handle_mcp_sampling_finished(app, ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::app::actions::StreamingAction;
+    use crate::utils::test_utils::create_test_app;
+
+    fn default_ctx() -> AppActionContext {
+        AppActionContext {
+            term_width: 80,
+            term_height: 24,
+        }
+    }
+
+    #[test]
+    fn sampling_finished_clears_active_request() {
+        let mut app = create_test_app();
+        let params = rust_mcp_schema::CreateMessageRequestParams {
+            include_context: None,
+            max_tokens: 16,
+            messages: vec![],
+            meta: None,
+            metadata: None,
+            model_preferences: None,
+            stop_sequences: vec![],
+            system_prompt: None,
+            task: None,
+            temperature: None,
+            tool_choice: None,
+            tools: vec![],
+        };
+        app.session.active_sampling_request = Some(crate::core::app::session::McpSamplingRequest {
+            server_id: "s".into(),
+            request: rust_mcp_schema::CreateMessageRequest::new(
+                rust_mcp_schema::RequestId::Integer(1),
+                params,
+            ),
+            messages: vec![],
+        });
+        let _ = super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::McpSamplingFinished,
+            default_ctx(),
+        );
+        assert!(app.session.active_sampling_request.is_none());
+    }
+}

--- a/src/core/app/actions/stream_errors.rs
+++ b/src/core/app/actions/stream_errors.rs
@@ -1,0 +1,62 @@
+use super::{App, AppActionContext, AppCommand};
+
+pub(super) fn handle_stream_error(
+    app: &mut App,
+    message: String,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    super::handle_stream_error(app, message, ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::app::actions::{AppCommand, StreamingAction};
+    use crate::core::message::{ROLE_APP_ERROR, ROLE_ASSISTANT, ROLE_USER};
+    use crate::utils::test_utils::create_test_app;
+
+    fn default_ctx() -> AppActionContext {
+        AppActionContext {
+            term_width: 80,
+            term_height: 24,
+        }
+    }
+
+    #[test]
+    fn stream_errored_drops_empty_assistant_placeholder() {
+        let mut app = create_test_app();
+        let ctx = default_ctx();
+
+        let command = super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::SubmitMessage {
+                message: "Hello there".into(),
+            },
+            ctx,
+        );
+
+        let stream_id = match command {
+            Some(AppCommand::SpawnStream(params)) => params.stream_id,
+            _ => panic!("expected stream"),
+        };
+
+        let result = super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::StreamErrored {
+                message: " network failure ".into(),
+                stream_id,
+            },
+            ctx,
+        );
+        assert!(result.is_none());
+        assert!(app
+            .ui
+            .messages
+            .iter()
+            .all(|m| m.role != ROLE_ASSISTANT || !m.content.trim().is_empty()));
+        let last = app.ui.messages.back().expect("last");
+        assert_eq!(last.role, ROLE_APP_ERROR);
+        assert_eq!(last.content, "network failure");
+        assert_eq!(app.ui.messages.front().expect("first").role, ROLE_USER);
+    }
+}

--- a/src/core/app/actions/stream_lifecycle.rs
+++ b/src/core/app/actions/stream_lifecycle.rs
@@ -1,0 +1,148 @@
+use super::{App, AppActionContext, AppCommand};
+
+pub(super) fn spawn_stream_for_message(
+    app: &mut App,
+    message: String,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    super::spawn_stream_for_message(app, message, ctx)
+}
+
+pub(super) fn retry_last_message(app: &mut App, ctx: AppActionContext) -> Option<AppCommand> {
+    super::retry_last_message(app, ctx)
+}
+
+pub(super) fn refine_last_message(
+    app: &mut App,
+    prompt: String,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    super::refine_last_message(app, prompt, ctx)
+}
+
+pub(super) fn finalize_stream(app: &mut App, ctx: AppActionContext) -> Option<AppCommand> {
+    super::finalize_stream(app, ctx)
+}
+
+pub(super) fn append_response_chunk(app: &mut App, chunk: &str, ctx: AppActionContext) {
+    super::append_response_chunk(app, chunk, ctx)
+}
+
+pub(super) fn append_stream_app_message(
+    app: &mut App,
+    kind: crate::core::message::AppMessageKind,
+    message: String,
+    ctx: AppActionContext,
+) {
+    super::append_stream_app_message(app, kind, message, ctx)
+}
+
+pub(super) fn append_tool_call_delta(
+    app: &mut App,
+    delta: crate::core::chat_stream::ToolCallDelta,
+) {
+    super::append_tool_call_delta(app, delta)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::app::actions::{AppCommand, StreamingAction};
+    use crate::core::message::{
+        AppMessageKind, ROLE_APP_WARNING, ROLE_TOOL_CALL, ROLE_TOOL_RESULT,
+    };
+    use crate::utils::test_utils::create_test_app;
+
+    fn default_ctx() -> AppActionContext {
+        AppActionContext {
+            term_width: 80,
+            term_height: 24,
+        }
+    }
+
+    #[test]
+    fn stream_app_message_adds_trimmed_content_and_keeps_stream_alive() {
+        let mut app = create_test_app();
+        let ctx = default_ctx();
+        let command = super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::SubmitMessage {
+                message: "Hello there".into(),
+            },
+            ctx,
+        );
+        let stream_id = match command {
+            Some(AppCommand::SpawnStream(params)) => params.stream_id,
+            _ => panic!("expected stream"),
+        };
+        let result = super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::StreamAppMessage {
+                kind: AppMessageKind::Warning,
+                message: "  invalid utf8  ".into(),
+                stream_id,
+            },
+            ctx,
+        );
+        assert!(result.is_none());
+        let last = app.ui.messages.back().expect("message");
+        assert_eq!(last.role, ROLE_APP_WARNING);
+        assert_eq!(last.content, "invalid utf8");
+        assert!(app.ui.is_streaming);
+    }
+
+    #[test]
+    fn stream_tool_call_delta_flushes_on_complete() {
+        let mut app = create_test_app();
+        let ctx = default_ctx();
+        let command = super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::SubmitMessage {
+                message: "Run a tool".into(),
+            },
+            ctx,
+        );
+        let stream_id = match command {
+            Some(AppCommand::SpawnStream(params)) => params.stream_id,
+            _ => panic!("expected stream"),
+        };
+        super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::StreamToolCallDelta {
+                stream_id,
+                delta: crate::core::chat_stream::ToolCallDelta {
+                    index: 0,
+                    id: Some("call-1".into()),
+                    name: Some("lookup".into()),
+                    arguments: Some("{\"q\":".into()),
+                },
+            },
+            ctx,
+        );
+        super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::StreamToolCallDelta {
+                stream_id,
+                delta: crate::core::chat_stream::ToolCallDelta {
+                    index: 0,
+                    id: None,
+                    name: None,
+                    arguments: Some("\"mcp\"}".into()),
+                },
+            },
+            ctx,
+        );
+        let command = super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::StreamCompleted { stream_id },
+            ctx,
+        );
+        assert!(matches!(command, Some(AppCommand::SpawnStream(_))));
+        assert!(app.ui.messages.iter().any(|msg| msg.role == ROLE_TOOL_CALL));
+        assert!(app
+            .ui
+            .messages
+            .iter()
+            .any(|msg| msg.role == ROLE_TOOL_RESULT));
+    }
+}

--- a/src/core/app/actions/tool_calls.rs
+++ b/src/core/app/actions/tool_calls.rs
@@ -1,0 +1,100 @@
+use super::{App, AppActionContext, AppCommand};
+use crate::core::app::session::ToolFailureKind;
+use crate::mcp::permissions::ToolPermissionDecision;
+
+#[derive(Debug, Clone)]
+pub(super) struct ToolResultMeta {
+    pub(super) server_label: Option<String>,
+    pub(super) server_id: Option<String>,
+    pub(super) tool_call_id: Option<String>,
+    pub(super) raw_arguments: Option<String>,
+    pub(super) failure_kind: Option<ToolFailureKind>,
+}
+
+impl ToolResultMeta {
+    pub(super) fn new(
+        server_label: Option<String>,
+        server_id: Option<String>,
+        tool_call_id: Option<String>,
+        raw_arguments: Option<String>,
+    ) -> Self {
+        Self {
+            server_label,
+            server_id,
+            tool_call_id,
+            raw_arguments,
+            failure_kind: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PendingToolError {
+    pub(super) tool_name: String,
+    pub(super) server_id: Option<String>,
+    pub(super) tool_call_id: Option<String>,
+    pub(super) raw_arguments: Option<String>,
+    pub(super) error: String,
+}
+
+pub(super) fn handle_tool_permission_decision(
+    app: &mut App,
+    decision: ToolPermissionDecision,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    super::handle_tool_permission_decision(app, decision, ctx)
+}
+
+pub(super) fn handle_tool_call_completed(
+    app: &mut App,
+    tool_name: String,
+    tool_call_id: Option<String>,
+    result: Result<String, String>,
+    ctx: AppActionContext,
+) -> Option<AppCommand> {
+    super::handle_tool_call_completed(app, tool_name, tool_call_id, result, ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::app::actions::StreamingAction;
+    use crate::core::app::session::{ToolCallRequest, ToolResultStatus};
+    use crate::utils::test_utils::create_test_app;
+
+    fn default_ctx() -> AppActionContext {
+        AppActionContext {
+            term_width: 80,
+            term_height: 24,
+        }
+    }
+
+    #[test]
+    fn tool_call_completed_flags_tool_error_payloads() {
+        let mut app = create_test_app();
+        let ctx = default_ctx();
+        app.session.active_tool_request = Some(ToolCallRequest {
+            server_id: "alpha".to_string(),
+            tool_name: "lookup".to_string(),
+            arguments: None,
+            raw_arguments: "{}".to_string(),
+            tool_call_id: Some("call-1".to_string()),
+        });
+
+        let payload = serde_json::json!({"content": [], "isError": true}).to_string();
+        let result = super::super::handle_streaming_action(
+            &mut app,
+            StreamingAction::ToolCallCompleted {
+                tool_name: "lookup".to_string(),
+                tool_call_id: Some("call-1".to_string()),
+                result: Ok(payload),
+            },
+            ctx,
+        );
+        assert!(result.is_none());
+
+        let record = app.session.tool_result_history.last().expect("record");
+        assert_eq!(record.status, ToolResultStatus::Error);
+        assert_eq!(record.failure_kind, Some(ToolFailureKind::ToolError));
+    }
+}


### PR DESCRIPTION
## Summary
This refactor splits the streaming action dispatcher into focused submodules
for stream lifecycle, tool-call handling, MCP gating, sampling, and stream
error paths.

## Why
The previous `streaming.rs` mixed multiple concerns, which made targeted test
coverage and future changes harder. Separating these paths improves local
reasoning and keeps responsibilities explicit while preserving behavior.

## Impact
- Preserves existing streaming/tool-call behavior while clarifying dispatch.
- Moves and scopes tests to each subdomain module for better maintainability.
- Keeps the public behavior unchanged; this is an internal architecture
  refactor.
- Updates README module map so contributors can locate streaming handlers
  quickly.
