### PR TITLE
refactor(settings): share set/unset helpers

### DIFF
--- a/src/cli/settings/handlers/provider_model_keyed.rs
+++ b/src/cli/settings/handlers/provider_model_keyed.rs
@@ -1,30 +1,65 @@
 //! Provider+model-keyed setting handlers for HashMap<String, HashMap<String, String>> settings.
 
-use std::collections::HashMap;
-
 use crate::cli::settings::error::SettingError;
-use crate::cli::settings::helpers::{mutate_config, validate_provider};
+use crate::cli::settings::helpers::{
+    format_provider_model_map, mutate_config_with_message, parse_provider_model,
+    parse_provider_model_value, success_set_provider_model_value,
+    success_unset_provider_model_value,
+};
 use crate::cli::settings::{SetContext, SettingHandler};
 use crate::core::config::data::Config;
 use crate::core::persona::PersonaManager;
 use crate::core::preset::PresetManager;
 
-/// Parse "provider model" from an unset command's optional value string and validate the provider.
-fn parse_provider_model_args(
+fn set_provider_model_value<V, M>(
+    args: &[String],
+    ctx: &mut SetContext<'_>,
+    setting: &'static str,
+    missing_hint: &'static str,
+    missing_example: &'static str,
+    validate_value: V,
+    mutate: M,
+) -> Result<String, SettingError>
+where
+    V: FnOnce(&mut SetContext<'_>, String) -> Result<String, SettingError>,
+    M: FnOnce(&mut Config, String, String, String),
+{
+    let (provider, model, value) =
+        parse_provider_model_value(args, ctx, missing_hint, missing_example)?;
+    let value = validate_value(ctx, value)?;
+
+    let message = success_set_provider_model_value(setting, &provider, &model, &value);
+
+    mutate_config_with_message(
+        move |config| {
+            mutate(config, provider, model, value);
+            Ok(())
+        },
+        message,
+    )
+}
+
+fn unset_provider_model_value<M>(
     args: Option<&str>,
-    ctx: &SetContext<'_>,
-    hint: &'static str,
-    example: &'static str,
-) -> Result<(String, String), SettingError> {
-    let value = args.ok_or(SettingError::MissingArgs { hint, example })?;
+    ctx: &mut SetContext<'_>,
+    setting: &'static str,
+    missing_hint: &'static str,
+    missing_example: &'static str,
+    mutate: M,
+) -> Result<String, SettingError>
+where
+    M: FnOnce(&mut Config, &str, &str),
+{
+    let (provider, model) = parse_provider_model(args, ctx, missing_hint, missing_example)?;
+    let message = success_unset_provider_model_value(setting, &provider, &model);
 
-    let parts: Vec<&str> = value.splitn(2, ' ').collect();
-    if parts.len() < 2 {
-        return Err(SettingError::MissingArgs { hint, example });
-    }
-
-    let resolved_provider = validate_provider(ctx.config, parts[0])?;
-    Ok((resolved_provider, parts[1].to_string()))
+    mutate_config_with_message(
+        move |config| {
+            mutate(config, &provider, &model);
+            Ok(())
+        },
+        message,
+    )
 }
 
 /// Handler for the `default-character` setting.
@@ -36,67 +71,45 @@ impl SettingHandler for DefaultCharacterHandler {
     }
 
     fn set(&self, args: &[String], ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
-        if args.len() < 3 {
-            return Err(SettingError::MissingArgs {
-                hint: "To set a default character, specify provider, model, and character:",
-                example: "chabeau set default-character openai gpt-4 alice",
-            });
-        }
-
-        let provider_input = &args[0];
-        let model = &args[1];
-        let character = args[2..].join(" ");
-
-        let resolved_provider = validate_provider(ctx.config, provider_input)?;
-
-        // Validate character exists
-        ctx.character_service
-            .resolve_by_name(&character)
-            .map_err(|_| SettingError::UnknownItem {
-                kind: "Character",
-                input: character.clone(),
-                hint: Some("Run 'chabeau import <file>' to import a character card first".into()),
-            })?;
-
-        let provider_msg = resolved_provider.clone();
-        let model_msg = model.clone();
-        let model_for_closure = model.clone();
-        let character_msg = character.clone();
-
-        mutate_config(move |config| {
-            config.set_default_character(resolved_provider, model_for_closure, character);
-            Ok(())
-        })?;
-
-        Ok(format!(
-            "✅ Set default character for '{}:{}' to: {}",
-            provider_msg, model_msg, character_msg
-        ))
+        set_provider_model_value(
+            args,
+            ctx,
+            "default character",
+            "To set a default character, specify provider, model, and character:",
+            "chabeau set default-character openai gpt-4 alice",
+            |ctx, character| {
+                ctx.character_service
+                    .resolve_by_name(&character)
+                    .map_err(|_| SettingError::UnknownItem {
+                        kind: "Character",
+                        input: character.clone(),
+                        hint: Some(
+                            "Run 'chabeau import <file>' to import a character card first".into(),
+                        ),
+                    })?;
+                Ok(character)
+            },
+            |config, provider, model, character| {
+                config.set_default_character(provider, model, character);
+            },
+        )
     }
 
     fn unset(&self, args: Option<&str>, ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
-        let (provider, model) = parse_provider_model_args(
+        unset_provider_model_value(
             args,
             ctx,
+            "default character",
             "To unset a default character, specify provider and model:",
             "chabeau unset default-character \"openai gpt-4\"",
-        )?;
-
-        let provider_msg = provider.clone();
-        let model_msg = model.clone();
-
-        mutate_config(move |config| {
-            config.unset_default_character(&provider, &model);
-            Ok(())
-        })?;
-
-        Ok(format!(
-            "✅ Unset default character for '{provider_msg}:{model_msg}'"
-        ))
+            |config, provider, model| {
+                config.unset_default_character(provider, model);
+            },
+        )
     }
 
     fn format(&self, config: &Config) -> String {
-        format_nested_map("default-characters", &config.default_characters)
+        format_provider_model_map("default-characters", &config.default_characters)
     }
 }
 
@@ -109,82 +122,62 @@ impl SettingHandler for DefaultPersonaHandler {
     }
 
     fn set(&self, args: &[String], ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
-        if args.len() < 3 {
-            return Err(SettingError::MissingArgs {
-                hint: "To set a default persona, specify provider, model, and persona:",
-                example: "chabeau set default-persona anthropic claude-3-5-sonnet friendly",
-            });
-        }
+        set_provider_model_value(
+            args,
+            ctx,
+            "default persona",
+            "To set a default persona, specify provider, model, and persona:",
+            "chabeau set default-persona anthropic claude-3-5-sonnet friendly",
+            |ctx, persona_id| {
+                let persona_manager = PersonaManager::load_personas(ctx.config)
+                    .map_err(|e| SettingError::ConfigError(e.to_string()))?;
 
-        let provider_input = &args[0];
-        let model = &args[1];
-        let persona_id = args[2..].join(" ");
+                if persona_manager.find_persona_by_id(&persona_id).is_none() {
+                    let available: Vec<_> = persona_manager
+                        .list_personas()
+                        .iter()
+                        .map(|p| p.id.as_str())
+                        .collect();
 
-        let resolved_provider = validate_provider(ctx.config, provider_input)?;
+                    let hint = if available.is_empty() {
+                        Some(
+                            "Add personas to your config.toml file in the [[personas]] section."
+                                .into(),
+                        )
+                    } else {
+                        Some(format!("Available personas: {}", available.join(", ")))
+                    };
 
-        // Validate persona exists
-        let persona_manager = PersonaManager::load_personas(ctx.config)
-            .map_err(|e| SettingError::ConfigError(e.to_string()))?;
+                    return Err(SettingError::UnknownItem {
+                        kind: "Persona",
+                        input: persona_id,
+                        hint,
+                    });
+                }
 
-        if persona_manager.find_persona_by_id(&persona_id).is_none() {
-            let available: Vec<_> = persona_manager
-                .list_personas()
-                .iter()
-                .map(|p| p.id.as_str())
-                .collect();
-
-            let hint = if available.is_empty() {
-                Some("Add personas to your config.toml file in the [[personas]] section.".into())
-            } else {
-                Some(format!("Available personas: {}", available.join(", ")))
-            };
-
-            return Err(SettingError::UnknownItem {
-                kind: "Persona",
-                input: persona_id,
-                hint,
-            });
-        }
-
-        let provider_msg = resolved_provider.clone();
-        let model_msg = model.clone();
-        let model_for_closure = model.clone();
-        let persona_msg = persona_id.clone();
-
-        mutate_config(move |config| {
-            config.set_default_persona(resolved_provider, model_for_closure, persona_id);
-            Ok(())
-        })?;
-
-        Ok(format!(
-            "✅ Set default persona for '{}:{}' to: {}",
-            provider_msg, model_msg, persona_msg
-        ))
+                Ok(persona_id)
+            },
+            |config, provider, model, persona_id| {
+                config.set_default_persona(provider, model, persona_id);
+            },
+        )
     }
 
     fn unset(&self, args: Option<&str>, ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
-        let (provider, model) = parse_provider_model_args(
+        unset_provider_model_value(
             args,
             ctx,
+            "default persona",
             "To unset a default persona, specify provider and model:",
             "chabeau unset default-persona \"anthropic claude-3-5-sonnet\"",
-        )?;
-
-        let provider_msg = provider.clone();
-        let model_msg = model.clone();
-
-        mutate_config(move |config| {
-            config.unset_default_persona(&provider, &model);
-            Ok(())
-        })?;
-
-        Ok(format!(
-            "✅ Unset default persona for '{provider_msg}:{model_msg}'"
-        ))
+            |config, provider, model| {
+                config.unset_default_persona(provider, model);
+            },
+        )
     }
 
     fn format(&self, config: &Config) -> String {
-        format_nested_map("default-personas", &config.default_personas)
+        format_provider_model_map("default-personas", &config.default_personas)
     }
 }
 
@@ -197,101 +190,61 @@ impl SettingHandler for DefaultPresetHandler {
     }
 
     fn set(&self, args: &[String], ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
-        if args.len() < 3 {
-            return Err(SettingError::MissingArgs {
-                hint: "To set a default preset, specify provider, model, and preset:",
-                example: "chabeau set default-preset openai gpt-4o short",
-            });
-        }
+        set_provider_model_value(
+            args,
+            ctx,
+            "default preset",
+            "To set a default preset, specify provider, model, and preset:",
+            "chabeau set default-preset openai gpt-4o short",
+            |ctx, preset_id| {
+                let preset_manager = PresetManager::load_presets(ctx.config)
+                    .map_err(|e| SettingError::ConfigError(e.to_string()))?;
 
-        let provider_input = &args[0];
-        let model = &args[1];
-        let preset_id = args[2..].join(" ");
+                if preset_manager.find_preset_by_id(&preset_id).is_none() {
+                    let available: Vec<_> = preset_manager
+                        .list_presets()
+                        .iter()
+                        .map(|p| p.id.as_str())
+                        .collect();
 
-        let resolved_provider = validate_provider(ctx.config, provider_input)?;
+                    let hint = if available.is_empty() {
+                        Some(
+                            "Add presets to your config.toml file in the [[presets]] section."
+                                .into(),
+                        )
+                    } else {
+                        Some(format!("Available presets: {}", available.join(", ")))
+                    };
 
-        // Validate preset exists
-        let preset_manager = PresetManager::load_presets(ctx.config)
-            .map_err(|e| SettingError::ConfigError(e.to_string()))?;
+                    return Err(SettingError::UnknownItem {
+                        kind: "Preset",
+                        input: preset_id,
+                        hint,
+                    });
+                }
 
-        if preset_manager.find_preset_by_id(&preset_id).is_none() {
-            let available: Vec<_> = preset_manager
-                .list_presets()
-                .iter()
-                .map(|p| p.id.as_str())
-                .collect();
-
-            let hint = if available.is_empty() {
-                Some("Add presets to your config.toml file in the [[presets]] section.".into())
-            } else {
-                Some(format!("Available presets: {}", available.join(", ")))
-            };
-
-            return Err(SettingError::UnknownItem {
-                kind: "Preset",
-                input: preset_id,
-                hint,
-            });
-        }
-
-        let provider_msg = resolved_provider.clone();
-        let model_msg = model.clone();
-        let model_for_closure = model.clone();
-        let preset_msg = preset_id.clone();
-
-        mutate_config(move |config| {
-            config.set_default_preset(resolved_provider, model_for_closure, preset_id);
-            Ok(())
-        })?;
-
-        Ok(format!(
-            "✅ Set default preset for '{}:{}' to: {}",
-            provider_msg, model_msg, preset_msg
-        ))
+                Ok(preset_id)
+            },
+            |config, provider, model, preset_id| {
+                config.set_default_preset(provider, model, preset_id);
+            },
+        )
     }
 
     fn unset(&self, args: Option<&str>, ctx: &mut SetContext<'_>) -> Result<String, SettingError> {
-        let (provider, model) = parse_provider_model_args(
+        unset_provider_model_value(
             args,
             ctx,
+            "default preset",
             "To unset a default preset, specify provider and model:",
             "chabeau unset default-preset \"openai gpt-4o\"",
-        )?;
-
-        let provider_msg = provider.clone();
-        let model_msg = model.clone();
-
-        mutate_config(move |config| {
-            config.unset_default_preset(&provider, &model);
-            Ok(())
-        })?;
-
-        Ok(format!(
-            "✅ Unset default preset for '{provider_msg}:{model_msg}'"
-        ))
+            |config, provider, model| {
+                config.unset_default_preset(provider, model);
+            },
+        )
     }
 
     fn format(&self, config: &Config) -> String {
-        format_nested_map("default-presets", &config.default_presets)
-    }
-}
-
-/// Format a nested HashMap<String, HashMap<String, String>> for display.
-fn format_nested_map(name: &str, map: &HashMap<String, HashMap<String, String>>) -> String {
-    if map.is_empty() {
-        format!("  {name}: (none set)")
-    } else {
-        let mut output = format!("  {name}:\n");
-        let mut providers: Vec<_> = map.iter().collect();
-        providers.sort_by_key(|(k, _)| *k);
-        for (provider, models) in providers {
-            let mut model_entries: Vec<_> = models.iter().collect();
-            model_entries.sort_by_key(|(k, _)| *k);
-            for (model, value) in model_entries {
-                output.push_str(&format!("    {provider}:{model}: {value}\n"));
-            }
-        }
-        output.pop(); // Remove trailing newline
-        output
+        format_provider_model_map("default-presets", &config.default_presets)
     }
 }

--- a/src/cli/settings/handlers/simple.rs
+++ b/src/cli/settings/handlers/simple.rs
@@ -1,7 +1,9 @@
 //! Simple setting handlers for single-value settings.
 
 use crate::cli::settings::error::SettingError;
-use crate::cli::settings::helpers::{mutate_config, validate_provider, validate_theme};
+use crate::cli::settings::helpers::{
+    mutate_config_with_message, success_set, success_unset, validate_provider, validate_theme,
+};
 use crate::cli::settings::{SetContext, SettingHandler};
 use crate::core::config::data::Config;
 
@@ -21,16 +23,16 @@ impl SettingHandler for DefaultProviderHandler {
             });
         }
 
-        let provider_input = args.join(" ");
-        let resolved = validate_provider(ctx.config, &provider_input)?;
-        let msg = resolved.clone();
+        let provider = validate_provider(ctx.config, &args.join(" "))?;
+        let message = success_set("default-provider", &provider);
 
-        mutate_config(move |config| {
-            config.default_provider = Some(resolved);
-            Ok(())
-        })?;
-
-        Ok(format!("✅ Set default-provider to: {msg}"))
+        mutate_config_with_message(
+            move |config| {
+                config.default_provider = Some(provider);
+                Ok(())
+            },
+            message,
+        )
     }
 
     fn unset(
@@ -38,12 +40,13 @@ impl SettingHandler for DefaultProviderHandler {
         _args: Option<&str>,
         _ctx: &mut SetContext<'_>,
     ) -> Result<String, SettingError> {
-        mutate_config(|config| {
-            config.default_provider = None;
-            Ok(())
-        })?;
-
-        Ok("✅ Unset default-provider".to_string())
+        mutate_config_with_message(
+            |config| {
+                config.default_provider = None;
+                Ok(())
+            },
+            success_unset("default-provider"),
+        )
     }
 
     fn format(&self, config: &Config) -> String {
@@ -70,16 +73,16 @@ impl SettingHandler for ThemeHandler {
             });
         }
 
-        let theme_input = args.join(" ");
-        let resolved = validate_theme(ctx.config, &theme_input)?;
-        let msg = resolved.clone();
+        let theme = validate_theme(ctx.config, &args.join(" "))?;
+        let message = success_set("theme", &theme);
 
-        mutate_config(move |config| {
-            config.theme = Some(resolved);
-            Ok(())
-        })?;
-
-        Ok(format!("✅ Set theme to: {msg}"))
+        mutate_config_with_message(
+            move |config| {
+                config.theme = Some(theme);
+                Ok(())
+            },
+            message,
+        )
     }
 
     fn unset(
@@ -87,12 +90,13 @@ impl SettingHandler for ThemeHandler {
         _args: Option<&str>,
         _ctx: &mut SetContext<'_>,
     ) -> Result<String, SettingError> {
-        mutate_config(|config| {
-            config.theme = None;
-            Ok(())
-        })?;
-
-        Ok("✅ Unset theme".to_string())
+        mutate_config_with_message(
+            |config| {
+                config.theme = None;
+                Ok(())
+            },
+            success_unset("theme"),
+        )
     }
 
     fn format(&self, config: &Config) -> String {

--- a/src/cli/settings/handlers/string.rs
+++ b/src/cli/settings/handlers/string.rs
@@ -1,7 +1,7 @@
 //! String setting handlers for text-based settings.
 
 use crate::cli::settings::error::SettingError;
-use crate::cli::settings::helpers::mutate_config;
+use crate::cli::settings::helpers::{mutate_config_with_message, success_set};
 use crate::cli::settings::{SetContext, SettingHandler};
 use crate::core::config::data::{Config, DEFAULT_REFINE_INSTRUCTIONS, DEFAULT_REFINE_PREFIX};
 
@@ -24,12 +24,13 @@ impl SettingHandler for RefineInstructionsHandler {
         let value = args.join(" ");
         let display = truncate_with_ellipsis(&value, 50);
 
-        mutate_config(move |config| {
-            config.refine_instructions = Some(value);
-            Ok(())
-        })?;
-
-        Ok(format!("✅ Set refine-instructions to: {display}"))
+        mutate_config_with_message(
+            move |config| {
+                config.refine_instructions = Some(value);
+                Ok(())
+            },
+            success_set("refine-instructions", &display),
+        )
     }
 
     fn unset(
@@ -37,12 +38,13 @@ impl SettingHandler for RefineInstructionsHandler {
         _args: Option<&str>,
         _ctx: &mut SetContext<'_>,
     ) -> Result<String, SettingError> {
-        mutate_config(|config| {
-            config.refine_instructions = None;
-            Ok(())
-        })?;
-
-        Ok("✅ Unset refine-instructions (will use default)".to_string())
+        mutate_config_with_message(
+            |config| {
+                config.refine_instructions = None;
+                Ok(())
+            },
+            "✅ Unset refine-instructions (will use default)".to_string(),
+        )
     }
 
     fn format(&self, config: &Config) -> String {
@@ -91,14 +93,15 @@ impl SettingHandler for RefinePrefixHandler {
         }
 
         let value = args.join(" ");
-        let msg = value.clone();
+        let message = success_set("refine-prefix", &value);
 
-        mutate_config(move |config| {
-            config.refine_prefix = Some(value);
-            Ok(())
-        })?;
-
-        Ok(format!("✅ Set refine-prefix to: {msg}"))
+        mutate_config_with_message(
+            move |config| {
+                config.refine_prefix = Some(value);
+                Ok(())
+            },
+            message,
+        )
     }
 
     fn unset(
@@ -106,15 +109,16 @@ impl SettingHandler for RefinePrefixHandler {
         _args: Option<&str>,
         _ctx: &mut SetContext<'_>,
     ) -> Result<String, SettingError> {
-        mutate_config(|config| {
-            config.refine_prefix = None;
-            Ok(())
-        })?;
-
-        Ok(format!(
-            "✅ Unset refine-prefix (will use default: {})",
-            DEFAULT_REFINE_PREFIX
-        ))
+        mutate_config_with_message(
+            |config| {
+                config.refine_prefix = None;
+                Ok(())
+            },
+            format!(
+                "✅ Unset refine-prefix (will use default: {})",
+                DEFAULT_REFINE_PREFIX
+            ),
+        )
     }
 
     fn format(&self, config: &Config) -> String {

--- a/src/cli/settings/helpers.rs
+++ b/src/cli/settings/helpers.rs
@@ -1,10 +1,13 @@
 //! Helper functions for settings operations.
 
+use std::collections::HashMap;
+
 use crate::core::builtin_providers::find_builtin_provider;
 use crate::core::config::data::Config;
 use crate::ui::builtin_themes::find_builtin_theme;
 
 use super::error::SettingError;
+use super::SetContext;
 
 /// Wrapper around `Config::mutate` that maps errors to `SettingError::ConfigError`.
 pub fn mutate_config<F>(f: F) -> Result<(), SettingError>
@@ -12,6 +15,126 @@ where
     F: FnOnce(&mut Config) -> Result<(), Box<dyn std::error::Error>>,
 {
     Config::mutate(f).map_err(|e| SettingError::ConfigError(e.to_string()))
+}
+
+/// Execute a config mutation and return a standardized success message.
+pub fn mutate_config_with_message<F>(f: F, message: String) -> Result<String, SettingError>
+where
+    F: FnOnce(&mut Config) -> Result<(), Box<dyn std::error::Error>>,
+{
+    mutate_config(f)?;
+    Ok(message)
+}
+
+/// Parse and validate a provider/model/value tuple from `set` args.
+pub fn parse_provider_model_value(
+    args: &[String],
+    ctx: &SetContext<'_>,
+    hint: &'static str,
+    example: &'static str,
+) -> Result<(String, String, String), SettingError> {
+    if args.len() < 3 {
+        return Err(SettingError::MissingArgs { hint, example });
+    }
+
+    let provider = validate_provider(ctx.config, &args[0])?;
+    let model = args[1].clone();
+    let value = args[2..].join(" ");
+
+    Ok((provider, model, value))
+}
+
+/// Parse and validate a provider/model tuple from `unset` args.
+pub fn parse_provider_model(
+    args: Option<&str>,
+    ctx: &SetContext<'_>,
+    hint: &'static str,
+    example: &'static str,
+) -> Result<(String, String), SettingError> {
+    let value = args.ok_or(SettingError::MissingArgs { hint, example })?;
+    let parts: Vec<&str> = value.splitn(2, ' ').collect();
+
+    if parts.len() < 2 {
+        return Err(SettingError::MissingArgs { hint, example });
+    }
+
+    let provider = validate_provider(ctx.config, parts[0])?;
+    let model = parts[1].to_string();
+    Ok((provider, model))
+}
+
+/// Parse and validate a provider/value tuple from `set` args.
+pub fn parse_provider_value(
+    args: &[String],
+    ctx: &SetContext<'_>,
+    hint: &'static str,
+    example: &'static str,
+) -> Result<(String, String), SettingError> {
+    if args.len() < 2 {
+        return Err(SettingError::MissingArgs { hint, example });
+    }
+
+    let provider = validate_provider(ctx.config, &args[0])?;
+    let value = args[1..].join(" ");
+    Ok((provider, value))
+}
+
+/// Build a standardized success message for set operations.
+pub fn success_set(setting: &str, value: &str) -> String {
+    format!("✅ Set {setting} to: {value}")
+}
+
+/// Build a standardized success message for unset operations.
+pub fn success_unset(setting: &str) -> String {
+    format!("✅ Unset {setting}")
+}
+
+/// Build a standardized success message for provider-keyed set operations.
+pub fn success_set_provider_value(setting: &str, provider: &str, value: &str) -> String {
+    format!("✅ Set {setting} for provider '{provider}' to: {value}")
+}
+
+/// Build a standardized success message for provider-keyed unset operations.
+pub fn success_unset_provider_value(setting: &str, provider: &str) -> String {
+    format!("✅ Unset {setting} for provider: {provider}")
+}
+
+/// Build a standardized success message for provider/model-keyed set operations.
+pub fn success_set_provider_model_value(
+    setting: &str,
+    provider: &str,
+    model: &str,
+    value: &str,
+) -> String {
+    format!("✅ Set {setting} for '{provider}:{model}' to: {value}")
+}
+
+/// Build a standardized success message for provider/model-keyed unset operations.
+pub fn success_unset_provider_model_value(setting: &str, provider: &str, model: &str) -> String {
+    format!("✅ Unset {setting} for '{provider}:{model}'")
+}
+
+/// Format a provider/model nested map for display.
+pub fn format_provider_model_map(
+    name: &str,
+    map: &HashMap<String, HashMap<String, String>>,
+) -> String {
+    if map.is_empty() {
+        format!("  {name}: (none set)")
+    } else {
+        let mut output = format!("  {name}:\n");
+        let mut providers: Vec<_> = map.iter().collect();
+        providers.sort_by_key(|(k, _)| *k);
+        for (provider, models) in providers {
+            let mut model_entries: Vec<_> = models.iter().collect();
+            model_entries.sort_by_key(|(k, _)| *k);
+            for (model, value) in model_entries {
+                output.push_str(&format!("    {provider}:{model}: {value}\n"));
+            }
+        }
+        output.pop();
+        output
+    }
 }
 
 /// Parse a boolean value from user input.


### PR DESCRIPTION
- centralize provider and provider:model argument parsing
- add shared success-message builders for set/unset operations
- extract nested provider:model map formatting into helpers
- simplify settings handlers by reusing generic mutation wrappers