### PR TITLE
ci(release): add nightly pre-release binary pipeline

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,162 @@
+name: Nightly pre-release binaries
+
+on:
+  schedule:
+    - cron: '20 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: nightly-release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+          - os: macos-15
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - name: Build release binary
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo build --locked --release --target "$TARGET"
+
+      - name: Smoke test binary
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          BIN="target/$TARGET/release/chabeau"
+          "$BIN" --version
+          "$BIN" --help > /dev/null
+
+      - name: Package release archive
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          BIN_DIR="target/$TARGET/release"
+          ASSET_TARGET="$TARGET"
+          ASSET_TARGET="${ASSET_TARGET/-unknown-/-}"
+          ARCHIVE="chabeau-nightly-$ASSET_TARGET.tar.gz"
+          tar -C "$BIN_DIR" -czf "$ARCHIVE" chabeau
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+          else
+            shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+          fi
+
+      - name: Upload packaged artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-${{ matrix.target }}
+          path: |
+            chabeau-nightly-*.tar.gz
+            chabeau-nightly-*.tar.gz.sha256
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: nightly-*
+          merge-multiple: false
+
+      - name: Build combined checksum file
+        run: |
+          set -euo pipefail
+          cat dist/nightly-*/chabeau-nightly-*.tar.gz.sha256 > dist/SHA256SUMS
+
+      - name: Move nightly tag to this commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git tag -f nightly "$GITHUB_SHA"
+          git push origin refs/tags/nightly --force
+
+      - name: Publish or update nightly pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: Nightly
+          prerelease: true
+          make_latest: false
+          target_commitish: ${{ github.sha }}
+          body: |
+            Nightly build from commit `${{ github.sha }}`.
+
+            Artifacts include Linux and macOS binaries with per-archive SHA-256 checksums.
+          files: |
+            dist/nightly-*/chabeau-nightly-*.tar.gz
+            dist/nightly-*/chabeau-nightly-*.tar.gz.sha256
+            dist/SHA256SUMS
+          overwrite_files: true
+
+      - name: Remove stale nightly assets
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const distDir = path.join(process.env.GITHUB_WORKSPACE, "dist");
+
+            const keep = new Set();
+            for (const entry of fs.readdirSync(distDir, { withFileTypes: true })) {
+              if (!entry.isDirectory()) continue;
+              const dir = path.join(distDir, entry.name);
+              for (const file of fs.readdirSync(dir)) {
+                keep.add(file);
+              }
+            }
+            keep.add("SHA256SUMS");
+
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner,
+              repo,
+              tag: "nightly",
+            });
+
+            for (const asset of release.assets) {
+              if (!keep.has(asset.name)) {
+                await github.rest.repos.deleteReleaseAsset({
+                  owner,
+                  repo,
+                  asset_id: asset.id,
+                });
+              }
+            }

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,6 +116,13 @@ Outgoing requests are encapsulated in `StreamParams` and executed by `ChatStream
 a Tokio task that posts SSE frames into an unbounded channel, normalizes malformed input, reports API errors
 with helpful Markdown summaries, and honors cancellation tokens so that user interrupts stop work promptly.【F:src/core/chat_stream.rs†L9-L349】
 
+## Release automation
+Release distribution is split across dedicated GitHub workflows under `.github/workflows/`.
+`publish.yml` handles crates.io publication from semver tags that are reachable from `main`.
+`nightly.yml` builds Linux/macOS release binaries on a nightly schedule (or manual dispatch),
+smoke-tests each artifact with `--version`/`--help`, then updates the moving `nightly`
+pre-release tag with checksummed archives.
+
 ## Configuration orchestrator and test isolation
 All configuration reads and writes go through `ConfigOrchestrator`, which caches the on-disk state and
 serializes mutations so that concurrent access is safe.【F:src/core/config/orchestrator.rs†L13-L80】 The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chabeau"
-version = "0.7.2"
+version = "0.7.3-dev"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chabeau"
-version = "0.7.2"
+version = "0.7.3-dev"
 edition = "2021"
 rust-version = "1.80"
 description = "A full-screen terminal chat interface that connects to various AI APIs for real-time conversations"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ For features under consideration, see [WISHLIST.md](WISHLIST.md).
 cargo install chabeau
 ```
 
+Nightly pre-release binaries for Linux and macOS are published on the
+[GitHub Releases page](https://github.com/permacommons/chabeau/releases)
+under the `Nightly` pre-release tag.
+
+Each nightly artifact includes per-file SHA-256 checksums plus a combined
+`SHA256SUMS` file.
+
+On macOS, unsigned nightly binaries may be quarantined by Gatekeeper. If you
+trust the downloaded artifact, you can remove the quarantine attribute:
+
+```bash
+xattr -d com.apple.quarantine ./chabeau
+```
+
+Run unsigned binaries at your own risk.
+
 ### Configure Providers
 ```bash
 chabeau provider list
@@ -598,6 +614,11 @@ cargo fmt
 cargo test
 cargo clippy --all-targets --all-features
 ```
+
+### CI and Release Workflows
+- `.github/workflows/ci.yml` runs build, test, and reproducibility checks on pushes and pull requests.
+- `.github/workflows/publish.yml` publishes crates.io releases from semver tags that land on `main`.
+- `.github/workflows/nightly.yml` builds Linux/macOS release binaries on a schedule and updates the moving `Nightly` pre-release with checksummed artifacts.
 
 ### Performance
 


### PR DESCRIPTION
## Summary
This PR adds an automated nightly binary release pipeline for Chabeau and
documents how nightly artifacts are distributed and used.

## What changes
- Adds a new `nightly.yml` workflow that runs on schedule and manual dispatch.
- Builds release binaries for Linux (`x86_64-unknown-linux-gnu`) and macOS
  (`x86_64` and `arm64`).
- Runs smoke checks on each built artifact (`--version`, `--help`).
- Publishes a moving `Nightly` pre-release with `.tar.gz` assets and SHA-256
  checksum files.
- Cleans up stale nightly release assets after successful publish.
- Documents nightly availability in `README.md`, including a macOS quarantine
  workaround note for unsigned binaries.
- Adds release automation notes to `ARCHITECTURE.md`.

## Why
This establishes a low-friction way to validate and distribute cross-platform
binaries before formal tagged releases, while keeping artifacts discoverable in
GitHub Releases.

## Notes
- The crate version is currently set to `0.7.3-dev`.
