### PR TITLE
fix(ci): remove invalid release target_commitish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -350,7 +350,6 @@ jobs:
         with:
           tag_name: ${{ needs.check-branch.outputs.tag }}
           name: Chabeau ${{ needs.check-branch.outputs.tag }}
-          target_commitish: ${{ needs.check-branch.outputs.tag }}
           body: |
             Automated release artifacts for `${{ needs.check-branch.outputs.tag }}`.
 


### PR DESCRIPTION
## Summary
Fixes release publication failure in `publish.yml` caused by an invalid `target_commitish` value.

## What changed
- Removed `target_commitish` from the stable GitHub Release step.

## Why
- The workflow was passing the tag name (for example `v0.7.2`) as `target_commitish`, which caused GitHub's release API to reject creation with HTTP 422 (`field: target_commitish`).
- `tag_name` already identifies the release target, so `target_commitish` is unnecessary here.

## Impact
- Stable release publication can now create/update releases for existing semver tags without failing this validation.
