### PR TITLE
feat(ci): derive stable release body from changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -345,16 +345,45 @@ jobs:
             --output-certificate dist/SHA256SUMS.pem \
             dist/SHA256SUMS
 
+      - name: Build release notes from changelog
+        env:
+          TAG: ${{ needs.check-branch.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          NOTES_FILE="dist/RELEASE_NOTES.md"
+
+          {
+            echo "## Chabeau ${TAG}"
+            echo
+            echo "Automated release artifacts for \`${TAG}\`."
+            echo
+          } > "$NOTES_FILE"
+
+          section="$(awk -v ver="$VERSION" '
+            $0 == "## " ver { in_sec=1; print; next }
+            in_sec && /^## / { exit }
+            in_sec { print }
+          ' CHANGELOG.md)"
+
+          if [[ -n "$section" ]]; then
+            printf '%s\n' "$section" >> "$NOTES_FILE"
+            echo >> "$NOTES_FILE"
+            echo "_Release notes extracted from CHANGELOG.md._" >> "$NOTES_FILE"
+          else
+            {
+              echo "### Notes"
+              echo "- See CHANGELOG.md for a full history of changes."
+            } >> "$NOTES_FILE"
+          fi
+
       - name: Publish or update GitHub release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.check-branch.outputs.tag }}
           name: Chabeau ${{ needs.check-branch.outputs.tag }}
-          body: |
-            Automated release artifacts for `${{ needs.check-branch.outputs.tag }}`.
-
-            Artifacts include Linux, macOS, and Windows binaries with per-archive SHA-256 checksums.
-            The checksum manifest is signed with keyless Sigstore via GitHub Actions OIDC.
+          body_path: dist/RELEASE_NOTES.md
           files: |
             dist/release-*/chabeau-${{ needs.check-branch.outputs.tag }}-*.tar.gz
             dist/release-*/chabeau-${{ needs.check-branch.outputs.tag }}-*.zip
@@ -363,4 +392,5 @@ jobs:
             dist/SHA256SUMS
             dist/SHA256SUMS.sig
             dist/SHA256SUMS.pem
+            dist/RELEASE_NOTES.md
           overwrite_files: true

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,6 +125,8 @@ Release distribution is split across dedicated GitHub workflows under `.github/w
 publication in parallel: crates.io publication plus versioned GitHub Release binaries
 for Linux/macOS/Windows. The stable release job also generates `SHA256SUMS` and signs it
 with keyless Sigstore using GitHub Actions OIDC before uploading release assets.
+Stable GitHub Release descriptions are generated from the matching version section in
+`CHANGELOG.md` (falling back to a short default note when missing).
 `nightly.yml` builds Linux/macOS/Windows release binaries on a nightly schedule (or manual
 dispatch), smoke-tests each artifact with `--version`/`--help`, signs nightly `SHA256SUMS`
 with keyless Sigstore using GitHub Actions OIDC, then updates the moving `nightly`

--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ cargo clippy --all-targets --all-features
 
 ### CI and Release Workflows
 - `.github/workflows/ci.yml` runs build, test, and reproducibility checks on pushes and pull requests.
-- `.github/workflows/publish.yml` selects the newest semver tag reachable from `main`, then publishes the matching crates.io release and GitHub Release binaries with SHA-256 checksums and a keyless Sigstore-signed checksum manifest.
+- `.github/workflows/publish.yml` selects the newest semver tag reachable from `main`, then publishes the matching crates.io release and GitHub Release binaries with SHA-256 checksums, a keyless Sigstore-signed checksum manifest, and a GitHub Release description extracted from the matching `CHANGELOG.md` version section.
 - `.github/workflows/nightly.yml` builds Linux/macOS/Windows release binaries on a schedule and updates the moving `Nightly` pre-release with checksummed artifacts and a keyless Sigstore-signed checksum manifest.
 
 ### Performance


### PR DESCRIPTION
## Summary
This updates stable release publishing so GitHub Release descriptions are generated from the matching version section in `CHANGELOG.md` instead of a static workflow message.

## What changed
- During stable release publication, the workflow now:
  - derives version from the selected tag (for example `v0.7.2` -> `0.7.2`)
  - extracts the corresponding `## <version>` section from `CHANGELOG.md`
  - writes `dist/RELEASE_NOTES.md` and uses it as the release body (`body_path`)
- Added a concise fallback note when no matching changelog section is present.

## Why
- Keeps GitHub release descriptions aligned with your existing release-note source of truth.
- Removes duplicate manual release-summary maintenance in workflow YAML.
- Ensures release publication stays robust even if changelog/tag sync is temporarily imperfect.

## Impact
- Stable GitHub releases now show structured version notes from `CHANGELOG.md`.
- Nightly flow is unchanged.
