### PR TITLE
refactor: use typed transcript roles across chat flow

### DIFF
--- a/benches/render_cache.rs
+++ b/benches/render_cache.rs
@@ -1,5 +1,5 @@
 use chabeau::core::app::App;
-use chabeau::core::message::Message;
+use chabeau::core::message::{Message, TranscriptRole};
 use chabeau::ui::theme::Theme;
 use chabeau::utils::scroll::ScrollCalculator;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
@@ -9,11 +9,19 @@ fn make_messages(n_pairs: usize, base: &str) -> VecDeque<Message> {
     let mut v = VecDeque::new();
     for i in 0..n_pairs {
         v.push_back(Message {
-            role: if i % 2 == 0 { "user" } else { "assistant" }.into(),
+            role: if i % 2 == 0 {
+                TranscriptRole::User
+            } else {
+                TranscriptRole::Assistant
+            },
             content: base.into(),
         });
         v.push_back(Message {
-            role: if i % 2 == 0 { "assistant" } else { "user" }.into(),
+            role: if i % 2 == 0 {
+                TranscriptRole::Assistant
+            } else {
+                TranscriptRole::User
+            },
             content: base.into(),
         });
     }

--- a/src/cli/provider_list.rs
+++ b/src/cli/provider_list.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use crate::{
     auth::{AuthManager, ProviderAuthStatus},
-    core::message::{Message, ROLE_ASSISTANT},
+    core::message::{Message, TranscriptRole},
     core::{builtin_providers::find_builtin_provider, config::data::Config},
     ui::{
         layout::TableOverflowPolicy,
@@ -59,7 +59,7 @@ pub async fn list_providers() -> Result<(), Box<dyn Error>> {
     let terminal_width = terminal::size().ok().map(|(w, _)| w as usize);
     let rendered = markdown::render_message_with_config(
         &Message {
-            role: ROLE_ASSISTANT.to_string(),
+            role: TranscriptRole::Assistant,
             content,
         },
         &monochrome_theme,

--- a/src/commands/handlers/io.rs
+++ b/src/commands/handlers/io.rs
@@ -100,7 +100,9 @@ pub fn dump_conversation_with_overwrite(
         .ui
         .messages
         .iter()
-        .filter(|msg| !message::is_app_message_role(&msg.role) || msg.role == message::ROLE_APP_LOG)
+        .filter(|msg| {
+            !message::is_app_message_role(msg.role) || msg.role == message::TranscriptRole::AppLog
+        })
         .collect();
 
     if conversation_messages.is_empty() {
@@ -120,11 +122,15 @@ pub fn dump_conversation_with_overwrite(
     let user_display_name = app.persona_manager.get_display_name();
 
     for msg in conversation_messages {
-        match msg.role.as_str() {
-            "user" => writeln!(writer, "{}: {}", user_display_name, msg.content)?,
-            message::ROLE_APP_LOG => writeln!(writer, "## {}", msg.content)?,
-            message::ROLE_TOOL_CALL => writeln!(writer, "Tool call: {}", msg.content)?,
-            message::ROLE_TOOL_RESULT => writeln!(writer, "Tool result: {}", msg.content)?,
+        match msg.role {
+            message::TranscriptRole::User => {
+                writeln!(writer, "{}: {}", user_display_name, msg.content)?
+            }
+            message::TranscriptRole::AppLog => writeln!(writer, "## {}", msg.content)?,
+            message::TranscriptRole::ToolCall => writeln!(writer, "Tool call: {}", msg.content)?,
+            message::TranscriptRole::ToolResult => {
+                writeln!(writer, "Tool result: {}", msg.content)?
+            }
             _ => writeln!(writer, "{}", msg.content)?,
         }
         writeln!(writer)?;

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -1,9 +1,11 @@
 use super::*;
 use crate::character::card::{CharacterCard, CharacterData};
 use crate::core::config::data::{Config, McpServerConfig, Persona};
-use crate::core::message::ROLE_ASSISTANT;
+use crate::core::message::TranscriptRole;
 use crate::core::persona::PersonaManager;
-use crate::utils::test_utils::{create_test_app, create_test_message, with_test_config_env};
+use crate::utils::test_utils::{
+    create_test_app, create_test_message, create_test_message_with_role, with_test_config_env,
+};
 use rust_mcp_schema::{
     Implementation, InitializeResult, ListPromptsResult, ListResourceTemplatesResult,
     ListResourcesResult, ListToolsResult, PromptArgument, ServerCapabilities,
@@ -88,9 +90,10 @@ fn clear_command_shows_character_greeting_when_available() {
     app.session.set_character(character);
     app.session.character_greeting_shown = true;
     app.session.has_received_assistant_message = true;
-    app.ui
-        .messages
-        .push_back(create_test_message(ROLE_ASSISTANT, &greeting_text));
+    app.ui.messages.push_back(create_test_message_with_role(
+        TranscriptRole::Assistant,
+        &greeting_text,
+    ));
     app.ui
         .messages
         .push_back(create_test_message("user", "Hi!"));
@@ -100,7 +103,7 @@ fn clear_command_shows_character_greeting_when_available() {
     assert_eq!(app.ui.status.as_deref(), Some("Transcript cleared"));
     assert_eq!(app.ui.messages.len(), 1);
     let greeting = app.ui.messages.front().unwrap();
-    assert_eq!(greeting.role, ROLE_ASSISTANT);
+    assert_eq!(greeting.role, TranscriptRole::Assistant);
     assert_eq!(greeting.content, greeting_text);
     assert!(app.session.character_greeting_shown);
     assert!(!app.session.has_received_assistant_message);
@@ -189,8 +192,8 @@ fn test_dump_conversation() {
     app.ui
         .messages
         .push_back(create_test_message("assistant", "Hi there!"));
-    app.ui.messages.push_back(create_test_message(
-        crate::core::message::ROLE_APP_INFO,
+    app.ui.messages.push_back(create_test_message_with_role(
+        crate::core::message::TranscriptRole::AppInfo,
         "App message",
     ));
 

--- a/src/core/app/actions/stream_errors.rs
+++ b/src/core/app/actions/stream_errors.rs
@@ -107,7 +107,7 @@ fn is_tool_unsupported_error(message: &str) -> bool {
 mod tests {
     use super::*;
     use crate::core::app::actions::AppCommand;
-    use crate::core::message::{ROLE_APP_ERROR, ROLE_ASSISTANT, ROLE_USER};
+    use crate::core::message::TranscriptRole;
     use crate::utils::test_utils::create_test_app;
 
     fn default_ctx() -> AppActionContext {
@@ -136,10 +136,13 @@ mod tests {
             .ui
             .messages
             .iter()
-            .all(|m| m.role != ROLE_ASSISTANT || !m.content.trim().is_empty()));
+            .all(|m| m.role != TranscriptRole::Assistant || !m.content.trim().is_empty()));
         let last = app.ui.messages.back().expect("last");
-        assert_eq!(last.role, ROLE_APP_ERROR);
+        assert_eq!(last.role, TranscriptRole::AppError);
         assert_eq!(last.content, "network failure");
-        assert_eq!(app.ui.messages.front().expect("first").role, ROLE_USER);
+        assert_eq!(
+            app.ui.messages.front().expect("first").role,
+            TranscriptRole::User
+        );
     }
 }

--- a/src/core/app/actions/stream_lifecycle.rs
+++ b/src/core/app/actions/stream_lifecycle.rs
@@ -112,9 +112,7 @@ pub(super) fn append_tool_call_delta(
 mod tests {
     use super::*;
     use crate::core::app::actions::AppCommand;
-    use crate::core::message::{
-        AppMessageKind, ROLE_APP_WARNING, ROLE_TOOL_CALL, ROLE_TOOL_RESULT,
-    };
+    use crate::core::message::{AppMessageKind, TranscriptRole};
     use crate::utils::test_utils::create_test_app;
 
     fn default_ctx() -> AppActionContext {
@@ -142,7 +140,7 @@ mod tests {
         let result = finalize_stream(&mut app, ctx);
         assert!(result.is_none() || matches!(result, Some(AppCommand::SpawnStream(_))));
         let last = app.ui.messages.back().expect("message");
-        assert_eq!(last.role, ROLE_APP_WARNING);
+        assert_eq!(last.role, TranscriptRole::AppWarning);
         assert_eq!(last.content, "invalid utf8");
         assert!(app.ui.is_streaming || stream_id > 0);
     }
@@ -173,12 +171,16 @@ mod tests {
         );
         let command = finalize_stream(&mut app, ctx);
         assert!(matches!(command, Some(AppCommand::SpawnStream(_))));
-        assert!(app.ui.messages.iter().any(|msg| msg.role == ROLE_TOOL_CALL));
         assert!(app
             .ui
             .messages
             .iter()
-            .any(|msg| msg.role == ROLE_TOOL_RESULT));
+            .any(|msg| msg.role == TranscriptRole::ToolCall));
+        assert!(app
+            .ui
+            .messages
+            .iter()
+            .any(|msg| msg.role == TranscriptRole::ToolResult));
     }
 
     #[test]

--- a/src/core/app/actions/streaming.rs
+++ b/src/core/app/actions/streaming.rs
@@ -11,7 +11,7 @@ use crate::core::app::ui_state::ToolPromptRequest;
 use crate::core::chat_stream::StreamParams;
 use crate::core::config::data::McpToolPayloadRetention;
 use crate::core::mcp_sampling::{serialize_sampling_params, summarize_sampling_request};
-use crate::core::message::{AppMessageKind, Message, ROLE_ASSISTANT, ROLE_USER};
+use crate::core::message::{AppMessageKind, Message, TranscriptRole};
 use crate::mcp::permissions::ToolPermissionDecision;
 use crate::mcp::{MCP_INSTANT_RECALL_TOOL, MCP_SESSION_MEMORY_SERVER_ID};
 use rust_mcp_schema::{ContentBlock, PromptMessage, Role, RpcError};
@@ -159,13 +159,10 @@ fn handle_mcp_prompt_completed(
         for message in prompt_result.messages.iter() {
             let content = prompt_message_content_to_string(message);
             let role = match message.role {
-                Role::User => ROLE_USER,
-                Role::Assistant => ROLE_ASSISTANT,
+                Role::User => TranscriptRole::User,
+                Role::Assistant => TranscriptRole::Assistant,
             };
-            conversation.add_message(Message {
-                role: role.to_string(),
-                content,
-            });
+            conversation.add_message(Message::new(role, content));
         }
 
         conversation.add_app_message(

--- a/src/core/app/tests.rs
+++ b/src/core/app/tests.rs
@@ -2,10 +2,12 @@ use super::*;
 use crate::api::{ChatMessage, ChatToolCall, ChatToolCallFunction};
 use crate::core::app::session::{ToolPayloadHistoryEntry, ToolResultRecord, ToolResultStatus};
 use crate::core::config::data::McpServerConfig;
-use crate::core::message::Message;
+use crate::core::message::{Message, TranscriptRole};
 use crate::core::text_wrapping::{TextWrapper, WrapConfig};
 use crate::ui::picker::{PickerItem, PickerState};
-use crate::utils::test_utils::{create_test_app, create_test_message};
+use crate::utils::test_utils::{
+    create_test_app, create_test_message, create_test_message_with_role,
+};
 use rust_mcp_schema::{
     ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, Resource, ResourceTemplate,
     Tool, ToolInputSchema,
@@ -593,7 +595,11 @@ fn test_prewrap_cache_reuse_when_unchanged() {
     let mut app = create_test_app();
     for i in 0..50 {
         app.ui.messages.push_back(Message {
-            role: if i % 2 == 0 { "user" } else { "assistant" }.into(),
+            role: if i % 2 == 0 {
+                TranscriptRole::User
+            } else {
+                TranscriptRole::Assistant
+            },
             content: "lorem ipsum dolor sit amet consectetur adipiscing elit".into(),
         });
     }
@@ -758,11 +764,11 @@ fn prewrap_cache_plain_text_last_message_wrapping() {
 
     // Start with two assistant messages
     app.ui.messages.push_back(Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Short".into(),
     });
     app.ui.messages.push_back(Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "This is a very long plain text line that should wrap when width is small".into(),
     });
 
@@ -1385,7 +1391,7 @@ fn test_scroll_height_consistency_with_tables_regression() {
 "#;
 
     app.ui.messages.push_back(Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: table_content.to_string(),
     });
 
@@ -1465,7 +1471,7 @@ fn test_scroll_height_consistency_narrow_terminal_regression() {
 Some additional text after the table."#;
 
     app.ui.messages.push_back(Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: wide_table.to_string(),
     });
 
@@ -1612,8 +1618,8 @@ fn test_prev_next_user_message_index_navigation() {
     app.ui
         .messages
         .push_back(create_test_message("assistant", "a1"));
-    app.ui.messages.push_back(create_test_message(
-        crate::core::message::ROLE_APP_INFO,
+    app.ui.messages.push_back(create_test_message_with_role(
+        crate::core::message::TranscriptRole::AppInfo,
         "s1",
     ));
     app.ui.messages.push_back(create_test_message("user", "u2"));

--- a/src/core/app/ui_helpers.rs
+++ b/src/core/app/ui_helpers.rs
@@ -1,6 +1,6 @@
 use super::App;
 use crate::commands::matching_commands;
-use crate::core::message::{Message, ROLE_ASSISTANT, ROLE_USER};
+use crate::core::message::{Message, TranscriptRole};
 use crate::ui::span::SpanKind;
 use ratatui::text::Line;
 
@@ -130,13 +130,13 @@ impl App {
             return;
         }
 
-        let role = self.ui.messages[actual_index].role.clone();
-        if role != ROLE_USER && role != ROLE_ASSISTANT {
+        let role = self.ui.messages[actual_index].role;
+        if !role.is_user() && !role.is_assistant() {
             return;
         }
 
         self.ui.messages[actual_index].content = new_text;
-        if role == ROLE_ASSISTANT {
+        if role.is_assistant() {
             self.session
                 .prune_tool_records_for_assistant_index(actual_index);
         }
@@ -154,10 +154,9 @@ impl App {
             return;
         }
 
-        self.ui.messages.push_back(Message {
-            role: ROLE_ASSISTANT.to_string(),
-            content: new_text,
-        });
+        self.ui
+            .messages
+            .push_back(Message::new(TranscriptRole::Assistant, new_text));
         self.invalidate_prewrap_cache();
         let user_display_name = self.persona_manager.get_display_name();
         let _ = self

--- a/src/core/app/ui_state.rs
+++ b/src/core/app/ui_state.rs
@@ -1,5 +1,5 @@
 use crate::core::config::data::Config;
-use crate::core::message::{AppMessageKind, Message, ROLE_ASSISTANT, ROLE_USER};
+use crate::core::message::{AppMessageKind, Message, TranscriptRole};
 use crate::core::text_wrapping::{TextWrapper, WrapConfig, WrappedCursorLayout};
 use crate::ui::span::SpanKind;
 use crate::ui::theme::Theme;
@@ -312,7 +312,7 @@ impl UiState {
         }
     }
 
-    fn last_message_index_with_role(&self, role: &str) -> Option<usize> {
+    fn last_message_index_with_role(&self, role: TranscriptRole) -> Option<usize> {
         self.messages
             .iter()
             .enumerate()
@@ -321,7 +321,11 @@ impl UiState {
             .map(|(i, _)| i)
     }
 
-    fn prev_message_index_with_role(&self, role: &str, from_index: usize) -> Option<usize> {
+    fn prev_message_index_with_role(
+        &self,
+        role: TranscriptRole,
+        from_index: usize,
+    ) -> Option<usize> {
         if from_index == 0 {
             return None;
         }
@@ -335,7 +339,11 @@ impl UiState {
             .map(|(i, _)| i)
     }
 
-    fn next_message_index_with_role(&self, role: &str, from_index: usize) -> Option<usize> {
+    fn next_message_index_with_role(
+        &self,
+        role: TranscriptRole,
+        from_index: usize,
+    ) -> Option<usize> {
         self.messages
             .iter()
             .enumerate()
@@ -344,7 +352,7 @@ impl UiState {
             .map(|(i, _)| i)
     }
 
-    fn first_message_index_with_role(&self, role: &str) -> Option<usize> {
+    fn first_message_index_with_role(&self, role: TranscriptRole) -> Option<usize> {
         self.messages
             .iter()
             .enumerate()
@@ -353,35 +361,35 @@ impl UiState {
     }
 
     pub fn last_user_message_index(&self) -> Option<usize> {
-        self.last_message_index_with_role(ROLE_USER)
+        self.last_message_index_with_role(TranscriptRole::User)
     }
 
     pub fn prev_user_message_index(&self, from_index: usize) -> Option<usize> {
-        self.prev_message_index_with_role(ROLE_USER, from_index)
+        self.prev_message_index_with_role(TranscriptRole::User, from_index)
     }
 
     pub fn next_user_message_index(&self, from_index: usize) -> Option<usize> {
-        self.next_message_index_with_role(ROLE_USER, from_index)
+        self.next_message_index_with_role(TranscriptRole::User, from_index)
     }
 
     pub fn first_user_message_index(&self) -> Option<usize> {
-        self.first_message_index_with_role(ROLE_USER)
+        self.first_message_index_with_role(TranscriptRole::User)
     }
 
     pub fn last_assistant_message_index(&self) -> Option<usize> {
-        self.last_message_index_with_role(ROLE_ASSISTANT)
+        self.last_message_index_with_role(TranscriptRole::Assistant)
     }
 
     pub fn prev_assistant_message_index(&self, from_index: usize) -> Option<usize> {
-        self.prev_message_index_with_role(ROLE_ASSISTANT, from_index)
+        self.prev_message_index_with_role(TranscriptRole::Assistant, from_index)
     }
 
     pub fn next_assistant_message_index(&self, from_index: usize) -> Option<usize> {
-        self.next_message_index_with_role(ROLE_ASSISTANT, from_index)
+        self.next_message_index_with_role(TranscriptRole::Assistant, from_index)
     }
 
     pub fn first_assistant_message_index(&self) -> Option<usize> {
-        self.first_message_index_with_role(ROLE_ASSISTANT)
+        self.first_message_index_with_role(TranscriptRole::Assistant)
     }
 
     pub fn enter_edit_select_mode(&mut self, target: EditSelectTarget) {

--- a/src/core/persona.rs
+++ b/src/core/persona.rs
@@ -458,13 +458,13 @@ mod tests {
 }
 #[test]
 fn test_message_rendering_with_persona_display_name() {
-    use crate::core::message::Message;
+    use crate::core::message::{Message, TranscriptRole};
     use crate::ui::markdown::{render_message_with_config, MessageRenderConfig};
     use crate::ui::theme::Theme;
 
     let theme = Theme::dark_default();
     let message = Message {
-        role: "user".to_string(),
+        role: TranscriptRole::User,
         content: "Hello world".to_string(),
     };
 

--- a/src/ui/chat_loop/keybindings/handlers.rs
+++ b/src/ui/chat_loop/keybindings/handlers.rs
@@ -14,7 +14,7 @@ use crate::core::app::{
     InspectAction, InspectMode, PickerAction, StatusAction, StreamingAction,
 };
 use crate::core::chat_stream::ChatStreamService;
-use crate::core::message::ROLE_ASSISTANT;
+use crate::core::message::TranscriptRole;
 use crate::mcp::permissions::ToolPermissionDecision;
 use crate::ui::chat_loop::keybindings::registry::{KeyHandler, KeyResult};
 use crate::ui::chat_loop::modes::{
@@ -893,11 +893,10 @@ impl KeyHandler for CtrlNHandler {
         let (last_prompt, can_retry) = app
             .read(|app| {
                 let prompt = app.session.last_refine_prompt.clone();
-                let can_retry = app
-                    .ui
-                    .messages
-                    .iter()
-                    .any(|msg| msg.role == ROLE_ASSISTANT && !msg.content.is_empty());
+                let can_retry =
+                    app.ui.messages.iter().any(|msg| {
+                        msg.role == TranscriptRole::Assistant && !msg.content.is_empty()
+                    });
                 (prompt, can_retry)
             })
             .await;
@@ -1187,7 +1186,7 @@ mod tests {
         apply_actions, AppAction, AppActionDispatcher, AppActionEnvelope, ComposeAction,
         InputAction, StatusAction, StreamingAction,
     };
-    use crate::core::message::{Message, ROLE_ASSISTANT, ROLE_USER};
+    use crate::core::message::{Message, TranscriptRole};
     use crate::ui::chat_loop::AppHandle;
     use crate::utils::test_utils::create_test_app;
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -1210,11 +1209,11 @@ mod tests {
         let mut app = create_test_app();
         app.session.last_refine_prompt = Some("Tighten it up".to_string());
         app.ui.messages.push_back(Message {
-            role: ROLE_USER.to_string(),
+            role: TranscriptRole::User,
             content: "Question".to_string(),
         });
         app.ui.messages.push_back(Message {
-            role: ROLE_ASSISTANT.to_string(),
+            role: TranscriptRole::Assistant,
             content: "Answer".to_string(),
         });
 
@@ -1244,11 +1243,11 @@ mod tests {
         let handler = CtrlNHandler;
         let mut app = create_test_app();
         app.ui.messages.push_back(Message {
-            role: ROLE_USER.to_string(),
+            role: TranscriptRole::User,
             content: "Question".to_string(),
         });
         app.ui.messages.push_back(Message {
-            role: ROLE_ASSISTANT.to_string(),
+            role: TranscriptRole::Assistant,
             content: "Answer".to_string(),
         });
 
@@ -1279,7 +1278,7 @@ mod tests {
         let mut app = create_test_app();
         app.session.last_refine_prompt = Some("Polish it".to_string());
         app.ui.messages.push_back(Message {
-            role: ROLE_USER.to_string(),
+            role: TranscriptRole::User,
             content: "Question".to_string(),
         });
         // No assistant message added

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -162,13 +162,15 @@ impl LayoutEngine {
 mod tests {
     use super::{LayoutConfig, LayoutEngine, Theme};
     use crate::core::message::Message;
+    #[cfg(test)]
+    use crate::core::message::TranscriptRole;
     use std::collections::VecDeque;
 
     #[test]
     fn markdown_layout_populates_span_metadata() {
         let mut messages = VecDeque::new();
         messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: "Testing a [link](https://example.com) span.".into(),
         });
         let theme = Theme::dark_default();
@@ -189,7 +191,7 @@ mod tests {
     fn plain_text_layout_synthesizes_metadata() {
         let mut messages = VecDeque::new();
         messages.push_back(Message {
-            role: "user".into(),
+            role: TranscriptRole::User,
             content: "Hello there".into(),
         });
         let theme = Theme::dark_default();
@@ -212,7 +214,7 @@ mod tests {
     fn layout_lines_can_be_encoded_with_osc_links() {
         let mut messages = VecDeque::new();
         messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: "[Rust](https://www.rust-lang.org) and [Go](https://go.dev)".into(),
         });
         let theme = Theme::dark_default();
@@ -233,7 +235,7 @@ mod tests {
     fn link_metadata_spans_cover_spaces_within_link_text() {
         let mut messages = VecDeque::new();
         messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: "[associative trails](https://example.com)".into(),
         });
         let theme = Theme::dark_default();

--- a/src/ui/markdown/render.rs
+++ b/src/ui/markdown/render.rs
@@ -6,7 +6,7 @@ use super::metadata::RenderedMessageDetails;
 use super::parser::find_items_needing_blank_lines;
 use super::table::TableRenderer;
 use super::wrap::wrap_spans_to_width_generic_shared;
-use crate::core::message::{self, AppMessageKind, Message, ROLE_ASSISTANT, ROLE_USER};
+use crate::core::message::{self, AppMessageKind, Message, TranscriptRole};
 use crate::ui::span::SpanKind;
 use crate::ui::theme::Theme;
 use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
@@ -44,16 +44,16 @@ pub enum RoleKind {
 
 impl RoleKind {
     fn from_message(msg: &Message) -> Self {
-        if msg.role == ROLE_USER {
+        if msg.role == TranscriptRole::User {
             RoleKind::User
-        } else if msg.role == ROLE_ASSISTANT {
+        } else if msg.role == TranscriptRole::Assistant {
             RoleKind::Assistant
-        } else if msg.role == message::ROLE_TOOL_CALL {
+        } else if msg.role == message::TranscriptRole::ToolCall {
             RoleKind::ToolCall
-        } else if msg.role == message::ROLE_TOOL_RESULT {
+        } else if msg.role == message::TranscriptRole::ToolResult {
             RoleKind::ToolResult
-        } else if message::is_app_message_role(&msg.role) {
-            RoleKind::App(message::app_message_kind_from_role(&msg.role))
+        } else if message::is_app_message_role(msg.role) {
+            RoleKind::App(message::app_message_kind_from_role(msg.role))
         } else {
             RoleKind::Assistant
         }

--- a/src/ui/markdown/test_fixtures.rs
+++ b/src/ui/markdown/test_fixtures.rs
@@ -3,14 +3,14 @@
 //! Provides canonical test cases covering edge cases for code block
 //! rendering and metadata extraction.
 
-use crate::core::message::{Message, ROLE_ASSISTANT, ROLE_USER};
+use crate::core::message::{Message, TranscriptRole};
 
 /// Test fixture: single code block in assistant message.
 ///
 /// Tests basic code block rendering with a language tag.
 pub fn single_block() -> Message {
     Message {
-        role: ROLE_ASSISTANT.to_string(),
+        role: TranscriptRole::Assistant,
         content: "Here's a function:\n\n```rust\nfn main() {}\n```\n".to_string(),
     }
 }
@@ -21,7 +21,7 @@ pub fn single_block() -> Message {
 /// multiple blocks in a single message.
 pub fn multiple_blocks() -> Message {
     Message {
-        role: ROLE_ASSISTANT.to_string(),
+        role: TranscriptRole::Assistant,
         content: concat!(
             "First, here's some Rust:\n\n",
             "```rust\nfn main() {\n    println!(\"Hello\");\n}\n```\n\n",
@@ -40,19 +40,19 @@ pub fn multiple_blocks() -> Message {
 pub fn blocks_across_messages() -> Vec<Message> {
     vec![
         Message {
-            role: ROLE_USER.to_string(),
+            role: TranscriptRole::User,
             content: "Show me Rust code".to_string(),
         },
         Message {
-            role: ROLE_ASSISTANT.to_string(),
+            role: TranscriptRole::Assistant,
             content: "```rust\nfn first() {}\n```".to_string(),
         },
         Message {
-            role: ROLE_USER.to_string(),
+            role: TranscriptRole::User,
             content: "And Python?".to_string(),
         },
         Message {
-            role: ROLE_ASSISTANT.to_string(),
+            role: TranscriptRole::Assistant,
             content: "```python\ndef second():\n    pass\n```".to_string(),
         },
     ]
@@ -64,7 +64,7 @@ pub fn blocks_across_messages() -> Vec<Message> {
 /// tracked with metadata.
 pub fn nested_in_list() -> Message {
     Message {
-        role: ROLE_ASSISTANT.to_string(),
+        role: TranscriptRole::Assistant,
         content: concat!(
             "1. First step\n\n",
             "   ```rust\n",
@@ -84,7 +84,7 @@ pub fn nested_in_list() -> Message {
 /// Tests that metadata is preserved across wrapped lines.
 pub fn wrapped_code() -> Message {
     Message {
-        role: ROLE_ASSISTANT.to_string(),
+        role: TranscriptRole::Assistant,
         content: concat!(
             "```rust\n",
             "fn very_long_function_name_that_will_definitely_wrap_on_narrow_terminals() {\n",
@@ -101,7 +101,7 @@ pub fn wrapped_code() -> Message {
 /// Tests handling of code blocks with no content.
 pub fn empty_block() -> Message {
     Message {
-        role: ROLE_ASSISTANT.to_string(),
+        role: TranscriptRole::Assistant,
         content: "Here's an empty block:\n\n```\n```\n\nDone.".to_string(),
     }
 }
@@ -111,7 +111,7 @@ pub fn empty_block() -> Message {
 /// Tests that blocks without language tags still get metadata.
 pub fn no_language_tag() -> Message {
     Message {
-        role: ROLE_ASSISTANT.to_string(),
+        role: TranscriptRole::Assistant,
         content: "```\nplain code\nno language\n```".to_string(),
     }
 }
@@ -121,7 +121,7 @@ pub fn no_language_tag() -> Message {
 /// Tests parsing when there's no whitespace around code blocks.
 pub fn adjacent_to_text() -> Message {
     Message {
-        role: ROLE_ASSISTANT.to_string(),
+        role: TranscriptRole::Assistant,
         content: "Before```rust\nfn adjacent() {}\n```After".to_string(),
     }
 }
@@ -131,7 +131,7 @@ pub fn adjacent_to_text() -> Message {
 /// Tests that user messages render code blocks with metadata.
 pub fn user_message_with_code() -> Message {
     Message {
-        role: ROLE_USER.to_string(),
+        role: TranscriptRole::User,
         content: "Can you explain this?\n\n```python\ndef mystery():\n    pass\n```".to_string(),
     }
 }
@@ -141,7 +141,7 @@ pub fn user_message_with_code() -> Message {
 /// Tests that code block metadata coexists with link metadata.
 pub fn code_and_links() -> Message {
     Message {
-        role: ROLE_ASSISTANT.to_string(),
+        role: TranscriptRole::Assistant,
         content: concat!(
             "Check [the docs](https://example.com) for details:\n\n",
             "```rust\nfn example() {}\n```\n\n",
@@ -156,7 +156,7 @@ pub fn code_and_links() -> Message {
 /// Tests language tag handling for common languages.
 pub fn various_languages() -> Message {
     Message {
-        role: ROLE_ASSISTANT.to_string(),
+        role: TranscriptRole::Assistant,
         content: concat!(
             "```bash\necho 'hello'\n```\n\n",
             "```javascript\nconsole.log('hi');\n```\n\n",

--- a/src/ui/markdown/tests/lists.rs
+++ b/src/ui/markdown/tests/lists.rs
@@ -2,7 +2,7 @@
 use super::helpers::{
     assert_first_span_is_space_indented, assert_line_text, line_texts, render_markdown_for_test,
 };
-use crate::core::message::Message;
+use crate::core::message::{Message, TranscriptRole};
 use crate::ui::markdown::render::{
     MarkdownRenderer, MarkdownRendererConfig, MarkdownWidthConfig, RoleKind,
 };
@@ -23,7 +23,7 @@ use unicode_width::UnicodeWidthStr;
 fn wrapped_list_items_align_under_text() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: "- Parent item that wraps within the width budget and keeps alignment.\n  - Child item that wraps nicely under its parent alignment requirement.\n    - Grandchild entry that wraps and keeps deeper indentation consistent.".into(),
         };
 
@@ -85,7 +85,7 @@ fn wrapped_list_items_align_under_text() {
 fn gfm_callout_blockquotes_render_content() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "> [!NOTE]\n> Always document parser upgrades.".into(),
     };
 
@@ -108,7 +108,7 @@ fn gfm_callout_blockquotes_render_content() {
 fn ordered_list_item_code_block_is_indented_under_marker() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "1. Intro text\n\n   ```\n   fn greet() {}\n   ```\n\n   Follow up text".into(),
     };
 
@@ -143,7 +143,7 @@ fn ordered_list_item_code_block_is_indented_under_marker() {
 fn multi_item_ordered_list_keeps_code_block_with_correct_item() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: "1. **Open a new terminal** on your local machine (keeping your SSH session open) and run `scp` as above.\n2. **Use `scp` in reverse** from the remote side *to* your local machine (if remote can reach your local machine and SSH is accessible), e.g.:\n   ```bash\n   scp /path/to/file you@your_local_IP:/path/to/local/destination/\n   ```\n   But this only works if your local machine is running an SSH server and is network-reachable — rarely the case.\n3. **Use `rsync` over SSH** similarly to `scp`."
                 .into(),
         };
@@ -193,7 +193,7 @@ fn multi_item_ordered_list_keeps_code_block_with_correct_item() {
 fn nested_bullet_lists_render_with_indentation() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "* Item 1\n    * Sub-item 1.1\n    * Sub-item 1.2\n        * Sub-sub-item 1.2.1"
             .into(),
     };
@@ -238,7 +238,7 @@ fn nested_bullet_lists_render_with_indentation() {
 fn nested_lists_dont_add_blank_lines_between_same_level_items() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content:
             "- Budget tree, branch one\n  - Emergency fund\n    - Sub-sticky note\n  - Groceries"
                 .into(),
@@ -278,7 +278,7 @@ fn list_with_source_blank_lines_preserves_spacing_between_top_level_items() {
     // those should be preserved to provide visual breathing room
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: "- Strategic Foundations\n  - Long-Horizon Thinking\n    - Scenario Branches\n\n- Implementation Patterns\n  - Knowledge Architecture\n    - Modular repositories\n\n- Resilience\n  - Stressors".into(),
         };
 
@@ -316,7 +316,7 @@ fn list_without_source_blank_lines_has_no_spacing_between_top_level_items() {
     // they should render consecutively without extra spacing
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "- First section\n  - Nested item\n- Second section\n  - Another nested".into(),
     };
 
@@ -347,7 +347,7 @@ fn list_preceded_by_paragraph_has_blank_line_before() {
     // A list preceded by a paragraph should have a blank line separating them
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Here is some introductory text.\n\n- First item\n- Second item".into(),
     };
 
@@ -378,7 +378,7 @@ fn list_followed_by_paragraph_has_blank_line_after() {
     // A list followed by a paragraph should have a blank line separating them
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "- First item\n- Second item\n\nThis is concluding text.".into(),
     };
 
@@ -409,7 +409,7 @@ fn list_preceded_by_heading_has_blank_line_before() {
     // A list preceded by a heading should have a blank line separating them
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "## My Section\n\n- First item\n- Second item".into(),
     };
 
@@ -437,7 +437,7 @@ fn list_followed_by_heading_has_blank_line_after() {
     // A list followed by a heading should have a blank line separating them
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "- First item\n- Second item\n\n## Next Section".into(),
     };
 
@@ -472,7 +472,7 @@ fn complex_nested_lists_with_long_text_preserve_blank_lines() {
     // and blank lines at various nesting depths
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: r#"### Architecture Overview
 
 1. **Primary Concept: The Architecture of a Modern Knowledge System**
@@ -622,7 +622,7 @@ fn blank_line_before_paragraph_doesnt_cause_blank_before_later_list_item() {
     // get a blank line because there's no blank immediately before it.
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"- First item
 Paragraph text after first item.
 
@@ -677,7 +677,7 @@ fn lists_with_numeric_text_before_them_dont_shift_indices() {
     // to appear at wrong positions
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"2024 roadmap includes several initiatives.
 
 1. First initiative
@@ -729,7 +729,7 @@ fn lists_with_plus_markers_preserve_blank_lines() {
     // blank lines from source, just like - and * markers
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"+ First item
 + Second item
 
@@ -787,7 +787,7 @@ fn code_blocks_dont_shift_list_item_indices() {
     // blank lines to appear at wrong positions
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"Example code:
 ```
 - not a real item
@@ -843,7 +843,7 @@ fn list_items_with_multiple_paragraphs_preserve_blank_lines() {
     // should be preserved, not suppressed by the "skip blank after paragraph in list" logic
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"- First paragraph in item
 
   Second paragraph in same item
@@ -902,7 +902,7 @@ fn list_items_preserve_blank_lines_before_all_block_elements() {
     // within list items should be preserved, not just blank lines before paragraphs
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"- Introduction paragraph
 
   ```python
@@ -976,7 +976,7 @@ fn list_items_preserve_blank_lines_before_all_block_elements() {
 fn list_paragraphs_keep_indent_after_blank_lines() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: r#"- **Primary Concept**
   In designing a contemporary knowledge system, several foundational components must be conceptualized.
 
@@ -1013,7 +1013,7 @@ fn list_paragraphs_keep_indent_after_blank_lines() {
 fn list_paragraphs_with_soft_breaks_keep_indent() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: r#"- **Primary Concept: The Architecture of a Modern Knowledge System**
   In designing a contemporary knowledge system, several foundational components must be conceptualized, integrated, and optimized for scalability.
   The architecture should balance **information retrieval efficiency**, **semantic accuracy**, and **human-centered accessibility**.
@@ -1061,7 +1061,7 @@ fn nested_lists_with_single_blank_line_dont_double_space() {
     // peeking ahead and seeing Tag::List, and another from Tag::Item preprocessing)
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"- parent
 
   - child one
@@ -1099,7 +1099,7 @@ fn blockquote_followed_by_list_has_single_blank_line() {
     // inside the blockquote, and another from TagEnd::BlockQuote)
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"> "Relax," it squeals, "we're diversified in hope and overdue library fines."
 
 - **Merit:** it funds the dream of four walls and a window box."#
@@ -1135,7 +1135,7 @@ fn blockquote_followed_by_paragraph_has_single_blank_line() {
     // the single blank line from the source, not double it
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"> Important quote here.
 
 This is a paragraph after the quote."#
@@ -1176,7 +1176,7 @@ fn blockquote_followed_by_heading_has_single_blank_line() {
     // Same issue with headings after blockquotes
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"> Important quote here.
 
 ## Next Section"#
@@ -1217,7 +1217,7 @@ fn blockquote_with_code_block_followed_by_paragraph() {
     // Test what happens when a blockquote contains a code block
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"> ```python
 > code_here()
 > ```

--- a/src/ui/markdown/tests/misc.rs
+++ b/src/ui/markdown/tests/misc.rs
@@ -2,7 +2,7 @@
 use super::helpers::{
     assert_first_span_is_space_indented, assert_line_text, line_texts, render_markdown_for_test,
 };
-use crate::core::message::Message;
+use crate::core::message::{Message, TranscriptRole};
 use crate::ui::markdown::render::{
     MarkdownRenderer, MarkdownRendererConfig, MarkdownWidthConfig, RoleKind,
 };
@@ -39,7 +39,7 @@ fn tool_call_arguments_do_not_render_markdown() {
 fn markdown_images_emit_clickable_links() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Look at this sketch: ![diagram](https://example.com/diagram.png) neat, right?"
             .into(),
     };
@@ -76,7 +76,7 @@ fn markdown_images_emit_clickable_links() {
 fn horizontal_rules_render_as_centered_lines() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Above\n\n---\n\nBelow".into(),
     };
 
@@ -117,7 +117,7 @@ fn horizontal_rules_render_as_centered_lines() {
 fn superscript_and_subscript_render_without_markers() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Subscripts: ~abc~ alongside superscripts: ^def^.".into(),
     };
 
@@ -206,7 +206,7 @@ fn test_extremely_narrow_terminal_no_truncation() {
     // Test that even extremely narrow terminals never truncate content
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r"| A | B |
 |---|---|
 | VeryLongUnbreakableWord | AnotherLongWord |
@@ -261,7 +261,7 @@ fn emphasis_with_standalone_paren() {
     // But let's test when the ) is 1 past by using fundamentally_x
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Space exploration is *fundamentally_x* )".into(),
     };
 

--- a/src/ui/markdown/tests/syntax_spans.rs
+++ b/src/ui/markdown/tests/syntax_spans.rs
@@ -2,7 +2,7 @@
 use super::helpers::{
     assert_first_span_is_space_indented, assert_line_text, line_texts, render_markdown_for_test,
 };
-use crate::core::message::Message;
+use crate::core::message::{Message, TranscriptRole};
 use crate::ui::markdown::render::{
     MarkdownRenderer, MarkdownRendererConfig, MarkdownWidthConfig, RoleKind,
 };
@@ -23,7 +23,7 @@ use unicode_width::UnicodeWidthStr;
 fn markdown_details_metadata_matches_lines_and_tags() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Testing metadata with a [link](https://example.com) inside.".into(),
     };
 
@@ -72,7 +72,7 @@ fn markdown_details_metadata_matches_lines_and_tags() {
 fn metadata_marks_user_prefix() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "user".into(),
+        role: TranscriptRole::User,
         content: "Hello world".into(),
     };
 

--- a/src/ui/markdown/tests/tables.rs
+++ b/src/ui/markdown/tests/tables.rs
@@ -2,7 +2,7 @@
 use super::helpers::{
     assert_first_span_is_space_indented, assert_line_text, line_texts, render_markdown_for_test,
 };
-use crate::core::message::Message;
+use crate::core::message::{Message, TranscriptRole};
 use crate::ui::markdown::render::{
     MarkdownRenderer, MarkdownRendererConfig, MarkdownWidthConfig, RoleKind,
 };
@@ -23,7 +23,7 @@ use unicode_width::UnicodeWidthStr;
 fn metadata_marks_table_links() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r"| Label | Value |
 |-------|-------|
 | Mixed | plain text and [Example](https://example.com) with trailing words |
@@ -97,7 +97,7 @@ fn debug_table_events() {
 fn table_rendering_works() {
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r###"Here's a table:
 
 | Header 1 | Header 2 | Header 3 |
@@ -138,7 +138,7 @@ End of table."###
 fn table_renders_emoji_and_br_correctly() {
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r"| Header | Data |
 |---|---|
 | Abc | 123 |
@@ -455,7 +455,7 @@ fn test_table_no_content_truncation_wide_terminal() {
     // This test defines our goal: no content should ever be truncated with ellipsis
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: r"| Short | Medium Content Here | Very Long Column With Lots Of Text That Should Not Be Truncated |
 |-------|---------------------|------------------------------------------------------------------|
 | A     | Some content here   | This is a very long piece of text that contains important information that the user needs to see in full without any truncation or ellipsis |
@@ -510,7 +510,7 @@ fn test_table_content_wrapping_medium_terminal() {
     // Test that content wraps within cells when terminal is narrower
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: r"| Name | Description |
 |------|-------------|
 | API  | This is a detailed description of how the API works with multiple parameters and return values |
@@ -565,7 +565,7 @@ fn test_table_should_not_wrap_borders() {
     // This test reproduces the real-world issue where table borders get wrapped
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: r#"| System of Government | Definition | Key Features | Examples |
 |---------------------|------------|--------------|----------|
 | Democracy | Government by the people, either directly or through elected representatives. | Universal suffrage, free elections, protection of civil liberties. | United States, India, Germany |
@@ -622,7 +622,7 @@ fn test_styled_words_wrap_at_boundaries_in_table() {
     // boundaries (including hyphen breaks), not inside the styled words.
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r#"| Feature | Benefits |
 |---------|----------|
 | X | **Dramatically** _improved_ decision-making capabilities with ***real-time*** analytics |
@@ -683,7 +683,7 @@ fn test_table_wrapping_with_mixed_content() {
     // Test wrapping behavior with mixed short and long content
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: r"| ID | Status | Details |
 |----|--------|----------|
 | 1  | OK     | Everything is working perfectly and all systems are operational |
@@ -739,7 +739,7 @@ fn test_table_with_emoji_and_unicode_no_truncation() {
     // Test that emoji and Unicode characters are handled without truncation
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: r"| Status | Message | Details |
 |--------|---------|----------|
 | ✅     | Success | Operation completed successfully with all parameters validated |
@@ -788,7 +788,7 @@ fn table_preserves_words_with_available_space() {
 
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: markdown.to_string(),
     });
 
@@ -829,7 +829,7 @@ fn test_government_systems_table_from_testcase() {
     // 2. Vertical borders remain aligned
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: r#"| Government Type | Description | Key Characteristics | Examples |
 |-----------------|-------------|--------------------|---------|
 | **Democracy** | A system where power is vested in the people, who rule either *directly* or through elected representatives. | - Free and fair elections<br/>- Protection of individual rights and freedoms<br/>- Rule of law and separation of powers | - *United States*, *India*, *Germany* |
@@ -925,7 +925,7 @@ fn test_table_cell_word_wrapping_regression() {
     // Reproduce the table wrapping issue - test that words wrap within table cells
     let mut messages = VecDeque::new();
     messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: r###"Here's a table with long content that should wrap:
 
 | Column A | Column B | Column C |

--- a/src/ui/markdown/tests/wrapping.rs
+++ b/src/ui/markdown/tests/wrapping.rs
@@ -2,7 +2,7 @@
 use super::helpers::{
     assert_first_span_is_space_indented, assert_line_text, line_texts, render_markdown_for_test,
 };
-use crate::core::message::Message;
+use crate::core::message::{Message, TranscriptRole};
 use crate::ui::markdown::render::{
     MarkdownRenderer, MarkdownRendererConfig, MarkdownWidthConfig, RoleKind,
 };
@@ -23,7 +23,7 @@ use unicode_width::UnicodeWidthStr;
 fn shared_renderer_with_metadata_matches_details_wrapper() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "A [link](https://example.com) and a code block.\n\n```rust\nfn main() {}\n```"
             .into(),
     };
@@ -64,7 +64,7 @@ fn shared_renderer_with_metadata_matches_details_wrapper() {
 fn markdown_links_wrap_at_word_boundaries_with_width() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "abcd efgh [hypertext dreams](https://docs.hypertext.org) and more text".into(),
     };
 
@@ -101,7 +101,7 @@ fn markdown_links_wrap_at_word_boundaries_with_width() {
 fn markdown_links_wrap_in_long_paragraph_without_mid_word_break() {
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: SAMPLE_HYPERTEXT_PARAGRAPH.to_string(),
     };
 
@@ -219,7 +219,7 @@ fn emphasis_ending_one_after_width() {
     // Test when italic word extends one char past the width
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Space exploration is *fundamentally* good.".into(),
     };
 
@@ -243,7 +243,7 @@ fn strong_emphasis_ending_at_width() {
     // Test with **bold** text
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Space exploration is **fundamentally** useful.".into(),
     };
 
@@ -266,7 +266,7 @@ fn inline_code_ending_at_width() {
     // Test with `code` text
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "The function is `very_important_func` today.".into(),
     };
 
@@ -306,7 +306,7 @@ fn link_ending_at_width() {
     // Test with [text](url) links
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Check out [this important resource](http://example.com) here.".into(),
     };
 
@@ -329,7 +329,7 @@ fn strikethrough_ending_at_width() {
     // Test with ~~strikethrough~~ text
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "This approach is ~~fundamentally~~ useful.".into(),
     };
 
@@ -352,7 +352,7 @@ fn emphasis_with_punctuation_at_width() {
     // Test emphasis followed by punctuation then space
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Space exploration is *fundamentally*, I think, useful.".into(),
     };
 
@@ -377,7 +377,7 @@ fn emphasis_with_paren_inside_at_width() {
     // Test paren INSIDE emphasis: *(word)* next
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Space exploration is *(fundamentally)* useful.".into(),
     };
 
@@ -418,7 +418,7 @@ fn emphasis_with_paren_outside_one_past_width() {
     // Then ")" is at position 37 (1 past boundary)
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Space exploration is *fundamentally_x*) useful.".into(),
     };
 
@@ -455,7 +455,7 @@ fn code_with_closing_paren_at_width() {
     // Test inline code followed by closing paren: `code`) next
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "The function is `very_important_func`) today.".into(),
     };
 
@@ -494,7 +494,7 @@ fn emphasis_with_multiple_adjacent_punctuation() {
     // Then "))) more" - width limit is 37, so first ) fits but not all
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Space exploration is *fundamentally*))) more.".into(),
     };
 
@@ -535,7 +535,7 @@ fn emphasis_preserves_style_during_backtracking() {
     // The word "fundamentally_x" MUST remain italic on the wrapped line
     let theme = crate::ui::theme::Theme::dark_default();
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: "Space exploration is *fundamentally_x*) useful.".into(),
     };
 
@@ -585,7 +585,7 @@ fn emphasis_fills_entire_width_with_adjacent_punct() {
     // Create a word that's exactly 36 chars
     let word = "a_very_long_italicized_word_here"; // 32 chars
     let message = Message {
-        role: "assistant".into(),
+        role: TranscriptRole::Assistant,
         content: format!("*{}*) more.", word),
     };
 

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -11,7 +11,7 @@
 use crate::core::app::ui_state::{EditSelectTarget, ToolPrompt};
 use crate::core::app::App;
 use crate::core::app::InspectMode;
-use crate::core::message::{AppMessageKind, ROLE_ASSISTANT, ROLE_TOOL_CALL};
+use crate::core::message::{AppMessageKind, TranscriptRole};
 use crate::core::text_wrapping::{TextWrapper, WrapConfig};
 use crate::ui::layout::{LayoutConfig, LayoutEngine, TableOverflowPolicy};
 use crate::ui::osc_state::{compute_render_state, set_render_state, OscRenderState};
@@ -647,7 +647,7 @@ fn input_title_base(app: &App, input_width: u16) -> Cow<'_, str> {
         let mut title = String::from("Edit in place: Enter=Apply • Esc=Cancel (no send)");
         if app.ui.compose_mode {
             if let Some(message) = app.ui.messages.get(index) {
-                if message.role == ROLE_ASSISTANT {
+                if message.role == TranscriptRole::Assistant {
                     title.push_str(" • F4: toggle compose mode");
                 }
             }
@@ -680,7 +680,7 @@ fn tool_prompt_insert_index(
 
     let mut last_tool_call = None;
     for (idx, message) in messages.iter().enumerate().rev() {
-        if message.role == ROLE_TOOL_CALL {
+        if message.role == TranscriptRole::ToolCall {
             last_tool_call = Some(idx);
             break;
         }
@@ -690,7 +690,7 @@ fn tool_prompt_insert_index(
     let mut first_in_batch = last_tool_call;
     for idx in (0..=last_tool_call).rev() {
         let message = &messages[idx];
-        if message.role == ROLE_TOOL_CALL {
+        if message.role == TranscriptRole::ToolCall {
             first_in_batch = idx;
         } else {
             break;

--- a/src/ui/span.rs
+++ b/src/ui/span.rs
@@ -573,13 +573,13 @@ mod tests {
 
     #[test]
     fn extract_content_omits_list_indent() {
-        use crate::core::message::Message;
+        use crate::core::message::{Message, TranscriptRole};
         use crate::ui::markdown::{render_message_with_config, MessageRenderConfig};
         use crate::ui::theme::Theme;
 
         // Create a message with code in a list
         let msg = Message {
-            role: "assistant".to_string(),
+            role: TranscriptRole::Assistant,
             content: "1. Step one\n\n   ```python\n   def foo():\n       pass\n   ```\n"
                 .to_string(),
         };

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -1,4 +1,4 @@
-use crate::core::message::{Message, ROLE_APP_LOG, ROLE_ASSISTANT, ROLE_USER};
+use crate::core::message::{Message, TranscriptRole};
 use std::fs::OpenOptions;
 use std::io::{BufWriter, Write};
 use std::path::Path;
@@ -140,19 +140,19 @@ impl LoggingState {
             if Some(i) == skip_index {
                 continue;
             }
-            if msg.role == ROLE_USER {
+            if msg.role == TranscriptRole::User {
                 // Write user messages with the current user display name prefix
                 for line in format!("{}: {}", user_display_name, msg.content).lines() {
                     writeln!(temp_file, "{line}")?;
                 }
                 writeln!(temp_file)?; // Empty line for spacing
-            } else if msg.role == ROLE_ASSISTANT && !msg.content.is_empty() {
+            } else if msg.role == TranscriptRole::Assistant && !msg.content.is_empty() {
                 // Write assistant messages as-is (no prefix)
                 for line in msg.content.lines() {
                     writeln!(temp_file, "{line}")?;
                 }
                 writeln!(temp_file)?; // Empty line for spacing
-            } else if msg.role == ROLE_APP_LOG {
+            } else if msg.role == TranscriptRole::AppLog {
                 // Write log-type app messages with ## prefix
                 for line in format!("## {}", msg.content).lines() {
                     writeln!(temp_file, "{line}")?;

--- a/src/utils/scroll.rs
+++ b/src/utils/scroll.rs
@@ -1,4 +1,4 @@
-use crate::core::message::{Message, ROLE_ASSISTANT, ROLE_USER};
+use crate::core::message::{Message, TranscriptRole};
 #[cfg(test)]
 use crate::ui::markdown::build_markdown_display_lines;
 use crate::ui::span::SpanKind;
@@ -388,7 +388,7 @@ impl ScrollCalculator {
 
         if let Some(sel) = selected_index {
             if let Some(msg) = messages.get(sel) {
-                if msg.role == ROLE_USER || msg.role == ROLE_ASSISTANT {
+                if msg.role == TranscriptRole::User || msg.role == TranscriptRole::Assistant {
                     if let Some(span) = layout.message_spans.get(sel) {
                         let highlight_style = theme.selection_highlight_style.patch(highlight);
                         for (offset, (line, kinds)) in layout
@@ -692,7 +692,8 @@ mod tests {
     use crate::ui::span::SpanKind;
     use crate::ui::theme::Theme;
     use crate::utils::test_utils::{
-        create_test_message, create_test_messages, SAMPLE_HYPERTEXT_PARAGRAPH,
+        create_test_message, create_test_message_with_role, create_test_messages,
+        SAMPLE_HYPERTEXT_PARAGRAPH,
     };
     use ratatui::style::Style;
     use ratatui::text::Line as TLine;
@@ -779,7 +780,7 @@ mod tests {
         let mut messages: VecDeque<Message> = VecDeque::new();
         let content = "Short line\n\nThis is a much longer line that might wrap depending on terminal width\nAnother short one";
         messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: content.into(),
         });
 
@@ -819,7 +820,7 @@ mod tests {
         let mut messages: VecDeque<Message> = VecDeque::new();
         let long = "This is a very long plain text line without explicit newlines that should wrap when markdown is disabled";
         messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: long.into(),
         });
 
@@ -946,7 +947,7 @@ mod tests {
         let theme = Theme::dark_default();
         let mut messages = VecDeque::new();
         messages.push_back(Message {
-            role: "assistant".into(),
+            role: TranscriptRole::Assistant,
             content: SAMPLE_HYPERTEXT_PARAGRAPH.into(),
         });
 
@@ -1059,8 +1060,8 @@ mod tests {
     #[test]
     fn test_app_message_formatting() {
         let mut messages = VecDeque::new();
-        messages.push_back(create_test_message(
-            crate::core::message::ROLE_APP_INFO,
+        messages.push_back(create_test_message_with_role(
+            crate::core::message::TranscriptRole::AppInfo,
             "App message",
         ));
 

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -189,7 +189,19 @@ pub fn create_test_app() -> App {
 #[cfg(test)]
 pub fn create_test_message(role: &str, content: &str) -> Message {
     Message {
-        role: role.to_string(),
+        role: crate::core::message::TranscriptRole::try_from(role.to_string())
+            .expect("invalid test role"),
+        content: content.to_string(),
+    }
+}
+
+#[cfg(test)]
+pub fn create_test_message_with_role(
+    role: crate::core::message::TranscriptRole,
+    content: &str,
+) -> Message {
+    Message {
+        role,
         content: content.to_string(),
     }
 }


### PR DESCRIPTION
## Summary
- replace stringly-typed transcript roles with a `TranscriptRole` enum
  and move role checks to typed helpers (`is_user`, `is_assistant`,
  `is_app`, `to_api_role`, etc.)
- update message construction and role handling across conversation
  assembly, streaming lifecycle/actions, command handlers, rendering, and
  markdown/layout helpers to use typed roles end to end
- add serde conversion support for transcript role persistence and retain
  API compatibility by mapping only user/assistant roles into API payloads
- update tests and bench fixtures to align with the typed role model

## Why
Role values were previously carried as raw strings, which made role checks
and conversions repetitive and error-prone. Centralizing roles in a typed
enum improves correctness and consistency while keeping serialized and API
behavior intact.

## Impact
- no intended user-facing behavior change
- lower risk of invalid role strings and mismatched role comparisons
- clearer extension point for future role categories
