### PR TITLE
refactor: unify character test fixtures

### DIFF
--- a/src/character/import.rs
+++ b/src/character/import.rs
@@ -103,6 +103,7 @@ fn import_card_into(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::character::test_helpers::helpers::{create_temp_card_file, create_valid_card_json};
     use std::io::Write;
     use tempfile::{NamedTempFile, TempDir};
 
@@ -119,29 +120,16 @@ mod tests {
         result
     }
 
-    fn create_valid_card_json() -> String {
-        serde_json::json!({
-            "spec": "chara_card_v2",
-            "spec_version": "2.0",
-            "data": {
-                "name": "Test Import Character",
-                "description": "A test character for import tests",
-                "personality": "Friendly",
-                "scenario": "Testing",
-                "first_mes": "Hello!",
-                "mes_example": "Example"
-            }
-        })
-        .to_string()
-    }
-
     fn create_valid_card_file() -> NamedTempFile {
-        let mut temp_file = NamedTempFile::with_suffix(".json").unwrap();
-        temp_file
-            .write_all(create_valid_card_json().as_bytes())
-            .unwrap();
-        temp_file.flush().unwrap();
-        temp_file
+        let mut card: crate::character::card::CharacterCard =
+            serde_json::from_str(&create_valid_card_json()).unwrap();
+        card.data.name = "Test Import Character".to_string();
+        card.data.description = "A test character for import tests".to_string();
+        card.data.personality = "Friendly".to_string();
+        card.data.scenario = "Testing".to_string();
+        card.data.first_mes = "Hello!".to_string();
+        card.data.mes_example = "Example".to_string();
+        create_temp_card_file(&card)
     }
 
     #[test]

--- a/src/character/service.rs
+++ b/src/character/service.rs
@@ -321,7 +321,7 @@ impl Default for CharacterService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::character::test_helpers::helpers::create_temp_cards_dir_with_cards;
+    use crate::character::test_helpers::helpers::{create_temp_cards_dir, create_test_character};
     use crate::utils::test_utils::TestEnvVarGuard;
     use std::fs;
     use std::thread;
@@ -329,7 +329,13 @@ mod tests {
 
     #[test]
     fn resolves_updates_after_file_change() {
-        let (_dir, cards_dir) = create_temp_cards_dir_with_cards(&[("Alice", "Hello there!")]);
+        let (_dir, cards_dir) = create_temp_cards_dir();
+        let card = create_test_character("Alice", "Hello there!");
+        fs::write(
+            cards_dir.join("alice.json"),
+            serde_json::to_string(&card).unwrap(),
+        )
+        .unwrap();
         let mut env_guard = TestEnvVarGuard::new();
         env_guard.set_var("CHABEAU_CARDS_DIR", &cards_dir);
 


### PR DESCRIPTION
### Motivation

- Reduce duplicated fixture code across character tests by centralizing defaults and helpers in one module so schema changes only need a single edit.
- Improve test consistency and make integration/unit tests consume the same fixture primitives for clearer intent.
- Simplify per-file test setup and avoid divergent helper implementations that drift over time.

### Description

- Introduced a single shared fixture source in `src/character/test_helpers.rs` with `base_character_data()` and exported helpers `create_test_character`, `create_temp_card_file`, `create_temp_cards_dir`, and `create_valid_card_json` to provide a single source of truth for default field values. 
- Updated `src/character/tests_integration.rs` to remove local fixture helpers and import the shared helpers from `crate::character::test_helpers::helpers`, and replaced ad-hoc temp-dir/card setup with `create_temp_cards_dir` and `create_temp_card_file` where applicable. 
- Updated `src/character/import.rs` and `src/character/loader.rs` tests to use `create_valid_card_json`/`create_temp_card_file` and `create_test_character` instead of local JSON builders and inline `CharacterCard` structs. 
- Adjusted `src/character/service.rs` tests to use `create_temp_cards_dir` and `create_test_character` and removed reliance on the removed per-file prepopulated-dir helper; removed redundant helper `create_temp_cards_dir_with_cards`. 

### Testing

- Ran `cargo fmt` and formatting completed successfully. 
- Ran `cargo check` and it completed successfully. 
- Ran `cargo test` and all tests passed (`724 passed; 0 failed`), including unit and doc-tests. 
- Ran `cargo clippy --all-targets --all-features -- -D warnings` and it completed with no warnings (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69942855a1c8832bb8835a563983b522)