### PR TITLE
test(markdown): trim unused test imports

### DIFF
--- a/src/ui/markdown/tests/lists.rs
+++ b/src/ui/markdown/tests/lists.rs
@@ -1,22 +1,7 @@
-#![allow(unused_imports)]
 use super::helpers::{
     assert_first_span_is_space_indented, assert_line_text, line_texts, render_markdown_for_test,
 };
 use crate::core::message::{Message, TranscriptRole};
-use crate::ui::markdown::render::{
-    MarkdownRenderer, MarkdownRendererConfig, MarkdownWidthConfig, RoleKind,
-};
-use crate::ui::markdown::table::TableRenderer;
-use crate::ui::markdown::{
-    render_message_markdown_details_with_policy_and_user_name, render_message_with_config,
-    MessageRenderConfig,
-};
-use crate::ui::span::SpanKind;
-use crate::utils::test_utils::SAMPLE_HYPERTEXT_PARAGRAPH;
-use pulldown_cmark::{Options, Parser};
-use ratatui::style::Modifier;
-use ratatui::text::Span;
-use std::collections::VecDeque;
 use unicode_width::UnicodeWidthStr;
 
 #[test]

--- a/src/ui/markdown/tests/misc.rs
+++ b/src/ui/markdown/tests/misc.rs
@@ -1,20 +1,8 @@
-#![allow(unused_imports)]
-use super::helpers::{
-    assert_first_span_is_space_indented, assert_line_text, line_texts, render_markdown_for_test,
-};
+use super::helpers::{assert_line_text, line_texts, render_markdown_for_test};
 use crate::core::message::{Message, TranscriptRole};
-use crate::ui::markdown::render::{
-    MarkdownRenderer, MarkdownRendererConfig, MarkdownWidthConfig, RoleKind,
-};
 use crate::ui::markdown::table::TableRenderer;
-use crate::ui::markdown::{
-    render_message_markdown_details_with_policy_and_user_name, render_message_with_config,
-    MessageRenderConfig,
-};
+use crate::ui::markdown::{render_message_with_config, MessageRenderConfig};
 use crate::ui::span::SpanKind;
-use crate::utils::test_utils::SAMPLE_HYPERTEXT_PARAGRAPH;
-use pulldown_cmark::{Options, Parser};
-use ratatui::style::Modifier;
 use ratatui::text::Span;
 use std::collections::VecDeque;
 use unicode_width::UnicodeWidthStr;

--- a/src/ui/markdown/tests/syntax_spans.rs
+++ b/src/ui/markdown/tests/syntax_spans.rs
@@ -1,23 +1,6 @@
-#![allow(unused_imports)]
-use super::helpers::{
-    assert_first_span_is_space_indented, assert_line_text, line_texts, render_markdown_for_test,
-};
 use crate::core::message::{Message, TranscriptRole};
-use crate::ui::markdown::render::{
-    MarkdownRenderer, MarkdownRendererConfig, MarkdownWidthConfig, RoleKind,
-};
-use crate::ui::markdown::table::TableRenderer;
-use crate::ui::markdown::{
-    render_message_markdown_details_with_policy_and_user_name, render_message_with_config,
-    MessageRenderConfig,
-};
+use crate::ui::markdown::render_message_markdown_details_with_policy_and_user_name;
 use crate::ui::span::SpanKind;
-use crate::utils::test_utils::SAMPLE_HYPERTEXT_PARAGRAPH;
-use pulldown_cmark::{Options, Parser};
-use ratatui::style::Modifier;
-use ratatui::text::Span;
-use std::collections::VecDeque;
-use unicode_width::UnicodeWidthStr;
 
 #[test]
 fn markdown_details_metadata_matches_lines_and_tags() {

--- a/src/ui/markdown/tests/tables.rs
+++ b/src/ui/markdown/tests/tables.rs
@@ -1,20 +1,9 @@
-#![allow(unused_imports)]
-use super::helpers::{
-    assert_first_span_is_space_indented, assert_line_text, line_texts, render_markdown_for_test,
-};
+use super::helpers::{line_texts, render_markdown_for_test};
 use crate::core::message::{Message, TranscriptRole};
-use crate::ui::markdown::render::{
-    MarkdownRenderer, MarkdownRendererConfig, MarkdownWidthConfig, RoleKind,
-};
+use crate::ui::markdown::render_message_markdown_details_with_policy_and_user_name;
 use crate::ui::markdown::table::TableRenderer;
-use crate::ui::markdown::{
-    render_message_markdown_details_with_policy_and_user_name, render_message_with_config,
-    MessageRenderConfig,
-};
 use crate::ui::span::SpanKind;
-use crate::utils::test_utils::SAMPLE_HYPERTEXT_PARAGRAPH;
 use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
-use ratatui::style::Modifier;
 use ratatui::text::Span;
 use std::collections::VecDeque;
 use unicode_width::UnicodeWidthStr;

--- a/src/ui/markdown/tests/wrapping.rs
+++ b/src/ui/markdown/tests/wrapping.rs
@@ -1,22 +1,14 @@
-#![allow(unused_imports)]
-use super::helpers::{
-    assert_first_span_is_space_indented, assert_line_text, line_texts, render_markdown_for_test,
-};
+use super::helpers::{line_texts, render_markdown_for_test};
 use crate::core::message::{Message, TranscriptRole};
 use crate::ui::markdown::render::{
     MarkdownRenderer, MarkdownRendererConfig, MarkdownWidthConfig, RoleKind,
 };
+use crate::ui::markdown::render_message_markdown_details_with_policy_and_user_name;
 use crate::ui::markdown::table::TableRenderer;
-use crate::ui::markdown::{
-    render_message_markdown_details_with_policy_and_user_name, render_message_with_config,
-    MessageRenderConfig,
-};
 use crate::ui::span::SpanKind;
 use crate::utils::test_utils::SAMPLE_HYPERTEXT_PARAGRAPH;
-use pulldown_cmark::{Options, Parser};
 use ratatui::style::Modifier;
 use ratatui::text::Span;
-use std::collections::VecDeque;
 use unicode_width::UnicodeWidthStr;
 
 #[test]


### PR DESCRIPTION
### Motivation
- Remove broad `#![allow(unused_imports)]` on markdown test modules so unused imports are not silently ignored.
- Reduce each test file's `use` lists to only the symbols actually referenced to keep tests clear and enforce hygiene.
- Retain explicit `super::helpers` imports for the shared test helpers rather than introducing a blanket prelude.

### Description
- Removed the crate-level `#![allow(unused_imports)]` from the markdown test modules under `src/ui/markdown/tests/` and trimmed each file's imports to the minimal set used.
- Files changed: `syntax_spans.rs`, `tables.rs`, `wrapping.rs`, `misc.rs`, and `lists.rs` now only import the symbols they require (and keep `super::helpers` imports where helpers are used).
- Restored a few focused imports used by tests (for example `unicode_width::UnicodeWidthStr` where `width()` calls are used) instead of keeping broad `pulldown_cmark`, `ratatui`, or renderer imports when unused.
- Kept explicit calls to the existing helper functions (`render_markdown_for_test`, `line_texts`, etc.) so no shared prelude was introduced.

### Testing
- Ran `cargo check --tests` and it completed successfully.
- Ran the full test suite with `cargo test` and all tests passed (`722 passed; 0 failed`).
- Verified formatting with `cargo fmt --check` which succeeded.
- Ran `cargo clippy --tests -- -D warnings` and it finished without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c4e89190832ba7a01cf18147ca9f)