### PR TITLE
refactor(core::app): prune stale re-exports and tighten public API

### DIFF
--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -9,6 +9,8 @@
 //! module also provides action dispatching for UI events and background commands.
 
 use crate::character::service::CharacterService;
+use crate::core::app::picker::PickerController;
+use crate::core::app::ui_state::UiState;
 use crate::core::config::data::Config;
 use crate::core::message::AppMessageKind;
 use crate::core::providers::ProviderSession;
@@ -36,22 +38,15 @@ pub use actions::{
     CommandAction, ComposeAction, FilePromptAction, InputAction, InspectAction, McpPromptAction,
     PickerAction, PromptAction, StatusAction, StreamingAction,
 };
-#[allow(unused_imports)]
-pub use conversation::ConversationController;
 pub use inspect::{InspectController, InspectMode, InspectState, ToolInspectKind, ToolInspectView};
 #[cfg(test)]
 pub use picker::PickerData;
-#[allow(unused_imports)]
-pub use picker::{
-    CharacterPickerState, ModelPickerState, PersonaPickerState, PickerController, PickerMode,
-    PickerSession, PresetPickerState, ProviderPickerState, ThemePickerState,
-};
+// This module intentionally re-exports the high-level picker enums commonly used
+// by UI and command orchestration code to keep `core::app` imports concise.
+pub use picker::PickerMode;
 pub use pickers::ModelPickerRequest;
 pub use session::{SessionBootstrap, SessionContext, UninitializedSessionBootstrap};
-#[allow(unused_imports)]
-pub use settings::{ProviderController, ThemeController};
-#[allow(unused_imports)]
-pub use ui_state::{ActivityKind, UiState, VerticalCursorDirection};
+pub use ui_state::ActivityKind;
 
 /// Configuration parameters for initializing an App with authentication.
 ///

--- a/src/core/app/picker/mod.rs
+++ b/src/core/app/picker/mod.rs
@@ -1,4 +1,4 @@
-use super::{SessionContext, UiState};
+use super::{session::SessionContext, ui_state::UiState};
 use crate::api::models::sort_models;
 use crate::api::ModelsResponse;
 use crate::auth::AuthManager;

--- a/src/core/app/tests.rs
+++ b/src/core/app/tests.rs
@@ -1,9 +1,13 @@
 use super::*;
 use crate::api::{ChatMessage, ChatToolCall, ChatToolCallFunction};
+use crate::core::app::picker::{
+    ModelPickerState, PickerData, PickerSession, ProviderPickerState, ThemePickerState,
+};
 use crate::core::app::session::{
     PendingToolCall, StreamContinuation, ToolCallRequest, ToolPayloadHistoryEntry,
     ToolResultRecord, ToolResultStatus,
 };
+use crate::core::app::ui_state::VerticalCursorDirection;
 use crate::core::config::data::McpServerConfig;
 use crate::core::message::{Message, TranscriptRole};
 use crate::core::text_wrapping::{TextWrapper, WrapConfig};

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -987,11 +987,12 @@ fn apply_code_block_highlight(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::app::{apply_actions, AppAction, AppActionContext, AppActionEnvelope};
-    use crate::core::app::{
-        App, CharacterPickerState, ModelPickerState, PickerData, PickerSession,
-        ProviderPickerState, StreamingAction, ThemePickerState,
+    use crate::core::app::picker::{
+        CharacterPickerState, ModelPickerState, PickerData, PickerSession, ProviderPickerState,
+        ThemePickerState,
     };
+    use crate::core::app::{apply_actions, AppAction, AppActionContext, AppActionEnvelope};
+    use crate::core::app::{App, StreamingAction};
     use crate::ui::picker::PickerState;
     use crate::ui::theme::Theme;
 


### PR DESCRIPTION
### Motivation

- Reduce API sprawl by removing top-level re-exports that were kept only behind `#[allow(unused_imports)]` and are no longer necessary. 
- Prevent accidental consumers from relying on internal types and improve clarity of the intended public surface of `core::app`.

### Description

- Removed stale umbrella re-exports from `src/core/app/mod.rs` (conversation controller, detailed picker state/controller internals, settings controllers, and `UiState`/`VerticalCursorDirection`) and kept only intentional ergonomic exports `PickerMode` and `ActivityKind` with a short module-level comment documenting that policy. 
- Added explicit internal imports for `PickerController` and `UiState` in `core::app::mod` so internal code continues to build without relying on the removed re-exports. 
- Updated dependent code and tests to import concrete submodules instead of the removed umbrella exports, specifically adjusting `src/core/app/picker/mod.rs`, `src/core/app/tests.rs`, and `src/ui/renderer.rs` to reference `core::app::picker` and `core::app::ui_state` where appropriate. 
- Kept `PickerData` re-export for tests (`#[cfg(test)]`) and preserved other intended public symbols from `actions`, `inspect`, `pickers`, and `session` modules.

### Testing

- Ran `cargo fmt --all` and `cargo fmt --all --check` to ensure formatting, which succeeded. 
- Ran `cargo check` which finished successfully. 
- Ran the full test suite with `cargo test`, which completed with all tests passing. 
- Ran `cargo clippy --all-targets --all-features -- -D warnings`, which completed successfully with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ca39eb24832bb8a06604630a117f)