### PR TITLE
refactor: use input structs for hot paths

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -616,36 +616,36 @@ async fn handle_args(args: Args) -> Result<(), Box<dyn Error>> {
                         }
                         Some(model) => {
                             // -m was provided with a value, use it for chat
-                            run_chat(
-                                model.to_string(),
-                                args.log,
-                                provider_for_operations,
-                                args.env_only,
-                                character_for_operations,
-                                args.persona,
-                                preset_for_operations.clone(),
-                                args.disable_mcp,
-                                service_for_run
+                            run_chat(crate::ui::chat_loop::RunChatOptions {
+                                model: model.to_string(),
+                                log: args.log,
+                                provider: provider_for_operations,
+                                env_only: args.env_only,
+                                character: character_for_operations,
+                                persona: args.persona,
+                                preset: preset_for_operations.clone(),
+                                disable_mcp: args.disable_mcp,
+                                character_service: service_for_run
                                     .take()
                                     .expect("character service available for run_chat"),
-                            )
+                            })
                             .await
                         }
                         None => {
                             // -m was not provided, use default model for chat
-                            run_chat(
-                                "default".to_string(),
-                                args.log,
-                                provider_for_operations,
-                                args.env_only,
-                                character_for_operations,
-                                args.persona,
-                                preset_for_operations,
-                                args.disable_mcp,
-                                service_for_run
+                            run_chat(crate::ui::chat_loop::RunChatOptions {
+                                model: "default".to_string(),
+                                log: args.log,
+                                provider: provider_for_operations,
+                                env_only: args.env_only,
+                                character: character_for_operations,
+                                persona: args.persona,
+                                preset: preset_for_operations,
+                                disable_mcp: args.disable_mcp,
+                                character_service: service_for_run
                                     .take()
                                     .expect("character service available for run_chat"),
-                            )
+                            })
                             .await
                         }
                     }
@@ -669,15 +669,15 @@ async fn handle_args(args: Args) -> Result<(), Box<dyn Error>> {
             }
         }
         Some(Commands::Say { prompt }) => {
-            say::run_say(
+            say::run_say(say::RunSayOptions {
                 prompt,
-                args.model,
-                args.provider,
-                args.env_only,
-                args.character,
-                args.persona,
-                args.preset,
-            )
+                model: args.model,
+                provider: args.provider,
+                env_only: args.env_only,
+                character: args.character,
+                persona: args.persona,
+                preset: args.preset,
+            })
             .await
         }
         Some(Commands::Mcp { command }) => handle_mcp_command(command, args.env_only).await,

--- a/src/cli/say.rs
+++ b/src/cli/say.rs
@@ -234,6 +234,17 @@ fn plain_text_lines(lines: &[Line<'_>]) -> Vec<String> {
         .collect()
 }
 
+#[derive(Debug, Default)]
+pub struct RunSayOptions {
+    pub prompt: Vec<String>,
+    pub model: Option<String>,
+    pub provider: Option<String>,
+    pub env_only: bool,
+    pub character: Option<String>,
+    pub persona: Option<String>,
+    pub preset: Option<String>,
+}
+
 fn resolve_prompt_from_args(
     mut prompt: String,
     stdin: &mut dyn Read,
@@ -255,16 +266,16 @@ fn resolve_prompt_from_args(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn run_say(
-    prompt: Vec<String>,
-    model: Option<String>,
-    provider: Option<String>,
-    env_only: bool,
-    character: Option<String>,
-    persona: Option<String>,
-    preset: Option<String>,
-) -> Result<(), Box<dyn Error>> {
+pub async fn run_say(options: RunSayOptions) -> Result<(), Box<dyn Error>> {
+    let RunSayOptions {
+        prompt,
+        model,
+        provider,
+        env_only,
+        character,
+        persona,
+        preset,
+    } = options;
     let mut stdin = io::stdin();
     let stdin_is_terminal = stdin.is_terminal();
     let prompt = match resolve_prompt_from_args(prompt.join(" "), &mut stdin, stdin_is_terminal)? {

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -181,16 +181,16 @@ pub async fn new_with_auth(
         theme,
         startup_requires_provider,
         mut startup_errors,
-    } = session::prepare_with_auth(
-        init_config.model,
-        init_config.log_file,
-        init_config.provider,
-        init_config.env_only,
-        &effective_config,
-        init_config.pre_resolved_session,
-        init_config.character,
-        &mut character_service,
-    )
+    } = session::prepare_with_auth(session::PrepareWithAuthInput {
+        model: init_config.model,
+        log_file: init_config.log_file,
+        provider: init_config.provider,
+        env_only: init_config.env_only,
+        config: &effective_config,
+        pre_resolved_session: init_config.pre_resolved_session,
+        character: init_config.character,
+        character_service: &mut character_service,
+    })
     .await?;
 
     // Initialize PersonaManager and apply CLI persona if provided

--- a/src/ui/chat_loop/event_loop.rs
+++ b/src/ui/chat_loop/event_loop.rs
@@ -50,6 +50,18 @@ use super::lifecycle::{
 use super::setup::bootstrap_app;
 use super::AppHandle;
 
+pub struct RunChatOptions {
+    pub model: String,
+    pub log: Option<String>,
+    pub provider: Option<String>,
+    pub env_only: bool,
+    pub character: Option<String>,
+    pub persona: Option<String>,
+    pub preset: Option<String>,
+    pub disable_mcp: bool,
+    pub character_service: CharacterService,
+}
+
 #[derive(Debug)]
 pub enum UiEvent {
     Crossterm(Event),
@@ -542,30 +554,8 @@ fn spawn_event_reader(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn run_chat(
-    model: String,
-    log: Option<String>,
-    provider: Option<String>,
-    env_only: bool,
-    character: Option<String>,
-    persona: Option<String>,
-    preset: Option<String>,
-    disable_mcp: bool,
-    character_service: CharacterService,
-) -> Result<(), Box<dyn Error>> {
-    let app = bootstrap_app(
-        model.clone(),
-        log.clone(),
-        provider.clone(),
-        env_only,
-        character,
-        persona,
-        preset,
-        disable_mcp,
-        character_service,
-    )
-    .await?;
+pub async fn run_chat(options: RunChatOptions) -> Result<(), Box<dyn Error>> {
+    let app = bootstrap_app(options).await?;
 
     app.update(|app| {
         app.conversation().show_character_greeting_if_needed();

--- a/src/ui/chat_loop/mod.rs
+++ b/src/ui/chat_loop/mod.rs
@@ -12,7 +12,7 @@ pub mod modes;
 mod setup;
 
 #[allow(unused_imports)]
-pub use event_loop::{run_chat, UiEvent};
+pub use event_loop::{run_chat, RunChatOptions, UiEvent};
 pub use keybindings::KeyLoopAction;
 
 use std::sync::Arc;

--- a/src/ui/chat_loop/setup.rs
+++ b/src/ui/chat_loop/setup.rs
@@ -2,11 +2,10 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use super::AppHandle;
+use super::{AppHandle, RunChatOptions};
 
 use crate::{
     auth::AuthManager,
-    character::CharacterService,
     core::{
         app,
         app::session::{exit_if_env_only_missing_env, exit_with_provider_resolution_error},
@@ -20,18 +19,20 @@ use crate::{
 ///
 /// This logic was historically embedded inside `run_chat`; extracting it keeps the event loop
 /// focused on UI concerns while centralising provider/model setup policy.
-#[allow(clippy::too_many_arguments)]
 pub async fn bootstrap_app(
-    model: String,
-    log: Option<String>,
-    provider: Option<String>,
-    env_only: bool,
-    character: Option<String>,
-    persona: Option<String>,
-    preset: Option<String>,
-    disable_mcp: bool,
-    character_service: CharacterService,
+    options: RunChatOptions,
 ) -> Result<AppHandle, Box<dyn std::error::Error>> {
+    let RunChatOptions {
+        model,
+        log,
+        provider,
+        env_only,
+        character,
+        persona,
+        preset,
+        disable_mcp,
+        character_service,
+    } = options;
     let config = Config::load()?;
     let auth_manager = AuthManager::new()?;
 

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -76,12 +76,14 @@ pub fn ui(f: &mut Frame, app: &mut App) {
         let layout = crate::utils::scroll::ScrollCalculator::build_layout_with_theme_and_selection_and_flags_and_width(
             &app.ui.messages,
             &app.ui.theme,
-            app.ui.selected_edit_message_index(),
-            highlight,
-            app.ui.markdown_enabled,
-            app.ui.syntax_enabled,
-            Some(chunks[0].width as usize),
-            Some(app.ui.user_display_name.clone()),
+            crate::utils::scroll::SelectionLayoutInput {
+                selected_index: app.ui.selected_edit_message_index(),
+                highlight,
+                markdown_enabled: app.ui.markdown_enabled,
+                syntax_enabled: app.ui.syntax_enabled,
+                terminal_width: Some(chunks[0].width as usize),
+                user_display_name: Some(app.ui.user_display_name.clone()),
+            },
         );
         (layout.lines, layout.span_metadata, None)
     } else if app.ui.in_block_select_mode() {


### PR DESCRIPTION
- replace positional args with focused input structs for session, say, and chat loop entry points
- migrate call sites to named-field struct literals for clearer initialization flow
- split scroll wrapping state into helper structs and convert selection layout APIs to structured inputs
- remove too-many-arguments suppressions once signatures compile with one input object

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d5c96234832bb9eb36d31f500601)