### PR TITLE
refactor(oauth): split open_in_browser into cfg-specific helpers

### DIFF
--- a/src/core/oauth.rs
+++ b/src/core/oauth.rs
@@ -239,34 +239,40 @@ async fn fetch_oauth_metadata(client: &reqwest::Client, url: &str) -> Option<OAu
 }
 
 pub fn open_in_browser(url: &str) -> Result<(), Box<dyn Error>> {
-    #[cfg(target_os = "macos")]
-    {
-        let status = std::process::Command::new("open").arg(url).status()?;
-        if status.success() {
-            return Ok(());
-        }
-        return Err("failed to launch browser with open".into());
-    }
-    #[cfg(target_os = "windows")]
-    {
-        let status = std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
-            .status()?;
-        if status.success() {
-            return Ok(());
-        }
-        return Err("failed to launch browser with start".into());
-    }
-    #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        let status = std::process::Command::new("xdg-open").arg(url).status()?;
-        if status.success() {
-            return Ok(());
-        }
-        return Err("failed to launch browser with xdg-open".into());
-    }
+    open_in_browser_impl(url)
+}
 
-    #[allow(unreachable_code)]
+#[cfg(target_os = "macos")]
+fn open_in_browser_impl(url: &str) -> Result<(), Box<dyn Error>> {
+    let status = std::process::Command::new("open").arg(url).status()?;
+    if status.success() {
+        return Ok(());
+    }
+    Err("failed to launch browser with open".into())
+}
+
+#[cfg(target_os = "windows")]
+fn open_in_browser_impl(url: &str) -> Result<(), Box<dyn Error>> {
+    let status = std::process::Command::new("cmd")
+        .args(["/C", "start", "", url])
+        .status()?;
+    if status.success() {
+        return Ok(());
+    }
+    Err("failed to launch browser with start".into())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn open_in_browser_impl(url: &str) -> Result<(), Box<dyn Error>> {
+    let status = std::process::Command::new("xdg-open").arg(url).status()?;
+    if status.success() {
+        return Ok(());
+    }
+    Err("failed to launch browser with xdg-open".into())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", unix)))]
+fn open_in_browser_impl(url: &str) -> Result<(), Box<dyn Error>> {
     Err(format!("no browser launcher configured for URL: {url}").into())
 }
 


### PR DESCRIPTION
### Motivation
- Remove the `#[allow(unreachable_code)]` fallback by consolidating platform-specific browser launch logic into clearly separated implementations.
- Make `open_in_browser` have a single, platform-agnostic entry point that delegates to per-target helpers for clarity and maintainability.

### Description
- Route `open_in_browser` through a single helper call to `open_in_browser_impl`.
- Add `open_in_browser_impl` implementations for macOS (`target_os = "macos"`), Windows (`target_os = "windows"`), and other Unix (`all(unix, not(target_os = "macos"))`).
- Add a default unsupported-target `open_in_browser_impl` (`not(any(...))`) that returns the existing launcher-missing error.
- Remove the previous unreachable fallback and delete the `#[allow(unreachable_code)]` usage.

### Testing
- Ran `cargo fmt` which completed successfully.
- Ran `cargo check` which completed successfully.
- Ran `cargo test` and unit tests/doc-tests completed successfully (`722` tests passed in the test suite).
- Ran `cargo clippy --all-targets --all-features` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ddd89608832bb5053c0f578ad5f8)