### PR TITLE
refactor(ui): drop unused UiEvent re-export

### DIFF
--- a/src/ui/chat_loop/mod.rs
+++ b/src/ui/chat_loop/mod.rs
@@ -11,8 +11,7 @@ mod lifecycle;
 pub mod modes;
 mod setup;
 
-#[allow(unused_imports)]
-pub use event_loop::{run_chat, RunChatOptions, UiEvent};
+pub use event_loop::{run_chat, RunChatOptions};
 pub use keybindings::KeyLoopAction;
 
 use std::sync::Arc;


### PR DESCRIPTION
### Motivation
- Remove an unnecessary `#[allow(unused_imports)]` and make the chat-loop public API explicit so only actually consumed items are re-exported.

### Description
- Remove the `#[allow(unused_imports)]` and stop re-exporting `UiEvent` from `src/ui/chat_loop/mod.rs`, keeping only `run_chat` and `RunChatOptions` as public re-exports.

### Testing
- Ran `cargo fmt`, `cargo check`, `cargo test`, and `cargo clippy --all-targets --all-features`, and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ddb68ebc832b95969495a8108a2c)