### PR TITLE
refactor(picker): box large PickerData variants to normalize enum footprint

### DIFF
--- a/src/core/app/actions/picker.rs
+++ b/src/core/app/actions/picker.rs
@@ -811,12 +811,12 @@ mod tests {
 
         app.picker.picker_session = Some(PickerSession {
             state: picker_state,
-            data: PickerData::Model(ModelPickerState {
+            data: PickerData::Model(Box::new(ModelPickerState {
                 search_filter: String::new(),
                 all_items: items,
                 before_model: Some("old-model".into()),
                 has_dates: false,
-            }),
+            })),
         });
 
         handle_picker_action(&mut app, PickerAction::PickerEscape, ctx);

--- a/src/core/app/settings.rs
+++ b/src/core/app/settings.rs
@@ -319,11 +319,11 @@ mod tests {
 
         app.picker.picker_session = Some(PickerSession {
             state: PickerState::new("Pick Provider", items.clone(), 0),
-            data: PickerData::Provider(ProviderPickerState {
+            data: PickerData::Provider(Box::new(ProviderPickerState {
                 search_filter: String::new(),
                 all_items: items,
                 before_provider: Some(("other".into(), "Other".into())),
-            }),
+            })),
         });
 
         let (result, should_open_model_picker) = {

--- a/src/core/app/tests.rs
+++ b/src/core/app/tests.rs
@@ -67,12 +67,12 @@ fn model_picker_title_uses_az_when_no_dates() {
     picker_state.sort_mode = crate::ui::picker::SortMode::Name;
     app.picker.picker_session = Some(PickerSession {
         state: picker_state,
-        data: PickerData::Model(ModelPickerState {
+        data: PickerData::Model(Box::new(ModelPickerState {
             search_filter: String::new(),
             all_items: items,
             before_model: None,
             has_dates: false,
-        }),
+        })),
     });
     app.update_picker_title();
     let picker = app.picker_state().unwrap();
@@ -311,12 +311,12 @@ fn default_sort_mode_helper_behaviour() {
     // Theme picker prefers alphabetical → Name
     app.picker.picker_session = Some(PickerSession {
         state: PickerState::new("Pick Theme", vec![], 0),
-        data: PickerData::Theme(ThemePickerState {
+        data: PickerData::Theme(Box::new(ThemePickerState {
             search_filter: String::new(),
             all_items: Vec::new(),
             before_theme: None,
             before_theme_id: None,
-        }),
+        })),
     });
     assert!(matches!(
         app.picker_session().unwrap().default_sort_mode(),
@@ -325,11 +325,11 @@ fn default_sort_mode_helper_behaviour() {
     // Provider picker prefers alphabetical → Name
     app.picker.picker_session = Some(PickerSession {
         state: PickerState::new("Pick Provider", vec![], 0),
-        data: PickerData::Provider(ProviderPickerState {
+        data: PickerData::Provider(Box::new(ProviderPickerState {
             search_filter: String::new(),
             all_items: Vec::new(),
             before_provider: None,
-        }),
+        })),
     });
     assert!(matches!(
         app.picker_session().unwrap().default_sort_mode(),
@@ -338,12 +338,12 @@ fn default_sort_mode_helper_behaviour() {
     // Model picker with dates → Date
     app.picker.picker_session = Some(PickerSession {
         state: PickerState::new("Pick Model", vec![], 0),
-        data: PickerData::Model(ModelPickerState {
+        data: PickerData::Model(Box::new(ModelPickerState {
             search_filter: String::new(),
             all_items: Vec::new(),
             before_model: None,
             has_dates: true,
-        }),
+        })),
     });
     assert!(matches!(
         app.picker_session().unwrap().default_sort_mode(),

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1012,12 +1012,12 @@ mod tests {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
         app.picker.picker_session = Some(PickerSession {
             state: picker_state,
-            data: PickerData::Model(ModelPickerState {
+            data: PickerData::Model(Box::new(ModelPickerState {
                 search_filter: search_filter.to_string(),
                 all_items: items,
                 before_model: None,
                 has_dates,
-            }),
+            })),
         });
     }
 
@@ -1030,12 +1030,12 @@ mod tests {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
         app.picker.picker_session = Some(PickerSession {
             state: picker_state,
-            data: PickerData::Theme(ThemePickerState {
+            data: PickerData::Theme(Box::new(ThemePickerState {
                 search_filter: search_filter.to_string(),
                 all_items: items,
                 before_theme: None,
                 before_theme_id: None,
-            }),
+            })),
         });
     }
 
@@ -1048,11 +1048,11 @@ mod tests {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
         app.picker.picker_session = Some(PickerSession {
             state: picker_state,
-            data: PickerData::Provider(ProviderPickerState {
+            data: PickerData::Provider(Box::new(ProviderPickerState {
                 search_filter: search_filter.to_string(),
                 all_items: items,
                 before_provider: None,
-            }),
+            })),
         });
     }
 


### PR DESCRIPTION
### Motivation

- Large picker state structs inflated the `PickerData` enum size and triggered a clippy enum-size warning, so the largest variants were identified and reduced in-variant footprint. 

### Description

- Change `PickerData::Theme`, `PickerData::Model`, and `PickerData::Provider` to store `Box<...>` instead of the concrete structs to normalize the enum footprint. 
- Update all construction sites and test/helpers to wrap those states with `Box::new(...)` and adjust nearby code to preserve existing access patterns. 
- Keep `Character`, `Persona`, and `Preset` picker states inline because they are small. 
- Remove the `#[allow(clippy::large_enum_variant)]` attribute and add a unit test that asserts the variant footprint is reduced to guard against regressions. 

### Testing

- Ran `cargo fmt` and formatting completed successfully. 
- Ran `cargo check` and the project compiled successfully. 
- Ran `cargo test` and all unit tests passed (`723 passed; 0 failed`). 
- Ran `cargo clippy --all-targets --all-features` with no blocking issues reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ddbd8cd4832baa92afa46a24e971)