### PR TITLE
refactor: gate test-only helper methods

### DIFF
--- a/benches/render_cache.rs
+++ b/benches/render_cache.rs
@@ -38,7 +38,7 @@ fn redraw_no_cache(
     let built = ScrollCalculator::build_display_lines_with_theme_and_flags_and_width(
         messages, theme, markdown, syntax, None,
     );
-    let _pre = ScrollCalculator::prewrap_lines(&built, width);
+    let _pre = ScrollCalculator::prewrap_lines_with_metadata(&built, None, width).0;
 }
 
 fn redraw_with_cache(app: &mut App, width: u16) {

--- a/src/core/app/pickers.rs
+++ b/src/core/app/pickers.rs
@@ -23,7 +23,7 @@ impl App {
         self.picker.session()
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub fn picker_session_mut(&mut self) -> Option<&mut PickerSession> {
         self.picker.session_mut()
     }

--- a/src/ui/osc.rs
+++ b/src/ui/osc.rs
@@ -121,7 +121,7 @@ impl<'a> OscHyperlink<'a> {
         buf.push_str(self.suffix);
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     fn as_encoded_string(&self) -> String {
         let mut out =
             String::with_capacity(self.prefix.len() + self.text.len() + self.suffix.len());

--- a/src/utils/scroll.rs
+++ b/src/utils/scroll.rs
@@ -149,7 +149,7 @@ impl ScrollCalculator {
     /// Pre-wrap the given lines to a specific width, preserving styles and wrapping at word
     /// boundaries consistent with the input wrapper (also breaks long tokens when needed).
     /// This allows rendering without ratatui's built-in wrapping, ensuring counts match output.
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub fn prewrap_lines(lines: &[Line], terminal_width: u16) -> Vec<Line<'static>> {
         Self::prewrap_lines_with_metadata(lines, None, terminal_width).0
     }
@@ -360,7 +360,7 @@ impl ScrollCalculator {
     }
 
     /// Build display lines with selection highlighting and terminal width for table balancing
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub fn build_display_lines_with_theme_and_selection_and_flags_and_width(
         messages: &VecDeque<Message>,
         theme: &Theme,


### PR DESCRIPTION
### Motivation
- Reduce broad `allow(dead_code)` suppressions and make intent explicit by marking helpers that are only used in tests as test-only.
- Preserve production-facing APIs and benchmarks while preventing dead code allowances from hiding unused public helpers in non-test builds.

### Description
- Replaced `#[cfg_attr(not(test), allow(dead_code))]` with `#[cfg(test)]` for the test-only helpers `ScrollCalculator::prewrap_lines`, `ScrollCalculator::build_display_lines_with_theme_and_selection_and_flags_and_width`, `OscHyperlink::as_encoded_string`, and `App::picker_session_mut` in `src/utils/scroll.rs`, `src/ui/osc.rs`, and `src/core/app/pickers.rs`.
- Kept the production `prewrap_lines_with_metadata` API and updated the benchmark in `benches/render_cache.rs` to call `ScrollCalculator::prewrap_lines_with_metadata(...).0` instead of the now-test-only `prewrap_lines` so benches continue to build and exercise a production API.
- Limited the mutable picker session accessor (`picker_session_mut`) to test builds to reduce surface area of test-only helpers.
- Small formatting and build-safe edits only; no behavior changes to production logic or layout engine.

### Testing
- Ran `cargo fmt --all -- --check` and it succeeded.
- Ran `cargo check` and it succeeded.
- Ran `cargo test` and all unit tests passed (`723` tests passed; `0` failed).
- Ran `cargo clippy --all-targets --all-features -- -D warnings` and it succeeded with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994e8fc7aa0832bbf58514af0b1b342)