### PR TITLE
Refactor key event handling contexts and simplify registry API

### DIFF
--- a/src/ui/chat_loop/event_loop.rs
+++ b/src/ui/chat_loop/event_loop.rs
@@ -43,7 +43,10 @@ use super::executors::mcp_tools::{
 };
 use super::executors::model_loader::spawn_model_picker_loader;
 use super::executors::ExecutorContext;
-use super::keybindings::{build_mode_aware_registry, KeyContext, KeyResult, ModeAwareRegistry};
+use super::keybindings::{
+    build_mode_aware_registry, KeyContext, KeyExecutionContext, KeyHandlingContext, KeyResult,
+    ModeAwareRegistry,
+};
 use super::lifecycle::{
     apply_cursor_color_to_terminal, restore_terminal, setup_terminal, SharedTerminal,
 };
@@ -332,13 +335,14 @@ async fn route_keyboard_event(
 
     let registry_result = mode_registry
         .handle_key_event(
-            app,
-            dispatcher,
             &key,
             context,
-            term_size.width,
-            term_size.height,
-            Some(*last_input_layout_update),
+            KeyExecutionContext { app, dispatcher },
+            KeyHandlingContext {
+                term_width: term_size.width,
+                term_height: term_size.height,
+                last_input_layout_update: Some(*last_input_layout_update),
+            },
         )
         .await;
 

--- a/src/ui/chat_loop/keybindings/mod.rs
+++ b/src/ui/chat_loop/keybindings/mod.rs
@@ -8,7 +8,9 @@ pub mod registry;
 
 // Public exports
 pub use handlers::{scroll_block_into_view, wrap_next_index, wrap_previous_index};
-pub use registry::{KeyContext, KeyResult, ModeAwareRegistry};
+pub use registry::{
+    KeyContext, KeyExecutionContext, KeyHandlingContext, KeyResult, ModeAwareRegistry,
+};
 
 /// Action to take in the main event loop
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
### Motivation
- Reduce argument bloat by grouping related parameters used for key handling into small context structs to improve call-site ergonomics and readability.
- Prepare an execution/context separation that makes it easier to evolve handler APIs (for example grouping `app` + `dispatcher` vs terminal/layout details).
- Keep existing dispatch semantics identical so behavioral regressions are avoided (exact-match handlers keep priority over wildcard handlers).

### Description
- Add `KeyExecutionContext` to group `app: &AppHandle` and `dispatcher: &AppActionDispatcher` for handler execution.
- Add `KeyHandlingContext` to group `term_width`, `term_height`, and `last_input_layout_update` for a single key event.
- Replace `ModeAwareRegistry::handle_key_event` parameters to accept `KeyExecutionContext` and `KeyHandlingContext` and remove `#[allow(clippy::too_many_arguments)]` from the method.
- Update the event loop call site to construct and pass the new context structs and re-export the new types from `keybindings::mod`.
- Preserve existing behavior: the registry still tries exact (non-wildcard) patterns first, then wildcard patterns, and `ModeAwareResult.updated_layout_time` semantics remain unchanged.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo check` successfully.
- Ran `cargo test` and all unit tests passed (`723 passed; 0 failed`).
- Ran `cargo clippy --all-targets --all-features -- -D warnings` successfully with no new warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994edb81b38832b9a10796292c7957c)