### PR TITLE
fix(ci): load changelog in publish-release job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -318,6 +318,19 @@ jobs:
     if: needs.check-branch.outputs.should_publish_release == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check out tagged commit
+        env:
+          TAG: ${{ needs.check-branch.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git checkout --quiet "$TAG"
+
       - name: Download packaged artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- Checkout the repository in `publish-release` before generating `dist/RELEASE_NOTES.md`.
- Checkout the selected release tag in that job so changelog extraction runs against the tagged source.

## Why
- The publish step failed because `CHANGELOG.md` was not present in the job workspace (artifact download alone does not include repository files).

## Impact
- Release publishing can now extract notes from `CHANGELOG.md` reliably for tagged releases.
