### PR TITLE
docs(modules): document crate boundaries and responsibilities

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,17 @@
+//! API payload types for chat and model endpoints.
+//!
+//! This module defines serializable request/response structs used across
+//! provider integrations and streaming assembly in [`crate::core::chat_stream`].
+//!
+//! Key responsibilities include:
+//! - chat request envelopes and streamed delta decoding.
+//! - tool call schema types shared with command/tool execution flows.
+//! - model metadata representations used by provider/model selection UIs.
+//!
+//! Ownership boundary: this layer is transport-format focused; connection logic
+//! belongs to provider/client code in [`crate::core`] while presentation lives
+//! in [`crate::ui`].
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,21 @@
+//! Core runtime services and domain state for Chabeau.
+//!
+//! This module owns configuration, provider and preset resolution, persona
+//! behavior, credential surfaces, and stream lifecycle management.
+//!
+//! Key submodules include:
+//! - [`app`]: startup/shutdown orchestration consumed by the binary entrypoint.
+//! - [`chat_stream`]: streaming chat execution and incremental response flow,
+//!   coordinated with [`crate::ui::chat_loop`] and [`crate::commands`].
+//! - [`config`], [`providers`], and [`preset`]: model/provider settings and
+//!   runtime defaults.
+//! - [`mcp_auth`] and [`mcp_sampling`]: MCP-specific auth and sampling bridges.
+//! - [`text_wrapping`] and [`message`]: shared message/text shaping utilities
+//!   used by both core flows and UI rendering.
+//!
+//! Ownership boundary: this layer contains application logic and state
+//! transitions, while [`crate::ui`] handles presentation and interaction.
+
 pub mod app;
 pub mod builtin_mcp;
 pub mod builtin_oauth;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,20 @@
+//! Chabeau is a terminal-first chatbot client for working with remote LLM APIs.
+//!
+//! The crate is organized around a small set of collaborating layers:
+//! - [`core`] owns runtime state, provider/model selection, presets, persona
+//!   handling, and streaming orchestration.
+//! - [`ui`] renders the terminal interface and runs the interactive event loop
+//!   that drives user input and display updates.
+//! - [`commands`] implements slash-command parsing and command execution used
+//!   by the chat loop.
+//! - [`mcp`] provides Model Context Protocol integration, including transport,
+//!   tool registration, and permission surfaces.
+//! - [`api`] defines chat/model payloads used by API clients and provider code.
+//!
+//! Runtime entrypoints live in the binary crate (`src/main.rs`) and route
+//! through [`crate::cli::main`], which initializes and dispatches into
+//! [`core::app`] and [`ui::chat_loop`] for interactive sessions.
+
 pub mod api;
 pub mod auth;
 pub mod character;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,3 +1,19 @@
+//! Model Context Protocol (MCP) integration surfaces.
+//!
+//! This module encapsulates client-side MCP connectivity, server registry
+//! coordination, event ingestion, and policy checks for tool access.
+//!
+//! Key submodules include:
+//! - [`client`]: MCP client orchestration and request execution.
+//! - [`transport`]: transport/session wiring for MCP traffic.
+//! - [`registry`]: available server/tool metadata management.
+//! - [`events`] and [`permissions`]: runtime event propagation and permission
+//!   decisions consumed by chat flows.
+//!
+//! Ownership boundary: MCP protocol concerns live here; higher-level flow
+//! control remains in [`crate::core::chat_stream`] and interaction stays in
+//! [`crate::ui::chat_loop`].
+
 pub mod client;
 pub mod events;
 pub mod permissions;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,18 @@
+//! Terminal UI layer for interactive chat sessions.
+//!
+//! The UI module owns rendering, layout, keyboard handling, and loop control
+//! for the text user interface.
+//!
+//! Key submodules include:
+//! - [`chat_loop`]: the main interaction loop that dispatches user input to
+//!   [`crate::commands`] and coordinates streaming via [`crate::core::chat_stream`].
+//! - [`renderer`], [`layout`], and [`span`]: view composition and frame output.
+//! - [`theme`], [`appearance`], and [`builtin_themes`]: color/style policy.
+//! - [`picker`] and [`help`]: selection and discoverability UI affordances.
+//!
+//! Ownership boundary: this layer presents and captures interaction state, while
+//! [`crate::core`] owns domain logic and backend coordination.
+
 pub mod appearance;
 pub mod builtin_themes;
 pub mod chat_loop;


### PR DESCRIPTION
## Summary
This PR adds crate/module-level Rustdoc overviews for the main layers of Chabeau:
`api`, `core`, `mcp`, `ui`, and the crate root.

The docs clarify each module’s responsibility, ownership boundary, and how key
flows connect (chat streaming, commands, MCP integration, and UI loop).

## Why
The architecture is spread across several top-level modules. Adding explicit
module overviews makes navigation and onboarding faster, and reduces ambiguity
about where new logic should live.

## Impact
- No runtime behavior changes.
- No API/interface changes.
- Documentation-only improvement to developer ergonomics.
