### PR TITLE
fix: harden OAuth endpoint URL handling

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,7 +32,8 @@ use crate::core::mcp_auth::{McpOAuthGrant, McpTokenStore};
 use crate::core::oauth::{
     apply_oauth_token_response, build_authorization_url, current_unix_epoch_s, exchange_oauth_code,
     open_in_browser, pkce_s256_challenge, probe_oauth_support, random_urlsafe,
-    register_oauth_client, wait_for_oauth_callback, AuthorizationUrlParams, OAuthMetadata,
+    register_oauth_client, validate_oauth_endpoint_url, wait_for_oauth_callback,
+    AuthorizationUrlParams, OAuthMetadata,
 };
 use crate::core::persona::PersonaManager;
 use crate::ui::chat_loop::run_chat;
@@ -1510,10 +1511,20 @@ async fn add_oauth_grant_for_server(
     };
 
     if let Some(authorization_endpoint) = metadata.authorization_endpoint.as_deref() {
+        validate_oauth_endpoint_url("authorization_endpoint", authorization_endpoint)?;
         let token_endpoint = metadata
             .token_endpoint
             .as_deref()
             .ok_or("OAuth metadata is missing token_endpoint.")?;
+        validate_oauth_endpoint_url("token_endpoint", token_endpoint)?;
+
+        let mut revocation_endpoint = metadata.revocation_endpoint.clone();
+        sanitize_optional_oauth_endpoint(
+            "revocation_endpoint",
+            &mut revocation_endpoint,
+            "Skipping token revocation metadata for this grant.",
+        );
+
         let mut client_id = if advanced {
             let client_id_input = prompt_optional("OAuth client id (optional): ")?;
             if client_id_input.is_empty() {
@@ -1528,12 +1539,19 @@ async fn add_oauth_grant_for_server(
             None
         };
 
+        let mut registration_endpoint = metadata.registration_endpoint.clone();
+        sanitize_optional_oauth_endpoint(
+            "registration_endpoint",
+            &mut registration_endpoint,
+            "Ignoring registration endpoint and continuing without automatic client registration.",
+        );
+
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
         let port = listener.local_addr()?.port();
         let redirect_uri = format!("http://127.0.0.1:{port}/oauth/callback");
 
         if client_id.is_none() {
-            if let Some(registration_endpoint) = metadata.registration_endpoint.as_deref() {
+            if let Some(registration_endpoint) = registration_endpoint.as_deref() {
                 match register_oauth_client(registration_endpoint, &redirect_uri).await {
                     Ok(registered_id) => {
                         println!("Registered OAuth client automatically.");
@@ -1610,7 +1628,7 @@ async fn add_oauth_grant_for_server(
             redirect_uri: Some(redirect_uri),
             authorization_endpoint: metadata.authorization_endpoint.clone(),
             token_endpoint: metadata.token_endpoint.clone(),
-            revocation_endpoint: metadata.revocation_endpoint.clone(),
+            revocation_endpoint,
             issuer: metadata.issuer.clone(),
         };
         let grant = apply_oauth_token_response(&grant_seed, token, now_epoch_s);
@@ -1634,24 +1652,28 @@ async fn remove_oauth_grant_for_server(server: &McpServerConfig) -> Result<(), B
     };
 
     if let Some(revocation_endpoint) = grant.revocation_endpoint.as_deref() {
-        let client = reqwest::Client::new();
-        match client
-            .post(revocation_endpoint)
-            .form(&[("token", grant.access_token.as_str())])
-            .send()
-            .await
-        {
-            Ok(response) if response.status().is_success() => {
-                println!("OAuth token revoked at server endpoint.");
-            }
-            Ok(response) => {
-                eprintln!(
-                    "⚠️ OAuth revocation returned HTTP {}. Removing local grant anyway.",
-                    response.status()
-                );
-            }
-            Err(err) => {
-                eprintln!("⚠️ OAuth revocation failed ({err}). Removing local grant anyway.");
+        if let Err(err) = validate_oauth_endpoint_url("revocation_endpoint", revocation_endpoint) {
+            eprintln!("⚠️ {err} Removing local grant only.");
+        } else {
+            let client = reqwest::Client::new();
+            match client
+                .post(revocation_endpoint)
+                .form(&[("token", grant.access_token.as_str())])
+                .send()
+                .await
+            {
+                Ok(response) if response.status().is_success() => {
+                    println!("OAuth token revoked at server endpoint.");
+                }
+                Ok(response) => {
+                    eprintln!(
+                        "⚠️ OAuth revocation returned HTTP {}. Removing local grant anyway.",
+                        response.status()
+                    );
+                }
+                Err(err) => {
+                    eprintln!("⚠️ OAuth revocation failed ({err}). Removing local grant anyway.");
+                }
             }
         }
     } else {
@@ -1928,6 +1950,19 @@ fn format_key_value_pairs(pairs: &std::collections::HashMap<String, String>) -> 
         .collect();
     formatted.sort();
     formatted.join(",")
+}
+
+fn sanitize_optional_oauth_endpoint(
+    endpoint_name: &str,
+    endpoint: &mut Option<String>,
+    invalid_endpoint_message: &str,
+) {
+    if let Some(endpoint_value) = endpoint.as_deref() {
+        if let Err(err) = validate_oauth_endpoint_url(endpoint_name, endpoint_value) {
+            eprintln!("⚠️ {err} {invalid_endpoint_message}");
+            *endpoint = None;
+        }
+    }
 }
 
 fn resolve_mcp_server<'a>(

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -258,6 +258,48 @@ fn test_parse_key_value_pairs_accepts_headers() {
 }
 
 #[test]
+fn test_sanitize_optional_oauth_endpoint_drops_invalid_registration_endpoint() {
+    let mut registration_endpoint = Some("http://auth.example.com/register".to_string());
+
+    sanitize_optional_oauth_endpoint(
+        "registration_endpoint",
+        &mut registration_endpoint,
+        "Ignoring registration endpoint and continuing without automatic client registration.",
+    );
+
+    assert!(registration_endpoint.is_none());
+}
+
+#[test]
+fn test_sanitize_optional_oauth_endpoint_keeps_loopback_http_registration_endpoint() {
+    let mut registration_endpoint = Some("http://127.0.0.1:8080/register".to_string());
+
+    sanitize_optional_oauth_endpoint(
+        "registration_endpoint",
+        &mut registration_endpoint,
+        "Ignoring registration endpoint and continuing without automatic client registration.",
+    );
+
+    assert_eq!(
+        registration_endpoint.as_deref(),
+        Some("http://127.0.0.1:8080/register")
+    );
+}
+
+#[test]
+fn test_sanitize_optional_oauth_endpoint_keeps_absent_endpoint() {
+    let mut revocation_endpoint = None;
+
+    sanitize_optional_oauth_endpoint(
+        "revocation_endpoint",
+        &mut revocation_endpoint,
+        "Skipping token revocation metadata for this grant.",
+    );
+
+    assert!(revocation_endpoint.is_none());
+}
+
+#[test]
 fn test_parse_key_value_pairs_rejects_invalid_entry() {
     let err = parse_key_value_pairs("A", "header entry", "Header name")
         .expect_err("invalid pair should fail");

--- a/src/core/oauth.rs
+++ b/src/core/oauth.rs
@@ -100,6 +100,58 @@ pub fn apply_oauth_token_response(
     }
 }
 
+fn is_local_oauth_host(host: &str) -> bool {
+    let normalized = host.trim_matches(['[', ']']);
+    if normalized.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    normalized
+        .parse::<std::net::IpAddr>()
+        .map(|address| address.is_loopback())
+        .unwrap_or(false)
+}
+
+pub fn validate_oauth_endpoint_url(endpoint_name: &str, url: &str) -> Result<(), Box<dyn Error>> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|err| format!("Invalid {endpoint_name} URL '{url}': {err}"))?;
+    match parsed.scheme() {
+        "https" => Ok(()),
+        "http" => {
+            let host = parsed
+                .host_str()
+                .ok_or_else(|| format!("Invalid {endpoint_name} URL '{url}': missing host"))?;
+            if is_local_oauth_host(host) {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Invalid {endpoint_name} URL '{url}': HTTP is only allowed for loopback hosts (localhost, 127.0.0.0/8, [::1])."
+                )
+                .into())
+            }
+        }
+        scheme => Err(format!(
+            "Invalid {endpoint_name} URL '{url}': unsupported scheme '{scheme}'."
+        )
+        .into()),
+    }
+}
+
+pub fn validate_oauth_metadata_endpoints(metadata: &OAuthMetadata) -> Result<(), Box<dyn Error>> {
+    if let Some(authorization_endpoint) = metadata.authorization_endpoint.as_deref() {
+        validate_oauth_endpoint_url("authorization_endpoint", authorization_endpoint)?;
+    }
+    if let Some(token_endpoint) = metadata.token_endpoint.as_deref() {
+        validate_oauth_endpoint_url("token_endpoint", token_endpoint)?;
+    }
+    if let Some(revocation_endpoint) = metadata.revocation_endpoint.as_deref() {
+        validate_oauth_endpoint_url("revocation_endpoint", revocation_endpoint)?;
+    }
+    if let Some(registration_endpoint) = metadata.registration_endpoint.as_deref() {
+        validate_oauth_endpoint_url("registration_endpoint", registration_endpoint)?;
+    }
+    Ok(())
+}
+
 async fn refresh_oauth_access_token(
     token_endpoint: &str,
     refresh_token: &str,
@@ -156,6 +208,7 @@ pub async fn refresh_oauth_grant_if_needed(
         .token_endpoint
         .as_deref()
         .ok_or("OAuth grant is missing token endpoint; re-auth required.")?;
+    validate_oauth_endpoint_url("token_endpoint", token_endpoint)?;
 
     let token =
         refresh_oauth_access_token(token_endpoint, &refresh_token, grant.client_id.as_deref())
@@ -718,5 +771,98 @@ mod tests {
         assert_eq!(token.access_token, "new-token");
         assert_eq!(token.refresh_token.as_deref(), Some("new-refresh"));
         assert_eq!(token.expires_in, Some(120));
+    }
+
+    #[test]
+    fn test_validate_oauth_endpoint_url_accepts_https() {
+        assert!(validate_oauth_endpoint_url(
+            "authorization_endpoint",
+            "https://auth.example.com/authorize"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_oauth_endpoint_url_rejects_non_https_non_loopback_http() {
+        let err = validate_oauth_endpoint_url("token_endpoint", "http://auth.example.com/token")
+            .expect_err("non-loopback HTTP endpoint should be rejected");
+        assert!(err
+            .to_string()
+            .contains("token_endpoint URL 'http://auth.example.com/token'"));
+    }
+
+    #[test]
+    fn test_validate_oauth_endpoint_url_accepts_loopback_http_hosts() {
+        assert!(validate_oauth_endpoint_url(
+            "authorization_endpoint",
+            "http://127.0.0.1:8080/authorize"
+        )
+        .is_ok());
+        assert!(validate_oauth_endpoint_url(
+            "authorization_endpoint",
+            "http://127.1.2.3:8080/authorize"
+        )
+        .is_ok());
+        assert!(validate_oauth_endpoint_url(
+            "authorization_endpoint",
+            "http://localhost:8080/authorize"
+        )
+        .is_ok());
+        assert!(validate_oauth_endpoint_url(
+            "authorization_endpoint",
+            "http://[::1]:8080/authorize"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_oauth_endpoint_url_rejects_malformed_url() {
+        let err = validate_oauth_endpoint_url("token_endpoint", "not a url")
+            .expect_err("malformed URL should be rejected");
+        assert!(err
+            .to_string()
+            .contains("Invalid token_endpoint URL 'not a url'"));
+    }
+
+    #[test]
+    fn test_validate_oauth_endpoint_url_accepts_case_insensitive_localhost() {
+        assert!(validate_oauth_endpoint_url(
+            "authorization_endpoint",
+            "http://LOCALHOST:8080/authorize"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_oauth_metadata_endpoints_accepts_loopback_http_optional_endpoints() {
+        let metadata = OAuthMetadata {
+            authorization_endpoint: Some("https://auth.example.com/authorize".to_string()),
+            token_endpoint: Some("https://auth.example.com/token".to_string()),
+            revocation_endpoint: Some("http://127.0.0.1:8080/revoke".to_string()),
+            issuer: None,
+            registration_endpoint: Some("http://localhost:7777/register".to_string()),
+            scopes_supported: None,
+            authorization_servers: None,
+        };
+
+        validate_oauth_metadata_endpoints(&metadata)
+            .expect("loopback HTTP optional endpoints should be accepted");
+    }
+
+    #[test]
+    fn test_validate_oauth_metadata_endpoints_reports_offending_endpoint() {
+        let metadata = OAuthMetadata {
+            authorization_endpoint: Some("https://auth.example.com/authorize".to_string()),
+            token_endpoint: Some("https://auth.example.com/token".to_string()),
+            revocation_endpoint: Some("ftp://auth.example.com/revoke".to_string()),
+            issuer: None,
+            registration_endpoint: Some("https://auth.example.com/register".to_string()),
+            scopes_supported: None,
+            authorization_servers: None,
+        };
+
+        let err = validate_oauth_metadata_endpoints(&metadata)
+            .expect_err("unsupported revocation endpoint scheme should fail");
+        assert!(err.to_string().contains("revocation_endpoint URL"));
     }
 }


### PR DESCRIPTION
## Summary
This hardens MCP OAuth endpoint handling so Chabeau only uses secure
remote OAuth endpoints and treats invalid optional endpoints as
non-fatal metadata instead of blindly trusting them.

## What Changed
- Validate OAuth authorization and token endpoints before starting an
  OAuth flow.
- Allow `http://` only for loopback hosts such as `localhost`,
  `127.0.0.1`, and `::1`, while requiring HTTPS for non-local OAuth
  endpoints.
- Sanitize optional revocation and dynamic registration endpoints so
  invalid values are ignored instead of being stored or called later.
- Re-check stored token and revocation endpoints before refresh and
  revoke operations.
- Expand tests around malformed URLs, loopback handling, and optional
  endpoint sanitization.

## Why
OAuth metadata can contain endpoints that are malformed or use
insecure schemes. The previous behavior could carry those values into
registration, refresh, or revocation paths. This change enforces a
clear trust boundary while preserving localhost callback workflows that
are common during OAuth flows.

## Impact
- Remote OAuth endpoints now need to use HTTPS.
- Local loopback HTTP endpoints remain supported for developer and
  callback scenarios.
- Invalid optional metadata degrades gracefully instead of causing
  unsafe follow-up requests.
