### PR TITLE
Allow session persistence with save/load commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,6 +39,12 @@ builds `App`, and chooses whether to launch provider/model pickers based on the
 current config state. If `--session <id>` is provided, setup restores the saved
 session after the app is built.
 
+Saved-session restore uses the snapshot for transcript-facing context
+(provider, model, base URL, tools, character/persona/preset, and UI settings)
+but resolves credentials at load time. If the saved provider cannot be restored,
+the session still loads and continues with the current startup provider while
+showing a status warning.
+
 ## Core application state
 The central runtime object is `App` (`src/core/app/mod.rs`), with session details
 kept in `SessionContext` (`src/core/app/session.rs`).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,7 +36,8 @@ Shared prompt/input behavior for CLI setup flows lives in
 Interactive chat setup is handled by `src/ui/chat_loop/setup.rs`.
 `bootstrap_app(...)` loads configuration, resolves auth through `AuthManager`,
 builds `App`, and chooses whether to launch provider/model pickers based on the
-current config state.
+current config state. If `--session <id>` is provided, setup restores the saved
+session after the app is built.
 
 ## Core application state
 The central runtime object is `App` (`src/core/app/mod.rs`), with session details
@@ -45,10 +46,11 @@ kept in `SessionContext` (`src/core/app/session.rs`).
 Notable state domains:
 
 - Conversation/history and UI mode/input focus.
-- Picker state (model/theme/provider/character/persona/preset/MCP prompt).
+- Picker state (model/theme/provider/character/persona/preset/saved session).
 - Streaming lifecycle and pending tool calls.
 - MCP manager, server enablement, and per-tool approval memory.
 - Tool inspection overlay state (`src/core/app/inspect.rs`).
+- Saved chat session snapshots in `src/core/session_store.rs`.
 
 ## MCP configuration and authentication
 MCP server configuration is defined in `src/core/config/data.rs`
@@ -103,6 +105,10 @@ Slash command routing is defined in `src/commands/mod.rs` with MCP handlers
 under `src/commands/handlers/mcp.rs` and prompt parsing in
 `src/commands/mcp_prompt_parser.rs`.
 
+Session commands live in `src/commands/handlers/session.rs`: `/save` writes the
+current `App` state through `session_store`, while `/load` and `/sessions` open
+the saved-session picker or restore by ID.
+
 The chat loop schedules MCP refresh/call work via executor helpers in
 `src/ui/chat_loop/executors/` (`mcp_init.rs`, `mcp_tools.rs`).
 
@@ -135,8 +141,9 @@ Key modules and responsibilities:
 - `src/core/app/conversation.rs` — owns transcript/session mutation logic through
   `ConversationController` (message append/finalize, retry/refine lifecycle,
   status updates, stream token setup).
-- `src/core/app/picker/mod.rs` — owns picker session data for model/provider/
-  theme/character/persona/preset flows and inspect metadata backing.
+- `src/core/app/picker/mod.rs` — owns `ActivePicker` data for model/provider/
+  theme/character/persona/preset/saved-session flows and inspect metadata
+  backing.
 - `src/core/app/actions/mod.rs` — root action and command contracts, plus
   top-level reducer fan-out (`apply_action`, `apply_actions`).
 - `src/core/app/actions/streaming.rs` — stream-side reducer entrypoint for

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Chabeau is a full-screen terminal chat interface that connects to various AI API
   - [Authenticate](#authenticate)
   - [Launch](#launch)
 - [Working with Providers and Models](#working-with-providers-and-models)
+- [Session Management](#session-management)
 - [Configuration](#configuration)
 - [MCP Servers](#mcp-servers)
 - [Character Cards](#character-cards)
@@ -61,6 +62,7 @@ The MCP server shown in the videos above is "[MCP Research Friend](https://githu
 - On-demand refinements of the last assistant response with `/refine <prompt>`
 - Slash command registry with inline help for faster command discovery
 - Conversation logging with pause/resume; quick `/dump` of contents to a file
+- Saved chat sessions with `/save`, `/load`, `/sessions`, and startup restore
 - Syntax highlighting for fenced code blocks (Python, Bash, JavaScript, and more)
 - Inline block selection (Ctrl+B) to copy or save fenced code blocks
 - User message selection (Ctrl+P) to revisit and copy prior prompts
@@ -141,6 +143,7 @@ chabeau                              # Start chat with defaults (pickers on dema
 chabeau --provider openai            # Use specific provider
 chabeau --model gpt-5                # Use specific model
 chabeau --log conversation.log       # Enable logging immediately on startup
+chabeau --session <session-id>       # Restore a saved chat session
 ```
 
 Discover available options:
@@ -193,6 +196,17 @@ When stdout is redirected to a file or piped into another program, Chabeau autom
 If you have multiple providers configured but no default set, Chabeau will prompt you to specify a provider with the `-p` flag. The `-p` and other global flags can be placed before or after the prompt.
 
 Environment variable values can make their way into shell histories or other places they shouldn't, so using the keyring is generally advisable.
+
+## Session Management
+
+Use `/save [name]` to persist the current conversation. Use `/load` or
+`/sessions` to browse saved sessions in a picker, or `/load <session-id>` to
+restore one directly.
+
+Saved sessions are JSON files under Chabeau's data directory, such as
+`~/.local/share/chabeau/sessions/` on Linux. They include transcript and session
+context, but not API keys. Start from a saved session with
+`chabeau --session <session-id>`.
 
 ## Configuration
 
@@ -536,7 +550,7 @@ Chabeau uses a modular design with focused components:
   - `settings/` – Trait-based `set`/`unset` handler registry
   - `theme_list.rs` – Theme listing functionality
 - `commands/` – Chat command processing and registry-driven dispatch
-  - `handlers/` – Domain-specific command handlers (`core`, `config`, `io`, `mcp`)
+  - `handlers/` – Domain-specific command handlers (`core`, `config`, `io`, `mcp`, `session`)
   - `mcp_prompt_parser.rs` – `/server-id:prompt-id` parser and helpers
   - `mod.rs` – Command dispatcher and command result plumbing
   - `refine.rs` – Message refinement logic
@@ -585,6 +599,7 @@ Chabeau uses a modular design with focused components:
   - `persona.rs` – Persona management and variable substitution
   - `preset.rs` – System instruction preset management
   - `providers.rs` – Provider selection and shared provider utilities
+  - `session_store.rs` – Saved chat session JSON persistence
   - `shared_selection.rs` – Shared current-selection helpers
   - `text_wrapping.rs` – Text wrapping utilities
 - `mcp/` – Model Context Protocol client integration

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,7 +15,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ChatMessage {
     pub role: String,
     pub content: String,
@@ -76,7 +76,7 @@ pub struct ChatToolCallDelta {
     pub function: Option<ChatToolCallFunctionDelta>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ChatToolCall {
     pub id: String,
     #[serde(rename = "type")]
@@ -84,7 +84,7 @@ pub struct ChatToolCall {
     pub function: ChatToolCallFunction,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ChatToolCallFunction {
     pub name: String,
     pub arguments: String,

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -676,6 +676,40 @@ fn get_cached_entry(provider_name: &str) -> Option<KeyringCacheEntry> {
 static TOKEN_CACHE: LazyLock<Mutex<HashMap<String, KeyringCacheEntry>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+#[cfg(test)]
+pub(crate) fn set_test_token(provider_name: &str, token: &str) {
+    let mut cache = TOKEN_CACHE
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    cache.insert(
+        provider_name.to_string(),
+        KeyringCacheEntry::Present(token.to_string()),
+    );
+}
+
+#[cfg(test)]
+pub(crate) fn clear_test_tokens() {
+    let mut cache = TOKEN_CACHE
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    cache.clear();
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_recoverable_keyring_error(provider_name: &str) {
+    let backend_error = std::io::Error::other("mock backend unavailable");
+    let keyring_error = keyring::Error::NoStorageAccess(Box::new(backend_error));
+    let mut cache = TOKEN_CACHE
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    cache.insert(
+        provider_name.to_string(),
+        KeyringCacheEntry::Error(SharedKeyringAccessError::new(KeyringAccessError::from(
+            keyring_error,
+        ))),
+    );
+}
+
 impl ProviderAuthSource for AuthManager {
     fn uses_keyring(&self) -> bool {
         self.use_keyring

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -179,6 +179,10 @@ pub struct Args {
     /// Disable MCP even if configured
     #[arg(short = 'd', long = "disable-mcp", action = clap::ArgAction::SetTrue)]
     pub disable_mcp: bool,
+
+    /// Session ID to load on startup
+    #[arg(short = 's', long, value_name = "SESSION")]
+    pub session: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -629,6 +633,7 @@ async fn handle_args(args: Args) -> Result<(), Box<dyn Error>> {
                                 character_service: service_for_run
                                     .take()
                                     .expect("character service available for run_chat"),
+                                session: args.session.clone(),
                             })
                             .await
                         }
@@ -646,6 +651,7 @@ async fn handle_args(args: Args) -> Result<(), Box<dyn Error>> {
                                 character_service: service_for_run
                                     .take()
                                     .expect("character service available for run_chat"),
+                                session: args.session.clone(),
                             })
                             .await
                         }

--- a/src/commands/handlers/mod.rs
+++ b/src/commands/handlers/mod.rs
@@ -2,6 +2,7 @@ pub(super) mod config;
 pub(super) mod core;
 pub(super) mod io;
 pub(super) mod mcp;
+pub(crate) mod session;
 
 use crate::commands::CommandResult;
 use crate::core::app::App;

--- a/src/commands/handlers/session.rs
+++ b/src/commands/handlers/session.rs
@@ -2,9 +2,7 @@ use super::usage_status;
 use crate::commands::registry::CommandInvocation;
 use crate::commands::CommandResult;
 use crate::core::app::App;
-use crate::core::session_store::{
-    list_sessions, save_session, SessionError, SessionSummary,
-};
+use crate::core::session_store::{list_sessions, save_session, SessionSummary};
 use crate::ui::picker::PickerItem;
 
 const USAGE_SAVE: &str = "Usage: /save [name]";
@@ -12,26 +10,22 @@ const USAGE_LOAD: &str = "Usage: /load [session-id]";
 
 pub(crate) fn handle_save(app: &mut App, invocation: CommandInvocation<'_>) -> CommandResult {
     let name = match invocation.args_len() {
-        0 => {
-            let name = generate_session_name(&app.ui.messages);
-            name
-        }
+        0 => generate_session_name(&app.ui.messages),
         1 => invocation.arg(0).unwrap_or("Untitled").to_string(),
         _ => return usage_status(app, USAGE_SAVE),
     };
 
-    let result = do_save_session(
+    let messages = app.ui.messages.iter().cloned().collect::<Vec<_>>();
+    let result = save_session(
         &app.session.session_id,
         &name,
         &app.session.provider_name,
         &app.session.model,
         &app.session.base_url,
         app.session.get_character().cloned(),
-        app.persona_manager
-            .get_active_persona()
-            .cloned(),
+        app.persona_manager.get_active_persona().cloned(),
         app.preset_manager.get_active_preset().cloned(),
-        &app.ui.messages,
+        &messages,
         &app.session.tool_pipeline.tool_results,
         &app.session.tool_pipeline.tool_payload_history,
         &app.session.mcp_init,
@@ -123,44 +117,6 @@ fn generate_session_name(
     "Untitled session".to_string()
 }
 
-fn do_save_session(
-    session_id: &str,
-    name: &str,
-    provider: &str,
-    model: &str,
-    base_url: &str,
-    character: Option<crate::character::card::CharacterCard>,
-    persona: Option<crate::core::config::data::Persona>,
-    preset: Option<crate::core::config::data::Preset>,
-    messages: &std::collections::VecDeque<crate::core::message::Message>,
-    tool_results: &[crate::api::ChatMessage],
-    tool_payloads: &[crate::core::app::session::ToolPayloadHistoryEntry],
-    mcp_init: &crate::core::app::session::McpInitState,
-    refine_instructions: &str,
-    refine_prefix: &str,
-    markdown_enabled: bool,
-    syntax_enabled: bool,
-) -> Result<(), SessionError> {
-    save_session(
-        session_id,
-        name,
-        provider,
-        model,
-        base_url,
-        character,
-        persona,
-        preset,
-        messages.iter().cloned().collect::<Vec<_>>().as_slice(),
-        tool_results,
-        tool_payloads,
-        mcp_init,
-        refine_instructions,
-        refine_prefix,
-        markdown_enabled,
-        syntax_enabled,
-    )
-}
-
 pub fn do_load_session(app: &mut App, id: &str) -> Result<(), String> {
     let snapshot = crate::core::session_store::load_session(id).map_err(|e| e.to_string())?;
 
@@ -239,13 +195,5 @@ fn show_session_picker(app: &mut App, sessions: Vec<SessionSummary>) {
         })
         .collect();
 
-    app.picker.start_picker(
-        crate::core::app::picker::SessionPickerState {
-            sessions,
-            selected_index: 0,
-            search_filter: String::new(),
-            all_items: items.clone(),
-        },
-        items,
-    );
+    app.picker.open_session_picker(sessions, items);
 }

--- a/src/commands/handlers/session.rs
+++ b/src/commands/handlers/session.rs
@@ -195,5 +195,5 @@ fn show_session_picker(app: &mut App, sessions: Vec<SessionSummary>) {
         })
         .collect();
 
-    app.picker.open_session_picker(sessions, items);
+    app.picker.open_saved_session_picker(sessions, items);
 }

--- a/src/commands/handlers/session.rs
+++ b/src/commands/handlers/session.rs
@@ -1,0 +1,251 @@
+use super::usage_status;
+use crate::commands::registry::CommandInvocation;
+use crate::commands::CommandResult;
+use crate::core::app::App;
+use crate::core::session_store::{
+    list_sessions, save_session, SessionError, SessionSummary,
+};
+use crate::ui::picker::PickerItem;
+
+const USAGE_SAVE: &str = "Usage: /save [name]";
+const USAGE_LOAD: &str = "Usage: /load [session-id]";
+
+pub(crate) fn handle_save(app: &mut App, invocation: CommandInvocation<'_>) -> CommandResult {
+    let name = match invocation.args_len() {
+        0 => {
+            let name = generate_session_name(&app.ui.messages);
+            name
+        }
+        1 => invocation.arg(0).unwrap_or("Untitled").to_string(),
+        _ => return usage_status(app, USAGE_SAVE),
+    };
+
+    let result = do_save_session(
+        &app.session.session_id,
+        &name,
+        &app.session.provider_name,
+        &app.session.model,
+        &app.session.base_url,
+        app.session.get_character().cloned(),
+        app.persona_manager
+            .get_active_persona()
+            .cloned(),
+        app.preset_manager.get_active_preset().cloned(),
+        &app.ui.messages,
+        &app.session.tool_pipeline.tool_results,
+        &app.session.tool_pipeline.tool_payload_history,
+        &app.session.mcp_init,
+        &app.session.refine_instructions,
+        &app.session.refine_prefix,
+        app.ui.markdown_enabled,
+        app.ui.syntax_enabled,
+    );
+
+    match result {
+        Ok(()) => {
+            let session_id = app.session.session_id.clone();
+            app.conversation()
+                .set_status(format!("Session saved: {} ({})", name, session_id));
+            CommandResult::ContinueWithTranscriptFocus
+        }
+        Err(e) => {
+            app.conversation().set_status(format!("Save error: {}", e));
+            CommandResult::ContinueWithTranscriptFocus
+        }
+    }
+}
+
+pub(crate) fn handle_load(app: &mut App, invocation: CommandInvocation<'_>) -> CommandResult {
+    match invocation.args_len() {
+        0 => match list_sessions() {
+            Ok(sessions) => {
+                if sessions.is_empty() {
+                    app.conversation().set_status("No saved sessions found.");
+                    return CommandResult::ContinueWithTranscriptFocus;
+                }
+                show_session_picker(app, sessions);
+                CommandResult::Continue
+            }
+            Err(e) => {
+                app.conversation()
+                    .set_status(format!("Session list error: {}", e));
+                CommandResult::ContinueWithTranscriptFocus
+            }
+        },
+        1 => {
+            let Some(id) = invocation.arg(0) else {
+                return usage_status(app, USAGE_LOAD);
+            };
+            match do_load_session(app, id) {
+                Ok(()) => CommandResult::ContinueWithTranscriptFocus,
+                Err(e) => {
+                    app.conversation().set_status(format!("Load error: {}", e));
+                    CommandResult::ContinueWithTranscriptFocus
+                }
+            }
+        }
+        _ => usage_status(app, USAGE_LOAD),
+    }
+}
+
+pub(crate) fn handle_sessions(app: &mut App, _invocation: CommandInvocation<'_>) -> CommandResult {
+    match list_sessions() {
+        Ok(sessions) => {
+            if sessions.is_empty() {
+                app.conversation().set_status("No saved sessions found.");
+                return CommandResult::ContinueWithTranscriptFocus;
+            }
+            show_session_picker(app, sessions);
+            CommandResult::Continue
+        }
+        Err(e) => {
+            app.conversation()
+                .set_status(format!("Session list error: {}", e));
+            CommandResult::ContinueWithTranscriptFocus
+        }
+    }
+}
+
+fn generate_session_name(
+    messages: &std::collections::VecDeque<crate::core::message::Message>,
+) -> String {
+    for msg in messages {
+        if msg.is_user() && !msg.content.is_empty() {
+            let first_line = msg.content.lines().next().unwrap_or("");
+            let truncated = if first_line.chars().count() > 50 {
+                first_line.chars().take(47).collect::<String>() + "..."
+            } else {
+                first_line.to_string()
+            };
+            return truncated;
+        }
+    }
+    "Untitled session".to_string()
+}
+
+fn do_save_session(
+    session_id: &str,
+    name: &str,
+    provider: &str,
+    model: &str,
+    base_url: &str,
+    character: Option<crate::character::card::CharacterCard>,
+    persona: Option<crate::core::config::data::Persona>,
+    preset: Option<crate::core::config::data::Preset>,
+    messages: &std::collections::VecDeque<crate::core::message::Message>,
+    tool_results: &[crate::api::ChatMessage],
+    tool_payloads: &[crate::core::app::session::ToolPayloadHistoryEntry],
+    mcp_init: &crate::core::app::session::McpInitState,
+    refine_instructions: &str,
+    refine_prefix: &str,
+    markdown_enabled: bool,
+    syntax_enabled: bool,
+) -> Result<(), SessionError> {
+    save_session(
+        session_id,
+        name,
+        provider,
+        model,
+        base_url,
+        character,
+        persona,
+        preset,
+        messages.iter().cloned().collect::<Vec<_>>().as_slice(),
+        tool_results,
+        tool_payloads,
+        mcp_init,
+        refine_instructions,
+        refine_prefix,
+        markdown_enabled,
+        syntax_enabled,
+    )
+}
+
+pub fn do_load_session(app: &mut App, id: &str) -> Result<(), String> {
+    let snapshot = crate::core::session_store::load_session(id).map_err(|e| e.to_string())?;
+
+    app.session.session_id = snapshot.id.clone();
+    app.ui.messages = snapshot.messages.into_iter().collect();
+    app.ui.invalidate_prewrap_cache();
+
+    app.session.tool_pipeline.tool_results = snapshot.tool_results;
+    app.session.tool_pipeline.tool_payload_history = snapshot
+        .tool_payloads
+        .into_iter()
+        .map(|tp| crate::core::app::session::ToolPayloadHistoryEntry {
+            server_id: tp.server_id,
+            tool_call_id: tp.tool_call_id,
+            assistant_message: tp.assistant_message,
+            tool_message: tp.tool_message,
+            assistant_message_index: tp.assistant_message_index,
+        })
+        .collect();
+
+    app.session.mcp_init = crate::core::app::session::McpInitState {
+        in_progress: false,
+        complete: snapshot.mcp_init_complete,
+        deferred_message: None,
+    };
+
+    app.session.refine_instructions = snapshot.refine_instructions;
+    app.session.refine_prefix = snapshot.refine_prefix;
+
+    app.ui.markdown_enabled = snapshot.markdown_enabled;
+    app.ui.syntax_enabled = snapshot.syntax_enabled;
+
+    app.session.provider_name = snapshot.provider;
+    app.session.model = snapshot.model;
+    app.session.base_url = snapshot.base_url;
+
+    // Restore character, persona, preset from stored data
+    if let Some(character) = snapshot.character {
+        app.session.set_character(character);
+    }
+    if let Some(persona) = snapshot.persona {
+        app.persona_manager.set_active_persona(&persona.id).ok();
+    }
+    if let Some(preset) = snapshot.preset {
+        app.preset_manager.set_active_preset(&preset.id).ok();
+    }
+
+    app.conversation()
+        .set_status(format!("Loaded session: {}", snapshot.name));
+
+    Ok(())
+}
+
+fn show_session_picker(app: &mut App, sessions: Vec<SessionSummary>) {
+    let items: Vec<PickerItem> = sessions
+        .iter()
+        .map(|s| {
+            let provider = &s.provider;
+            let model = &s.model;
+            let char_label = s.character.as_deref().unwrap_or("-");
+            let meta = format!(
+                "{} | {} | {} | {} msgs | {}",
+                provider,
+                model,
+                char_label,
+                s.message_count,
+                s.modified_at.format("%Y-%m-%d %H:%M")
+            );
+            PickerItem {
+                id: s.id.clone(),
+                label: s.name.clone(),
+                metadata: Some(meta),
+                inspect_metadata: None,
+                sort_key: Some(s.modified_at.to_string()),
+            }
+        })
+        .collect();
+
+    app.picker.start_picker(
+        crate::core::app::picker::SessionPickerState {
+            sessions,
+            selected_index: 0,
+            search_filter: String::new(),
+            all_items: items.clone(),
+        },
+        items,
+    );
+}

--- a/src/commands/handlers/session.rs
+++ b/src/commands/handlers/session.rs
@@ -1,12 +1,113 @@
 use super::usage_status;
+use crate::auth::AuthManager;
 use crate::commands::registry::CommandInvocation;
 use crate::commands::CommandResult;
 use crate::core::app::App;
+use crate::core::config::data::Config;
+use crate::core::providers::resolve_env_session;
 use crate::core::session_store::{list_sessions, save_session, SessionSummary};
 use crate::ui::picker::PickerItem;
 
 const USAGE_SAVE: &str = "Usage: /save [name]";
 const USAGE_LOAD: &str = "Usage: /load [session-id]";
+const OPENAI_PROVIDER: &str = "openai";
+const OPENAI_DISPLAY_NAME: &str = "OpenAI";
+const OPENAI_COMPATIBLE_PROVIDER: &str = "openai-compatible";
+const OPENAI_COMPATIBLE_DISPLAY_NAME: &str = "OpenAI-compatible";
+const OPENAI_ENV_FALLBACK_WARNING: &str = "using OPENAI_API_KEY fallback";
+
+struct RestoredSessionProvider {
+    api_key: String,
+    provider_display_name: String,
+    warning: Option<String>,
+}
+
+#[derive(Clone)]
+struct CurrentSessionProvider {
+    api_key: String,
+    base_url: String,
+    provider_name: String,
+    provider_display_name: String,
+    model: String,
+}
+
+enum LoadedSessionProvider {
+    Restored(RestoredSessionProvider),
+    Current {
+        provider: CurrentSessionProvider,
+        warning: String,
+    },
+}
+
+fn openai_env_fallback_display_name(provider: &str) -> Option<&'static str> {
+    match provider {
+        OPENAI_PROVIDER => Some(OPENAI_DISPLAY_NAME),
+        OPENAI_COMPATIBLE_PROVIDER => Some(OPENAI_COMPATIBLE_DISPLAY_NAME),
+        _ => None,
+    }
+}
+
+fn provider_ids_match(saved: &str, resolved: &str) -> bool {
+    saved.eq_ignore_ascii_case(resolved)
+}
+
+fn current_provider_warning(
+    snapshot_provider: &str,
+    current: &CurrentSessionProvider,
+    reason: &str,
+) -> String {
+    let current_provider = if current.provider_name.trim().is_empty() {
+        "(no provider selected)"
+    } else {
+        &current.provider_name
+    };
+    format!(
+        "provider '{}' unavailable; using current provider '{}': {}",
+        snapshot_provider, current_provider, reason
+    )
+}
+
+fn current_provider_fallback(
+    snapshot_provider: &str,
+    current: &CurrentSessionProvider,
+    reason: &str,
+) -> LoadedSessionProvider {
+    LoadedSessionProvider::Current {
+        provider: current.clone(),
+        warning: current_provider_warning(snapshot_provider, current, reason),
+    }
+}
+
+fn resolve_session_provider_after_auth_error(
+    snapshot_provider: &str,
+    current: &CurrentSessionProvider,
+    err: String,
+) -> LoadedSessionProvider {
+    if let Some(provider_display_name) = openai_env_fallback_display_name(snapshot_provider) {
+        return match resolve_env_session() {
+            Ok(session) => {
+                let (api_key, _, _, _) = session.into_tuple();
+                LoadedSessionProvider::Restored(RestoredSessionProvider {
+                    api_key,
+                    provider_display_name: provider_display_name.to_string(),
+                    warning: Some(OPENAI_ENV_FALLBACK_WARNING.to_string()),
+                })
+            }
+            Err(_) => current_provider_fallback(snapshot_provider, current, &err),
+        };
+    }
+
+    if provider_ids_match(&current.provider_name, snapshot_provider) && !current.api_key.is_empty()
+    {
+        return LoadedSessionProvider::Restored(RestoredSessionProvider {
+            api_key: current.api_key.clone(),
+            provider_display_name: current.provider_display_name.clone(),
+            warning: Some(format!("using current credentials: {}", err)),
+        });
+    }
+
+    current_provider_fallback(snapshot_provider, current, &err)
+}
 
 pub(crate) fn handle_save(app: &mut App, invocation: CommandInvocation<'_>) -> CommandResult {
     let name = match invocation.args_len() {
@@ -117,8 +218,48 @@ fn generate_session_name(
     "Untitled session".to_string()
 }
 
+fn resolve_session_provider_for_load(
+    snapshot_provider: &str,
+    current: &CurrentSessionProvider,
+) -> LoadedSessionProvider {
+    let resolved = AuthManager::new()
+        .map_err(|e| e.to_string())
+        .and_then(|auth_manager| {
+            let config = Config::load_test_safe().map_err(|e| e.to_string())?;
+            auth_manager
+                .resolve_authentication(Some(snapshot_provider), &config)
+                .map_err(|e| e.to_string())
+        });
+
+    match resolved {
+        Ok((api_key, _, resolved_provider, provider_display_name))
+            if provider_ids_match(snapshot_provider, &resolved_provider) =>
+        {
+            LoadedSessionProvider::Restored(RestoredSessionProvider {
+                api_key,
+                provider_display_name,
+                warning: None,
+            })
+        }
+        Ok((_, _, resolved_provider, _)) => current_provider_fallback(
+            snapshot_provider,
+            current,
+            &format!("resolved credentials for '{}'", resolved_provider),
+        ),
+        Err(err) => resolve_session_provider_after_auth_error(snapshot_provider, current, err),
+    }
+}
+
 pub fn do_load_session(app: &mut App, id: &str) -> Result<(), String> {
     let snapshot = crate::core::session_store::load_session(id).map_err(|e| e.to_string())?;
+    let current_provider = CurrentSessionProvider {
+        api_key: app.session.api_key.clone(),
+        base_url: app.session.base_url.clone(),
+        provider_name: app.session.provider_name.clone(),
+        provider_display_name: app.session.provider_display_name.clone(),
+        model: app.session.model.clone(),
+    };
+    let provider = resolve_session_provider_for_load(&snapshot.provider, &current_provider);
 
     app.session.session_id = snapshot.id.clone();
     app.ui.messages = snapshot.messages.into_iter().collect();
@@ -149,9 +290,24 @@ pub fn do_load_session(app: &mut App, id: &str) -> Result<(), String> {
     app.ui.markdown_enabled = snapshot.markdown_enabled;
     app.ui.syntax_enabled = snapshot.syntax_enabled;
 
-    app.session.provider_name = snapshot.provider;
-    app.session.model = snapshot.model;
-    app.session.base_url = snapshot.base_url;
+    let warning = match provider {
+        LoadedSessionProvider::Restored(auth) => {
+            app.session.api_key = auth.api_key;
+            app.session.base_url = snapshot.base_url;
+            app.session.provider_name = snapshot.provider;
+            app.session.provider_display_name = auth.provider_display_name;
+            app.session.model = snapshot.model;
+            auth.warning
+        }
+        LoadedSessionProvider::Current { provider, warning } => {
+            app.session.api_key = provider.api_key;
+            app.session.base_url = provider.base_url;
+            app.session.provider_name = provider.provider_name;
+            app.session.provider_display_name = provider.provider_display_name;
+            app.session.model = provider.model;
+            Some(warning)
+        }
+    };
 
     // Restore character, persona, preset from stored data
     if let Some(character) = snapshot.character {
@@ -164,10 +320,25 @@ pub fn do_load_session(app: &mut App, id: &str) -> Result<(), String> {
         app.preset_manager.set_active_preset(&preset.id).ok();
     }
 
-    app.conversation()
-        .set_status(format!("Loaded session: {}", snapshot.name));
+    let status = if let Some(warning) = warning {
+        format!("Loaded session: {} ({})", snapshot.name, warning)
+    } else {
+        format!("Loaded session: {}", snapshot.name)
+    };
+    app.conversation().set_status(status);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::provider_ids_match;
+
+    #[test]
+    fn provider_ids_match_rejects_different_resolved_provider() {
+        assert!(provider_ids_match("openai", "OpenAI"));
+        assert!(!provider_ids_match("anthropic", "openai"));
+    }
 }
 
 fn show_session_picker(app: &mut App, sessions: Vec<SessionSummary>) {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod registry;
 
 pub use handlers::io::dump_conversation_with_overwrite;
 pub(crate) use handlers::mcp::build_mcp_server_output;
+pub use handlers::session::do_load_session;
 pub use registry::{all_commands, matching_commands, CommandInvocation};
 
 use crate::core::app::App;

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -54,6 +54,21 @@ impl<'a> CommandInvocation<'a> {
     }
 
     #[cfg(test)]
+    pub fn new_for_test(
+        command: &'static Command,
+        input: &'a str,
+        args: &'a str,
+        tokens: Vec<&'a str>,
+    ) -> Self {
+        Self {
+            command,
+            input,
+            args,
+            tokens,
+        }
+    }
+
+    #[cfg(test)]
     /// Returns an iterator over whitespace-delimited argument tokens.
     pub fn args_iter(&'a self) -> impl Iterator<Item = &'a str> + 'a {
         self.tokens.iter().copied()
@@ -427,5 +442,39 @@ const COMMANDS: &[Command] = &[
         }],
         extra_help: &[],
         handler: super::refine::handle_refine,
+    },
+    Command {
+        name: "save",
+        usages: &[CommandUsage {
+            syntax: "/save [name]",
+            description:
+                "Save the current conversation as a session (optionally with a custom name).",
+        }],
+        extra_help: &[],
+        handler: super::handlers::session::handle_save,
+    },
+    Command {
+        name: "load",
+        usages: &[
+            CommandUsage {
+                syntax: "/load",
+                description: "Browse and load a saved session (opens a picker).",
+            },
+            CommandUsage {
+                syntax: "/load <session-id>",
+                description: "Load a saved session by its ID.",
+            },
+        ],
+        extra_help: &[],
+        handler: super::handlers::session::handle_load,
+    },
+    Command {
+        name: "sessions",
+        usages: &[CommandUsage {
+            syntax: "/sessions",
+            description: "List saved sessions and browse to load one.",
+        }],
+        extra_help: &[],
+        handler: super::handlers::session::handle_sessions,
     },
 ];

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -1686,7 +1686,6 @@ mod session_tests {
                     "https://api.openai.com/v1",
                     "gpt-4o",
                 );
-                assert_status_contains(&app, "using OPENAI_API_KEY fallback");
             });
         });
     }

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -1302,9 +1302,27 @@ fn validate_prompt_args_rejects_unknown_keys() {
 
 mod session_tests {
     use super::*;
+    use crate::core::config::data::{Config, CustomProvider};
     use crate::core::message::Message;
     use crate::core::session_store::save_session;
-    use crate::utils::test_utils::{create_test_app, create_test_message, TestEnvVarGuard};
+    use crate::utils::test_utils::{
+        create_test_app, create_test_message, with_test_config_env, TestEnvVarGuard,
+    };
+
+    struct TestAuthTokenGuard;
+
+    impl TestAuthTokenGuard {
+        fn new() -> Self {
+            crate::auth::clear_test_tokens();
+            Self
+        }
+    }
+
+    impl Drop for TestAuthTokenGuard {
+        fn drop(&mut self) {
+            crate::auth::clear_test_tokens();
+        }
+    }
 
     fn with_session_dir<F, R>(f: F) -> R
     where
@@ -1313,16 +1331,23 @@ mod session_tests {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let mut guard = TestEnvVarGuard::new();
         guard.set_var("CHABEAU_DATA_DIR", temp_dir.path());
+        let _auth_guard = TestAuthTokenGuard::new();
         f(temp_dir.path())
     }
 
-    fn save_test_session(session_id: &str, name: &str) {
-        let _ = save_session(
+    fn save_session_fixture(
+        session_id: &str,
+        name: &str,
+        provider: &str,
+        model: &str,
+        base_url: &str,
+    ) {
+        save_session(
             session_id,
             name,
-            "test-provider",
-            "test-model",
-            "https://example.com/v1",
+            provider,
+            model,
+            base_url,
             None,
             None,
             None,
@@ -1334,7 +1359,77 @@ mod session_tests {
             "",
             false,
             false,
+        )
+        .expect("save session fixture");
+    }
+
+    fn save_openai_session(session_id: &str, name: &str) {
+        crate::auth::set_test_token("openai", "test-openai-key");
+        save_session_fixture(
+            session_id,
+            name,
+            "openai",
+            "test-model",
+            "https://api.openai.com/v1",
         );
+    }
+
+    fn assert_loaded_context(
+        app: &crate::core::app::App,
+        api_key: &str,
+        provider: &str,
+        provider_display: &str,
+        base_url: &str,
+        model: &str,
+    ) {
+        assert_eq!(app.session.api_key, api_key);
+        assert_eq!(app.session.provider_name, provider);
+        assert_eq!(app.session.provider_display_name, provider_display);
+        assert_eq!(app.session.base_url, base_url);
+        assert_eq!(app.session.model, model);
+    }
+
+    fn assert_status_contains(app: &crate::core::app::App, expected: &str) {
+        assert!(app.ui.status.as_deref().unwrap_or("").contains(expected));
+    }
+
+    fn configure_custom_provider(id: &str, display_name: &str, base_url: &str) {
+        Config::mutate(|config| {
+            config.add_custom_provider(CustomProvider::new(
+                id.to_string(),
+                display_name.to_string(),
+                base_url.to_string(),
+                None,
+            ));
+            Ok(())
+        })
+        .expect("configure custom provider");
+    }
+
+    fn save_test_session(session_id: &str, name: &str) {
+        save_openai_session(session_id, name);
+    }
+
+    fn save_settings_session() {
+        save_session(
+            "sess-settings",
+            "Settings Test",
+            "openai",
+            "mod",
+            "https://api.openai.com/v1",
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            &[],
+            &crate::core::app::session::McpInitState::default(),
+            "custom refine instructions",
+            "custom refine prefix",
+            true,
+            false,
+        )
+        .expect("save settings session");
     }
 
     #[test]
@@ -1408,6 +1503,9 @@ mod session_tests {
         with_session_dir(|_| {
             let mut app = create_test_app();
             app.session.session_id = "sess-load-msgs".to_string();
+            app.session.provider_name = "openai".to_string();
+            app.session.api_key = "message-openai-key".to_string();
+            app.session.base_url = "https://api.openai.com/v1".to_string();
             app.ui
                 .messages
                 .push_back(create_test_message("user", "Before save"));
@@ -1416,6 +1514,7 @@ mod session_tests {
                 .push_back(create_test_message("assistant", "Response"));
 
             process_input(&mut app, "/save LoadMsgsTest");
+            crate::auth::set_test_token("openai", "message-openai-key");
 
             let mut app2 = create_test_app();
             app2.session.session_id = "new-session".to_string();
@@ -1437,37 +1536,290 @@ mod session_tests {
             let result = super::handlers::session::do_load_session(&mut app, "sess-ctx");
             assert!(result.is_ok());
             assert_eq!(app.session.session_id, "sess-ctx");
-            assert_eq!(app.session.provider_name, "test-provider");
-            assert_eq!(app.session.model, "test-model");
-            assert_eq!(app.session.base_url, "https://example.com/v1");
+            assert_loaded_context(
+                &app,
+                "test-openai-key",
+                "openai",
+                "OpenAI",
+                "https://api.openai.com/v1",
+                "test-model",
+            );
+        });
+    }
+
+    #[test]
+    fn load_command_by_id_resolves_provider_credentials() {
+        with_test_config_env(|_| {
+            with_session_dir(|_| {
+                crate::auth::set_test_token("openai", "loaded-openai-key");
+
+                save_session_fixture(
+                    "sess-auth",
+                    "Auth Test",
+                    "openai",
+                    "gpt-4o",
+                    "https://api.openai.com/v1",
+                );
+
+                let mut app = create_test_app();
+                app.session.api_key = "stale-provider-key".to_string();
+                app.session.provider_display_name = "Stale Provider".to_string();
+
+                let result = super::handlers::session::do_load_session(&mut app, "sess-auth");
+
+                assert!(result.is_ok());
+                assert_loaded_context(
+                    &app,
+                    "loaded-openai-key",
+                    "openai",
+                    "OpenAI",
+                    "https://api.openai.com/v1",
+                    "gpt-4o",
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn load_command_by_id_preserves_snapshot_base_url_for_configured_provider() {
+        with_test_config_env(|_| {
+            with_session_dir(|_| {
+                configure_custom_provider(
+                    "snapshot-provider",
+                    "Snapshot Provider",
+                    "https://current.example/v1",
+                );
+                crate::auth::set_test_token("snapshot-provider", "snapshot-provider-key");
+
+                save_session_fixture(
+                    "sess-snapshot-base",
+                    "Snapshot Base Test",
+                    "snapshot-provider",
+                    "custom-model",
+                    "https://saved.example/v1",
+                );
+
+                let mut app = create_test_app();
+                let result =
+                    super::handlers::session::do_load_session(&mut app, "sess-snapshot-base");
+
+                assert!(result.is_ok(), "load failed: {result:?}");
+                assert_loaded_context(
+                    &app,
+                    "snapshot-provider-key",
+                    "snapshot-provider",
+                    "Snapshot Provider",
+                    "https://saved.example/v1",
+                    "custom-model",
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn load_command_by_id_resolves_env_openai_compatible_credentials() {
+        with_test_config_env(|_| {
+            with_session_dir(|_| {
+                let mut env_guard = TestEnvVarGuard::new();
+                env_guard.set_var("OPENAI_API_KEY", "env-openai-compatible-key");
+                env_guard.remove_var("OPENAI_BASE_URL");
+
+                save_session_fixture(
+                    "sess-env-compatible",
+                    "Env Compatible Test",
+                    "openai-compatible",
+                    "custom-model",
+                    "https://compatible.example/v1",
+                );
+
+                let mut app = create_test_app();
+                app.session.api_key = "stale-provider-key".to_string();
+                app.session.base_url = "https://stale.example/v1".to_string();
+                app.session.provider_display_name = "Stale Provider".to_string();
+
+                let result =
+                    super::handlers::session::do_load_session(&mut app, "sess-env-compatible");
+
+                assert!(result.is_ok(), "load failed: {result:?}");
+                assert_loaded_context(
+                    &app,
+                    "env-openai-compatible-key",
+                    "openai-compatible",
+                    "OpenAI-compatible",
+                    "https://compatible.example/v1",
+                    "custom-model",
+                );
+                assert_status_contains(&app, "using OPENAI_API_KEY fallback");
+            });
+        });
+    }
+
+    #[test]
+    fn load_command_by_id_resolves_env_openai_credentials() {
+        with_test_config_env(|_| {
+            with_session_dir(|_| {
+                let mut env_guard = TestEnvVarGuard::new();
+                env_guard.set_var("OPENAI_API_KEY", "env-openai-key");
+                env_guard.remove_var("OPENAI_BASE_URL");
+
+                save_session_fixture(
+                    "sess-env-openai",
+                    "Env OpenAI Test",
+                    "openai",
+                    "gpt-4o",
+                    "https://api.openai.com/v1",
+                );
+
+                let mut app = create_test_app();
+                app.session.api_key = "stale-provider-key".to_string();
+                app.session.base_url = "https://stale.example/v1".to_string();
+                app.session.provider_display_name = "Stale Provider".to_string();
+
+                let result = super::handlers::session::do_load_session(&mut app, "sess-env-openai");
+
+                assert!(result.is_ok(), "load failed: {result:?}");
+                assert_loaded_context(
+                    &app,
+                    "env-openai-key",
+                    "openai",
+                    "OpenAI",
+                    "https://api.openai.com/v1",
+                    "gpt-4o",
+                );
+                assert_status_contains(&app, "using OPENAI_API_KEY fallback");
+            });
+        });
+    }
+
+    #[test]
+    fn load_command_by_id_warns_when_using_current_credentials_fallback() {
+        with_test_config_env(|_| {
+            with_session_dir(|_| {
+                save_session_fixture(
+                    "sess-current-fallback",
+                    "Current Fallback Test",
+                    "runtime-provider",
+                    "runtime-model",
+                    "https://saved-runtime.example/v1",
+                );
+
+                let mut app = create_test_app();
+                app.session.provider_name = "runtime-provider".to_string();
+                app.session.provider_display_name = "Runtime Provider".to_string();
+                app.session.api_key = "runtime-key".to_string();
+                app.session.base_url = "https://current-runtime.example/v1".to_string();
+
+                let result =
+                    super::handlers::session::do_load_session(&mut app, "sess-current-fallback");
+
+                assert!(result.is_ok(), "load failed: {result:?}");
+                assert_loaded_context(
+                    &app,
+                    "runtime-key",
+                    "runtime-provider",
+                    "Runtime Provider",
+                    "https://saved-runtime.example/v1",
+                    "runtime-model",
+                );
+                assert_status_contains(&app, "using current credentials");
+            });
+        });
+    }
+
+    #[test]
+    fn load_command_by_id_falls_back_to_current_provider_when_saved_provider_unavailable() {
+        with_test_config_env(|_| {
+            with_session_dir(|_| {
+                save_session_fixture(
+                    "sess-different-provider-fallback",
+                    "Different Provider Fallback Test",
+                    "missing-provider",
+                    "saved-model",
+                    "https://saved-missing.example/v1",
+                );
+
+                let mut app = create_test_app();
+                app.session.provider_name = "current-provider".to_string();
+                app.session.provider_display_name = "Current Provider".to_string();
+                app.session.api_key = "current-key".to_string();
+                app.session.base_url = "https://current.example/v1".to_string();
+                app.session.model = "current-model".to_string();
+
+                let result = super::handlers::session::do_load_session(
+                    &mut app,
+                    "sess-different-provider-fallback",
+                );
+
+                assert!(result.is_ok(), "load failed: {result:?}");
+                assert_loaded_context(
+                    &app,
+                    "current-key",
+                    "current-provider",
+                    "Current Provider",
+                    "https://current.example/v1",
+                    "current-model",
+                );
+                assert_status_contains(
+                    &app,
+                    "provider 'missing-provider' unavailable; using current provider 'current-provider'",
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn load_command_by_id_rejects_wrong_env_provider_fallback() {
+        with_test_config_env(|_| {
+            with_session_dir(|_| {
+                let mut env_guard = TestEnvVarGuard::new();
+                env_guard.set_var("OPENAI_API_KEY", "env-openai-key");
+                env_guard.remove_var("OPENAI_BASE_URL");
+                crate::auth::set_test_recoverable_keyring_error("anthropic");
+
+                save_session_fixture(
+                    "sess-wrong-env-fallback",
+                    "Wrong Env Fallback Test",
+                    "anthropic",
+                    "claude-sonnet-4-20250514",
+                    "https://api.anthropic.com",
+                );
+
+                let mut app = create_test_app();
+                app.session.provider_name = "current-provider".to_string();
+                app.session.provider_display_name = "Current Provider".to_string();
+                app.session.api_key = "current-key".to_string();
+                app.session.base_url = "https://current.example/v1".to_string();
+                app.session.model = "current-model".to_string();
+
+                let result =
+                    super::handlers::session::do_load_session(&mut app, "sess-wrong-env-fallback");
+
+                assert!(result.is_ok(), "load failed: {result:?}");
+                assert_loaded_context(
+                    &app,
+                    "current-key",
+                    "current-provider",
+                    "Current Provider",
+                    "https://current.example/v1",
+                    "current-model",
+                );
+                assert_status_contains(
+                    &app,
+                    "provider 'anthropic' unavailable; using current provider 'current-provider'",
+                );
+            });
         });
     }
 
     #[test]
     fn load_command_by_id_restores_ui_settings() {
         with_session_dir(|_| {
-            let _ = save_session(
-                "sess-settings",
-                "Settings Test",
-                "prov",
-                "mod",
-                "https://example.com/v1",
-                None,
-                None,
-                None,
-                &[],
-                &[],
-                &[],
-                &crate::core::app::session::McpInitState::default(),
-                "custom refine instructions",
-                "custom refine prefix",
-                true,
-                false,
-            );
+            save_settings_session();
 
             let mut app = create_test_app();
             app.ui.markdown_enabled = false;
             app.ui.syntax_enabled = true;
+            crate::auth::set_test_token("openai", "test-openai-key");
 
             let result = super::handlers::session::do_load_session(&mut app, "sess-settings");
             assert!(result.is_ok());
@@ -1601,6 +1953,7 @@ mod session_tests {
             let mut app = create_test_app();
             app.session.session_id = "sess-integration".to_string();
             app.session.provider_name = "openai".to_string();
+            app.session.api_key = "integration-openai-key".to_string();
             app.session.model = "gpt-4".to_string();
             app.session.base_url = "https://api.openai.com/v1".to_string();
             app.ui.markdown_enabled = true;
@@ -1615,6 +1968,7 @@ mod session_tests {
             ));
 
             process_input(&mut app, "/save IntegrationTest");
+            crate::auth::set_test_token("openai", "integration-openai-key");
 
             let mut app2 = create_test_app();
             app2.session.session_id = "fresh-session".to_string();

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -1299,3 +1299,344 @@ fn validate_prompt_args_rejects_unknown_keys() {
     assert!(err.contains("Unknown prompt argument"));
     assert!(err.contains("topic"));
 }
+
+mod session_tests {
+    use super::*;
+    use crate::core::message::Message;
+    use crate::core::session_store::{list_sessions, save_session};
+    use crate::utils::test_utils::{create_test_app, create_test_message, TestEnvVarGuard};
+    use std::env;
+
+    fn with_session_dir<F, R>(f: F) -> R
+    where
+        F: FnOnce(&std::path::Path) -> R,
+    {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let mut guard = TestEnvVarGuard::new();
+        guard.set_var("CHABEAU_DATA_DIR", temp_dir.path());
+        f(temp_dir.path())
+    }
+
+    fn save_test_session(session_id: &str, name: &str) {
+        let _ = save_session(
+            session_id,
+            name,
+            "test-provider",
+            "test-model",
+            "https://example.com/v1",
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            &[],
+            &crate::core::app::session::McpInitState::default(),
+            "",
+            "",
+            false,
+            false,
+        );
+    }
+
+    #[test]
+    fn save_command_without_name_uses_first_user_message() {
+        with_session_dir(|_| {
+            let mut app = create_test_app();
+            app.session.session_id = "sess-001".to_string();
+            app.ui.messages.push_back(create_test_message(
+                "user",
+                "This is a very long message that should be truncated because it exceeds fifty characters easily",
+            ));
+
+            let result = process_input(&mut app, "/save");
+            assert!(matches!(result, CommandResult::ContinueWithTranscriptFocus));
+            let status = app.ui.status.as_deref().unwrap_or("");
+            assert!(status.contains("This is a very long message"));
+            assert!(status.contains("sess-001"));
+        });
+    }
+
+    #[test]
+    fn save_command_with_explicit_name() {
+        with_session_dir(|_| {
+            let mut app = create_test_app();
+            app.session.session_id = "sess-002".to_string();
+            app.ui
+                .messages
+                .push_back(create_test_message("user", "Hello"));
+
+            let result = process_input(&mut app, "/save MySession");
+            assert!(matches!(result, CommandResult::ContinueWithTranscriptFocus));
+            let status = app.ui.status.as_deref().unwrap_or("");
+            assert!(status.contains("MySession"));
+            assert!(status.contains("sess-002"));
+        });
+    }
+
+    #[test]
+    fn save_command_rejects_too_many_args() {
+        let mut app = create_test_app();
+        let result = process_input(&mut app, "/save arg1 arg2");
+        assert!(matches!(result, CommandResult::Continue));
+        assert!(app
+            .ui
+            .status
+            .as_deref()
+            .unwrap_or("")
+            .contains("Usage: /save"));
+    }
+
+    #[test]
+    fn save_command_sets_confirmation_status() {
+        with_session_dir(|_| {
+            let mut app = create_test_app();
+            app.session.session_id = "sess-003".to_string();
+            app.ui
+                .messages
+                .push_back(create_test_message("user", "Test"));
+
+            let result = process_input(&mut app, "/save ConfirmTest");
+            assert!(matches!(result, CommandResult::ContinueWithTranscriptFocus));
+            let status = app.ui.status.as_deref().unwrap_or("");
+            assert!(status.contains("Session saved:"));
+            assert!(status.contains("ConfirmTest"));
+            assert!(status.contains("sess-003"));
+        });
+    }
+
+    #[test]
+    fn load_command_by_id_restores_messages() {
+        with_session_dir(|_| {
+            let mut app = create_test_app();
+            app.session.session_id = "sess-load-msgs".to_string();
+            app.ui
+                .messages
+                .push_back(create_test_message("user", "Before save"));
+            app.ui
+                .messages
+                .push_back(create_test_message("assistant", "Response"));
+
+            process_input(&mut app, "/save LoadMsgsTest");
+
+            let mut app2 = create_test_app();
+            app2.session.session_id = "new-session".to_string();
+
+            let result = super::handlers::session::do_load_session(&mut app2, "sess-load-msgs");
+            assert!(result.is_ok());
+            assert_eq!(app2.ui.messages.len(), 2);
+            assert_eq!(app2.ui.messages[0].content, "Before save");
+            assert_eq!(app2.ui.messages[1].content, "Response");
+        });
+    }
+
+    #[test]
+    fn load_command_by_id_restores_session_context() {
+        with_session_dir(|_| {
+            save_test_session("sess-ctx", "Context Test");
+
+            let mut app = create_test_app();
+            let result = super::handlers::session::do_load_session(&mut app, "sess-ctx");
+            assert!(result.is_ok());
+            assert_eq!(app.session.session_id, "sess-ctx");
+            assert_eq!(app.session.provider_name, "test-provider");
+            assert_eq!(app.session.model, "test-model");
+            assert_eq!(app.session.base_url, "https://example.com/v1");
+        });
+    }
+
+    #[test]
+    fn load_command_by_id_restores_ui_settings() {
+        with_session_dir(|_| {
+            let _ = save_session(
+                "sess-settings",
+                "Settings Test",
+                "prov",
+                "mod",
+                "https://example.com/v1",
+                None,
+                None,
+                None,
+                &[],
+                &[],
+                &[],
+                &crate::core::app::session::McpInitState::default(),
+                "custom refine instructions",
+                "custom refine prefix",
+                true,
+                false,
+            );
+
+            let mut app = create_test_app();
+            app.ui.markdown_enabled = false;
+            app.ui.syntax_enabled = true;
+
+            let result = super::handlers::session::do_load_session(&mut app, "sess-settings");
+            assert!(result.is_ok());
+            assert!(app.ui.markdown_enabled);
+            assert!(!app.ui.syntax_enabled);
+            assert_eq!(
+                app.session.refine_instructions,
+                "custom refine instructions"
+            );
+            assert_eq!(app.session.refine_prefix, "custom refine prefix");
+        });
+    }
+
+    #[test]
+    fn load_command_no_sessions_shows_message() {
+        with_session_dir(|_| {
+            let mut app = create_test_app();
+            let result = process_input(&mut app, "/load");
+            assert!(matches!(result, CommandResult::ContinueWithTranscriptFocus));
+            assert!(app
+                .ui
+                .status
+                .as_deref()
+                .unwrap_or("")
+                .contains("No saved sessions"));
+        });
+    }
+
+    #[test]
+    fn load_command_invalid_id_shows_error() {
+        let mut app = create_test_app();
+        let result = process_input(&mut app, "/load nonexistent-session-id");
+        assert!(matches!(result, CommandResult::ContinueWithTranscriptFocus));
+        let status = app.ui.status.as_deref().unwrap_or("");
+        assert!(status.contains("Load error:"));
+    }
+
+    #[test]
+    fn load_command_rejects_too_many_args() {
+        let mut app = create_test_app();
+        let result = process_input(&mut app, "/load id1 id2");
+        assert!(matches!(result, CommandResult::Continue));
+        assert!(app
+            .ui
+            .status
+            .as_deref()
+            .unwrap_or("")
+            .contains("Usage: /load"));
+    }
+
+    #[test]
+    fn sessions_command_no_sessions_shows_message() {
+        with_session_dir(|_| {
+            let mut app = create_test_app();
+            let result = process_input(&mut app, "/sessions");
+            assert!(matches!(result, CommandResult::ContinueWithTranscriptFocus));
+            assert!(app
+                .ui
+                .status
+                .as_deref()
+                .unwrap_or("")
+                .contains("No saved sessions"));
+        });
+    }
+
+    #[test]
+    fn sessions_command_with_sessions_opens_picker() {
+        with_session_dir(|_| {
+            save_test_session("sess-picker", "Picker Test");
+
+            let mut app = create_test_app();
+            let result = process_input(&mut app, "/sessions");
+            assert!(matches!(result, CommandResult::Continue));
+            assert!(app.picker_session().is_some());
+        });
+    }
+
+    #[test]
+    fn generate_session_name_truncates_long_messages() {
+        use crate::commands::handlers::session::handle_save;
+        use crate::commands::registry::CommandInvocation;
+        use std::collections::VecDeque;
+
+        let long_content = "a".repeat(100);
+        let mut messages = VecDeque::new();
+        messages.push_back(Message::new(TranscriptRole::User, long_content));
+
+        let mut app = create_test_app();
+        app.session.session_id = "sess-trunc".to_string();
+        app.ui.messages = messages;
+
+        let save_cmd = super::registry::find_command("save").expect("save command exists");
+        let invocation = CommandInvocation::new_for_test(save_cmd, "save", "", vec![]);
+
+        with_session_dir(|_| {
+            let result = handle_save(&mut app, invocation);
+            assert!(matches!(result, CommandResult::ContinueWithTranscriptFocus));
+            let status = app.ui.status.as_deref().unwrap_or("");
+            // 47 'a's + "..." = 50 chars
+            assert!(status.contains("aaa"));
+        });
+    }
+
+    #[test]
+    fn generate_session_name_fallback_no_user_messages() {
+        use crate::commands::handlers::session::handle_save;
+        use crate::commands::registry::CommandInvocation;
+        use std::collections::VecDeque;
+
+        let mut messages = VecDeque::new();
+        messages.push_back(create_test_message("assistant", "Only assistant"));
+
+        let mut app = create_test_app();
+        app.session.session_id = "sess-fallback".to_string();
+        app.ui.messages = messages;
+
+        let save_cmd = super::registry::find_command("save").expect("save command exists");
+        let invocation = CommandInvocation::new_for_test(save_cmd, "save", "", vec![]);
+
+        with_session_dir(|_| {
+            let result = handle_save(&mut app, invocation);
+            assert!(matches!(result, CommandResult::ContinueWithTranscriptFocus));
+            let status = app.ui.status.as_deref().unwrap_or("");
+            assert!(status.contains("Untitled session"));
+        });
+    }
+
+    #[test]
+    fn full_save_load_cycle_integration() {
+        with_session_dir(|_| {
+            let mut app = create_test_app();
+            app.session.session_id = "sess-integration".to_string();
+            app.session.provider_name = "openai".to_string();
+            app.session.model = "gpt-4".to_string();
+            app.session.base_url = "https://api.openai.com/v1".to_string();
+            app.ui.markdown_enabled = true;
+            app.ui.syntax_enabled = false;
+
+            app.ui
+                .messages
+                .push_back(create_test_message("user", "What is Rust?"));
+            app.ui.messages.push_back(create_test_message(
+                "assistant",
+                "Rust is a systems programming language.",
+            ));
+
+            process_input(&mut app, "/save IntegrationTest");
+
+            let mut app2 = create_test_app();
+            app2.session.session_id = "fresh-session".to_string();
+            app2.ui.markdown_enabled = false;
+            app2.ui.syntax_enabled = true;
+
+            let result = super::handlers::session::do_load_session(&mut app2, "sess-integration");
+            assert!(result.is_ok());
+
+            assert_eq!(app2.session.session_id, "sess-integration");
+            assert_eq!(app2.session.provider_name, "openai");
+            assert_eq!(app2.session.model, "gpt-4");
+            assert_eq!(app2.session.base_url, "https://api.openai.com/v1");
+            assert!(app2.ui.markdown_enabled);
+            assert!(!app2.ui.syntax_enabled);
+            assert_eq!(app2.ui.messages.len(), 2);
+            assert_eq!(app2.ui.messages[0].content, "What is Rust?");
+            assert_eq!(
+                app2.ui.messages[1].content,
+                "Rust is a systems programming language."
+            );
+        });
+    }
+}

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -1303,9 +1303,8 @@ fn validate_prompt_args_rejects_unknown_keys() {
 mod session_tests {
     use super::*;
     use crate::core::message::Message;
-    use crate::core::session_store::{list_sessions, save_session};
+    use crate::core::session_store::save_session;
     use crate::utils::test_utils::{create_test_app, create_test_message, TestEnvVarGuard};
-    use std::env;
 
     fn with_session_dir<F, R>(f: F) -> R
     where

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -403,7 +403,7 @@ fn theme_command_opens_picker() {
     let mut app = create_test_app();
     let res = process_input(&mut app, "/theme");
     assert!(matches!(res, CommandResult::OpenThemePicker));
-    assert!(app.picker_session().is_none());
+    assert!(app.active_picker().is_none());
 }
 
 #[test]
@@ -1541,7 +1541,7 @@ mod session_tests {
             let mut app = create_test_app();
             let result = process_input(&mut app, "/sessions");
             assert!(matches!(result, CommandResult::Continue));
-            assert!(app.picker_session().is_some());
+            assert!(app.active_picker().is_some());
         });
     }
 

--- a/src/core/app/actions/input/command.rs
+++ b/src/core/app/actions/input/command.rs
@@ -130,7 +130,7 @@ mod tests {
             ctx,
         );
 
-        assert!(app.picker_session().is_some());
+        assert!(app.active_picker().is_some());
     }
 
     #[test]

--- a/src/core/app/actions/picker.rs
+++ b/src/core/app/actions/picker.rs
@@ -206,6 +206,14 @@ fn handle_picker_backspace(app: &mut App) {
                 }
             }
         }
+        Some(PickerMode::SessionLoad) => {
+            if let Some(state) = app.session_load_picker_state_mut() {
+                if !state.search_filter.is_empty() {
+                    state.search_filter.pop();
+                    app.filter_sessions();
+                }
+            }
+        }
         None => {}
     }
 }
@@ -253,6 +261,12 @@ fn handle_picker_type_char(app: &mut App, ch: char) {
             if let Some(state) = app.preset_picker_state_mut() {
                 state.search_filter.push(ch);
                 app.filter_presets();
+            }
+        }
+        Some(PickerMode::SessionLoad) => {
+            if let Some(state) = app.session_load_picker_state_mut() {
+                state.search_filter.push(ch);
+                app.filter_sessions();
             }
         }
         None => {}
@@ -361,6 +375,9 @@ fn handle_picker_escape(app: &mut App, ctx: AppActionContext) {
             app.close_picker();
         }
         Some(PickerMode::Preset) => {
+            app.close_picker();
+        }
+        Some(PickerMode::SessionLoad) => {
             app.close_picker();
         }
         None => {}
@@ -506,6 +523,18 @@ fn handle_picker_apply_selection(
         }
         Some(PickerMode::Preset) => {
             app.apply_selected_preset(persistent);
+            None
+        }
+        Some(PickerMode::SessionLoad) => {
+            let Some(id) = selected_picker_id(app) else {
+                app.close_picker();
+                return None;
+            };
+            match crate::commands::do_load_session(app, &id) {
+                Ok(()) => input::set_status_message(app, format!("Loaded session: {}", id), ctx),
+                Err(e) => input::set_status_message(app, format!("Load error: {}", e), ctx),
+            }
+            app.close_picker();
             None
         }
         None => None,

--- a/src/core/app/actions/picker.rs
+++ b/src/core/app/actions/picker.rs
@@ -206,11 +206,11 @@ fn handle_picker_backspace(app: &mut App) {
                 }
             }
         }
-        Some(PickerMode::SessionLoad) => {
-            if let Some(state) = app.session_load_picker_state_mut() {
+        Some(PickerMode::SavedSession) => {
+            if let Some(state) = app.saved_session_picker_state_mut() {
                 if !state.search_filter.is_empty() {
                     state.search_filter.pop();
-                    app.filter_sessions();
+                    app.filter_saved_sessions();
                 }
             }
         }
@@ -263,10 +263,10 @@ fn handle_picker_type_char(app: &mut App, ch: char) {
                 app.filter_presets();
             }
         }
-        Some(PickerMode::SessionLoad) => {
-            if let Some(state) = app.session_load_picker_state_mut() {
+        Some(PickerMode::SavedSession) => {
+            if let Some(state) = app.saved_session_picker_state_mut() {
                 state.search_filter.push(ch);
-                app.filter_sessions();
+                app.filter_saved_sessions();
             }
         }
         None => {}
@@ -275,7 +275,7 @@ fn handle_picker_type_char(app: &mut App, ch: char) {
 
 fn handle_picker_inspect(app: &mut App, ctx: AppActionContext) {
     let (title, metadata) = {
-        let Some(session) = app.picker_session() else {
+        let Some(session) = app.active_picker() else {
             return;
         };
         let state = &session.state;
@@ -320,7 +320,7 @@ fn handle_picker_inspect(app: &mut App, ctx: AppActionContext) {
 fn handle_picker_escape(app: &mut App, ctx: AppActionContext) {
     if app.inspect_state().is_some() {
         app.close_inspect();
-        if app.picker_session().is_some() {
+        if app.active_picker().is_some() {
             input::set_status_message(
                 app,
                 "Returned to picker (Ctrl+O=Inspect again)".to_string(),
@@ -377,7 +377,7 @@ fn handle_picker_escape(app: &mut App, ctx: AppActionContext) {
         Some(PickerMode::Preset) => {
             app.close_picker();
         }
-        Some(PickerMode::SessionLoad) => {
+        Some(PickerMode::SavedSession) => {
             app.close_picker();
         }
         None => {}
@@ -525,7 +525,7 @@ fn handle_picker_apply_selection(
             app.apply_selected_preset(persistent);
             None
         }
-        Some(PickerMode::SessionLoad) => {
+        Some(PickerMode::SavedSession) => {
             let Some(id) = selected_picker_id(app) else {
                 app.close_picker();
                 return None;
@@ -806,7 +806,7 @@ mod tests {
     use super::*;
     use crate::character::card::{CharacterCard, CharacterData};
     use crate::core::app::picker::{
-        CharacterPickerState, ModelPickerState, PickerData, PickerSession,
+        ActivePicker, CharacterPickerState, ModelPickerState, PickerData,
     };
     use crate::core::config::data::{Config, Persona, Preset};
     use crate::ui::picker::{PickerItem, PickerState};
@@ -835,7 +835,7 @@ mod tests {
         handle_picker_action(&mut app, PickerAction::PickerEscape, ctx);
 
         assert_eq!(app.ui.theme.background_color, original_color);
-        assert!(app.picker_session().is_none());
+        assert!(app.active_picker().is_none());
     }
 
     #[test]
@@ -868,7 +868,7 @@ mod tests {
 
         let picker_state = PickerState::new("Pick Model", items.clone(), 0);
 
-        app.picker.picker_session = Some(PickerSession {
+        app.picker.active_picker = Some(ActivePicker {
             state: picker_state,
             data: PickerData::Model(Box::new(ModelPickerState {
                 search_filter: String::new(),
@@ -887,7 +887,7 @@ mod tests {
         assert_eq!(app.session.base_url, "https://api.old");
         assert!(!app.picker.in_provider_model_transition);
         assert!(app.picker.provider_model_transition_state.is_none());
-        assert!(app.picker_session().is_none());
+        assert!(app.active_picker().is_none());
         assert_eq!(app.ui.status.as_deref(), Some("Selection cancelled"));
     }
 
@@ -905,7 +905,7 @@ mod tests {
         }];
 
         let picker_state = PickerState::new("Pick Character", items.clone(), 0);
-        app.picker.picker_session = Some(PickerSession {
+        app.picker.active_picker = Some(ActivePicker {
             state: picker_state,
             data: PickerData::Character(CharacterPickerState {
                 search_filter: String::new(),
@@ -913,13 +913,13 @@ mod tests {
             }),
         });
 
-        assert!(app.picker_session().is_some());
+        assert!(app.active_picker().is_some());
         handle_picker_action(
             &mut app,
             PickerAction::PickerApplySelection { persistent: false },
             ctx,
         );
-        assert!(app.picker_session().is_none());
+        assert!(app.active_picker().is_none());
     }
 
     #[test]
@@ -944,7 +944,7 @@ mod tests {
         ];
 
         let picker_state = PickerState::new("Pick Character", items.clone(), 0);
-        app.picker.picker_session = Some(PickerSession {
+        app.picker.active_picker = Some(ActivePicker {
             state: picker_state,
             data: PickerData::Character(CharacterPickerState {
                 search_filter: String::new(),

--- a/src/core/app/app.rs
+++ b/src/core/app/app.rs
@@ -79,6 +79,7 @@ impl App {
             active_assistant_message_index: None,
             mcp_tools_enabled: false,
             mcp_tools_unsupported: false,
+            session_id: String::new(),
         };
 
         let ui = UiState::new_basic(theme, markdown_enabled, syntax_enabled, None);

--- a/src/core/app/picker/mod.rs
+++ b/src/core/app/picker/mod.rs
@@ -88,6 +88,7 @@ pub enum PickerMode {
     Character,
     Persona,
     Preset,
+    SessionLoad,
 }
 
 #[derive(Debug, Clone)]
@@ -131,6 +132,15 @@ pub struct PresetPickerState {
     pub all_items: Vec<PickerItem>,
 }
 
+/// State for the session load picker.
+#[derive(Debug, Clone)]
+pub struct SessionPickerState {
+    pub sessions: Vec<crate::core::session_store::SessionSummary>,
+    pub selected_index: usize,
+    pub search_filter: String,
+    pub all_items: Vec<PickerItem>,
+}
+
 #[derive(Debug, Clone)]
 pub enum PickerData {
     Theme(Box<ThemePickerState>),
@@ -139,6 +149,7 @@ pub enum PickerData {
     Character(CharacterPickerState),
     Persona(PersonaPickerState),
     Preset(PresetPickerState),
+    SessionLoad(SessionPickerState),
 }
 
 impl PickerData {
@@ -150,6 +161,7 @@ impl PickerData {
             PickerData::Character(_) => PickerMode::Character,
             PickerData::Persona(_) => PickerMode::Persona,
             PickerData::Preset(_) => PickerMode::Preset,
+            PickerData::SessionLoad(_) => PickerMode::SessionLoad,
         }
     }
 
@@ -160,7 +172,8 @@ impl PickerData {
             | PickerData::Provider(_)
             | PickerData::Character(_)
             | PickerData::Persona(_)
-            | PickerData::Preset(_) => true,
+            | PickerData::Preset(_)
+            | PickerData::SessionLoad(_) => true,
         }
     }
 
@@ -179,6 +192,7 @@ impl PickerData {
             PickerMode::Character => "Pick Character",
             PickerMode::Persona => "Pick Persona",
             PickerMode::Preset => "Pick Preset",
+            PickerMode::SessionLoad => "Load Session",
         }
     }
 
@@ -190,6 +204,7 @@ impl PickerData {
             PickerData::Character(state) => &state.search_filter,
             PickerData::Persona(state) => &state.search_filter,
             PickerData::Preset(state) => &state.search_filter,
+            PickerData::SessionLoad(state) => &state.search_filter,
         }
     }
 
@@ -201,6 +216,7 @@ impl PickerData {
             PickerData::Character(state) => &state.all_items,
             PickerData::Persona(state) => &state.all_items,
             PickerData::Preset(state) => &state.all_items,
+            PickerData::SessionLoad(state) => &state.all_items,
         }
     }
 }
@@ -288,6 +304,7 @@ picker_state_accessors! {
     (Character, character_state, character_state_mut, CharacterPickerState),
     (Persona, persona_state, persona_state_mut, PersonaPickerState),
     (Preset, preset_state, preset_state_mut, PresetPickerState),
+    (SessionLoad, session_load_state, session_load_state_mut, SessionPickerState),
 }
 
 pub struct PickerController {
@@ -333,6 +350,24 @@ impl PickerController {
 
     pub fn close(&mut self) {
         self.picker_session = None;
+    }
+
+    /// Start a session load picker with the given sessions and items.
+    pub fn start_picker(&mut self, session_state: SessionPickerState, items: Vec<PickerItem>) {
+        let selected = session_state
+            .selected_index
+            .min(items.len().saturating_sub(1));
+        let picker_state = PickerState::new("Load Session", items.clone(), selected);
+        let session = PickerSession {
+            state: picker_state,
+            data: PickerData::SessionLoad(SessionPickerState {
+                sessions: session_state.sessions,
+                selected_index: session_state.selected_index,
+                search_filter: String::new(),
+                all_items: items,
+            }),
+        };
+        self.start_picker_session(session, None);
     }
 
     fn start_picker_session(
@@ -1360,7 +1395,8 @@ mod tests {
         assert!(size_of::<ModelPickerState>() > small_inline);
         assert!(size_of::<ProviderPickerState>() > small_inline);
         assert!(size_of::<ThemePickerState>() > small_inline);
-        assert!(size_of::<PickerData>() < size_of::<ModelPickerState>());
+        // PickerData should still be reasonably compact (enum with large variants)
+        assert!(size_of::<PickerData>() < size_of::<ModelPickerState>() + size_of::<usize>());
     }
 
     #[test]

--- a/src/core/app/picker/mod.rs
+++ b/src/core/app/picker/mod.rs
@@ -353,16 +353,18 @@ impl PickerController {
     }
 
     /// Start a session load picker with the given sessions and items.
-    pub fn start_picker(&mut self, session_state: SessionPickerState, items: Vec<PickerItem>) {
-        let selected = session_state
-            .selected_index
-            .min(items.len().saturating_sub(1));
+    pub fn open_session_picker(
+        &mut self,
+        sessions: Vec<crate::core::session_store::SessionSummary>,
+        items: Vec<PickerItem>,
+    ) {
+        let selected = 0;
         let picker_state = PickerState::new("Load Session", items.clone(), selected);
         let session = PickerSession {
             state: picker_state,
             data: PickerData::SessionLoad(SessionPickerState {
-                sessions: session_state.sessions,
-                selected_index: session_state.selected_index,
+                sessions,
+                selected_index: selected,
                 search_filter: String::new(),
                 all_items: items,
             }),
@@ -938,6 +940,10 @@ impl PickerController {
         self.filter_session_items(PickerMode::Preset, &[TURN_OFF_PRESET_ID]);
     }
 
+    pub fn filter_sessions(&mut self) {
+        self.filter_session_items(PickerMode::SessionLoad, &[]);
+    }
+
     pub fn open_character_picker(
         &mut self,
         cards: Vec<CharacterCard>,
@@ -1385,6 +1391,50 @@ mod tests {
         assert_eq!(session.state.items.len(), 2);
         assert_eq!(session.state.items[0].id, TURN_OFF_PRESET_ID);
         assert!(session.state.items.iter().any(|item| item.id == "focus"));
+    }
+
+    #[test]
+    fn test_filter_sessions_updates_rendered_items_from_source_list() {
+        let mut controller = PickerController::new();
+        let items = vec![
+            picker_item("sess-alpha", "Alpha Session", Some("openai | gpt-4")),
+            picker_item("sess-beta", "Beta Session", Some("anthropic | claude")),
+            picker_item("sess-gamma", "Gamma Session", Some("local | llama")),
+        ];
+
+        let mut picker_state = PickerState::new("Load Session", items.clone(), 2);
+        picker_state.sort_mode = SortMode::Name;
+
+        let mut session = PickerSession {
+            state: picker_state,
+            data: PickerData::SessionLoad(SessionPickerState {
+                sessions: Vec::new(),
+                selected_index: 2,
+                search_filter: "claude".to_string(),
+                all_items: items,
+            }),
+        };
+        session.state.sort_mode = session.default_sort_mode();
+
+        controller.picker_session = Some(session);
+        controller.filter_sessions();
+
+        let session = controller.session().expect("session load picker");
+        assert_eq!(session.state.selected, 0);
+        assert_eq!(session.state.items.len(), 1);
+        assert_eq!(session.state.items[0].id, "sess-beta");
+
+        let session = controller.session_mut().expect("session load picker");
+        session
+            .session_load_state_mut()
+            .expect("session load state")
+            .search_filter
+            .clear();
+
+        controller.filter_sessions();
+
+        let session = controller.session().expect("session load picker");
+        assert_eq!(session.state.items.len(), 3);
     }
 
     #[test]

--- a/src/core/app/picker/mod.rs
+++ b/src/core/app/picker/mod.rs
@@ -1,16 +1,16 @@
 //! Picker domain state and reducers for selectable configuration surfaces.
 //!
 //! # Ownership boundary
-//! This module owns picker-session state (`PickerSession`, filtered items,
+//! This module owns active picker state (`ActivePicker`, filtered items,
 //! selection, inspect metadata) and picker transition bookkeeping used by the
 //! app shell. It delegates rendering to `ui::picker` and delegates event routing
 //! to `core::app::actions::picker`.
 //!
 //! # Main structures and invariants
-//! - [`PickerController`] stores at most one active picker session.
+//! - [`PickerController`] stores at most one active picker.
 //! - [`PickerData`] carries mode-specific backing data and preserves the
 //!   unfiltered item list for search.
-//! - Session sort/filter/title fields are updated together via helper reducers.
+//! - Picker sort/filter/title fields are updated together via helper reducers.
 //!
 //! # Call flow entrypoints
 //! Picker actions from the event loop call methods on [`PickerController`]
@@ -88,7 +88,7 @@ pub enum PickerMode {
     Character,
     Persona,
     Preset,
-    SessionLoad,
+    SavedSession,
 }
 
 #[derive(Debug, Clone)]
@@ -132,9 +132,9 @@ pub struct PresetPickerState {
     pub all_items: Vec<PickerItem>,
 }
 
-/// State for the session load picker.
+/// State for the saved-session picker.
 #[derive(Debug, Clone)]
-pub struct SessionPickerState {
+pub struct SavedSessionPickerState {
     pub sessions: Vec<crate::core::session_store::SessionSummary>,
     pub selected_index: usize,
     pub search_filter: String,
@@ -149,7 +149,7 @@ pub enum PickerData {
     Character(CharacterPickerState),
     Persona(PersonaPickerState),
     Preset(PresetPickerState),
-    SessionLoad(SessionPickerState),
+    SavedSession(SavedSessionPickerState),
 }
 
 impl PickerData {
@@ -161,7 +161,7 @@ impl PickerData {
             PickerData::Character(_) => PickerMode::Character,
             PickerData::Persona(_) => PickerMode::Persona,
             PickerData::Preset(_) => PickerMode::Preset,
-            PickerData::SessionLoad(_) => PickerMode::SessionLoad,
+            PickerData::SavedSession(_) => PickerMode::SavedSession,
         }
     }
 
@@ -173,7 +173,7 @@ impl PickerData {
             | PickerData::Character(_)
             | PickerData::Persona(_)
             | PickerData::Preset(_)
-            | PickerData::SessionLoad(_) => true,
+            | PickerData::SavedSession(_) => true,
         }
     }
 
@@ -192,7 +192,7 @@ impl PickerData {
             PickerMode::Character => "Pick Character",
             PickerMode::Persona => "Pick Persona",
             PickerMode::Preset => "Pick Preset",
-            PickerMode::SessionLoad => "Load Session",
+            PickerMode::SavedSession => "Load Session",
         }
     }
 
@@ -204,7 +204,7 @@ impl PickerData {
             PickerData::Character(state) => &state.search_filter,
             PickerData::Persona(state) => &state.search_filter,
             PickerData::Preset(state) => &state.search_filter,
-            PickerData::SessionLoad(state) => &state.search_filter,
+            PickerData::SavedSession(state) => &state.search_filter,
         }
     }
 
@@ -216,13 +216,13 @@ impl PickerData {
             PickerData::Character(state) => &state.all_items,
             PickerData::Persona(state) => &state.all_items,
             PickerData::Preset(state) => &state.all_items,
-            PickerData::SessionLoad(state) => &state.all_items,
+            PickerData::SavedSession(state) => &state.all_items,
         }
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct PickerSession {
+pub struct ActivePicker {
     pub state: PickerState,
     pub data: PickerData,
 }
@@ -249,7 +249,7 @@ macro_rules! picker_state_accessors {
             )+
         }
 
-        impl PickerSession {
+        impl ActivePicker {
             $(
                 pub fn $getter(&self) -> Option<&$state> {
                     self.data.$getter()
@@ -263,7 +263,7 @@ macro_rules! picker_state_accessors {
     };
 }
 
-impl PickerSession {
+impl ActivePicker {
     pub fn mode(&self) -> PickerMode {
         self.data.mode()
     }
@@ -304,11 +304,11 @@ picker_state_accessors! {
     (Character, character_state, character_state_mut, CharacterPickerState),
     (Persona, persona_state, persona_state_mut, PersonaPickerState),
     (Preset, preset_state, preset_state_mut, PresetPickerState),
-    (SessionLoad, session_load_state, session_load_state_mut, SessionPickerState),
+    (SavedSession, saved_session_state, saved_session_state_mut, SavedSessionPickerState),
 }
 
 pub struct PickerController {
-    pub picker_session: Option<PickerSession>,
+    pub active_picker: Option<ActivePicker>,
     pub in_provider_model_transition: bool,
     pub provider_model_transition_state: Option<(String, String, String, String, String)>,
     pub startup_requires_provider: bool,
@@ -319,7 +319,7 @@ pub struct PickerController {
 impl PickerController {
     pub(crate) fn new() -> Self {
         Self {
-            picker_session: None,
+            active_picker: None,
             in_provider_model_transition: false,
             provider_model_transition_state: None,
             startup_requires_provider: false,
@@ -328,64 +328,64 @@ impl PickerController {
         }
     }
 
-    pub fn session(&self) -> Option<&PickerSession> {
-        self.picker_session.as_ref()
+    pub fn active(&self) -> Option<&ActivePicker> {
+        self.active_picker.as_ref()
     }
 
-    pub fn session_mut(&mut self) -> Option<&mut PickerSession> {
-        self.picker_session.as_mut()
+    pub fn active_mut(&mut self) -> Option<&mut ActivePicker> {
+        self.active_picker.as_mut()
     }
 
     pub fn current_mode(&self) -> Option<PickerMode> {
-        self.session().map(PickerSession::mode)
+        self.active().map(ActivePicker::mode)
     }
 
     pub fn state(&self) -> Option<&PickerState> {
-        self.session().map(|session| &session.state)
+        self.active().map(|session| &session.state)
     }
 
     pub fn state_mut(&mut self) -> Option<&mut PickerState> {
-        self.session_mut().map(|session| &mut session.state)
+        self.active_mut().map(|session| &mut session.state)
     }
 
     pub fn close(&mut self) {
-        self.picker_session = None;
+        self.active_picker = None;
     }
 
-    /// Start a session load picker with the given sessions and items.
-    pub fn open_session_picker(
+    /// Start a picker for saved chat sessions.
+    pub fn open_saved_session_picker(
         &mut self,
         sessions: Vec<crate::core::session_store::SessionSummary>,
         items: Vec<PickerItem>,
     ) {
         let selected = 0;
         let picker_state = PickerState::new("Load Session", items.clone(), selected);
-        let session = PickerSession {
+        let active_picker = ActivePicker {
             state: picker_state,
-            data: PickerData::SessionLoad(SessionPickerState {
+            data: PickerData::SavedSession(SavedSessionPickerState {
                 sessions,
                 selected_index: selected,
                 search_filter: String::new(),
                 all_items: items,
             }),
         };
-        self.start_picker_session(session, None);
+        self.start_active_picker(active_picker, None);
     }
 
-    fn start_picker_session(
+    fn start_active_picker(
         &mut self,
-        mut session: PickerSession,
+        mut active_picker: ActivePicker,
         preferred_selection: Option<String>,
     ) {
-        let mode = session.mode();
-        session.state.sort_mode = session.default_sort_mode();
-        self.picker_session = Some(session);
+        let mode = active_picker.mode();
+        active_picker.state.sort_mode = active_picker.default_sort_mode();
+        self.active_picker = Some(active_picker);
 
         self.sort_items();
         self.update_title();
 
         if let Some(preferred) = preferred_selection {
-            if let Some(session) = self.session_mut() {
+            if let Some(session) = self.active_mut() {
                 if let Some((idx, _)) =
                     session
                         .state
@@ -469,7 +469,7 @@ impl PickerController {
         }
 
         let picker_state = PickerState::new("Pick Theme", items.clone(), selected);
-        let session = PickerSession {
+        let session = ActivePicker {
             state: picker_state,
             data: PickerData::Theme(Box::new(ThemePickerState {
                 search_filter: String::new(),
@@ -479,7 +479,7 @@ impl PickerController {
             })),
         };
 
-        self.start_picker_session(session, active_theme_id);
+        self.start_active_picker(session, active_theme_id);
         Ok(())
     }
 
@@ -595,7 +595,7 @@ impl PickerController {
         }
 
         let picker_state = PickerState::new("Pick Model", items.clone(), selected);
-        let session = PickerSession {
+        let session = ActivePicker {
             state: picker_state,
             data: PickerData::Model(Box::new(ModelPickerState {
                 search_filter: String::new(),
@@ -605,13 +605,13 @@ impl PickerController {
             })),
         };
 
-        self.start_picker_session(session, Some(session_context.model.clone()));
+        self.start_active_picker(session, Some(session_context.model.clone()));
 
         Ok(())
     }
 
     fn filter_session_items(&mut self, expected_mode: PickerMode, special_ids: &[&str]) {
-        let Some(session) = self.session_mut() else {
+        let Some(session) = self.active_mut() else {
             return;
         };
 
@@ -663,11 +663,11 @@ impl PickerController {
 
     pub fn revert_model_preview(&mut self, session: &mut SessionContext) {
         let previous_model = self
-            .session()
-            .and_then(PickerSession::model_state)
+            .active()
+            .and_then(ActivePicker::model_state)
             .and_then(|state| state.before_model.clone());
 
-        if let Some(session) = self.session_mut() {
+        if let Some(session) = self.active_mut() {
             if let Some(state) = session.model_state_mut() {
                 state.before_model = None;
                 state.search_filter.clear();
@@ -687,11 +687,11 @@ impl PickerController {
 
     pub fn revert_provider_preview(&mut self, session: &mut SessionContext) {
         let previous_provider = self
-            .session()
-            .and_then(PickerSession::provider_state)
+            .active()
+            .and_then(ActivePicker::provider_state)
             .and_then(|state| state.before_provider.clone());
 
-        if let Some(session) = self.session_mut() {
+        if let Some(session) = self.active_mut() {
             if let Some(state) = session.provider_state_mut() {
                 state.before_provider = None;
                 state.search_filter.clear();
@@ -732,7 +732,7 @@ impl PickerController {
 
     pub fn sort_items(&mut self) {
         let prefers_alpha = self.prefers_alphabetical();
-        if let Some(session) = self.session_mut() {
+        if let Some(session) = self.active_mut() {
             let picker = &mut session.state;
 
             // Extract special entries (like "turn off character mode") that should stay at top
@@ -787,7 +787,7 @@ impl PickerController {
     }
 
     pub fn update_title(&mut self) {
-        let Some(session) = self.session_mut() else {
+        let Some(session) = self.active_mut() else {
             return;
         };
 
@@ -911,7 +911,7 @@ impl PickerController {
         }
 
         let picker_state = PickerState::new("Pick Provider", items.clone(), selected);
-        let session = PickerSession {
+        let session = ActivePicker {
             state: picker_state,
             data: PickerData::Provider(Box::new(ProviderPickerState {
                 search_filter: String::new(),
@@ -923,7 +923,7 @@ impl PickerController {
             })),
         };
 
-        self.start_picker_session(session, Some(session_context.provider_name.clone()));
+        self.start_active_picker(session, Some(session_context.provider_name.clone()));
 
         Ok(())
     }
@@ -940,8 +940,8 @@ impl PickerController {
         self.filter_session_items(PickerMode::Preset, &[TURN_OFF_PRESET_ID]);
     }
 
-    pub fn filter_sessions(&mut self) {
-        self.filter_session_items(PickerMode::SessionLoad, &[]);
+    pub fn filter_saved_sessions(&mut self) {
+        self.filter_session_items(PickerMode::SavedSession, &[]);
     }
 
     pub fn open_character_picker(
@@ -1013,7 +1013,7 @@ impl PickerController {
             .and_then(|active_id| items.iter().position(|item| item.id == active_id))
             .unwrap_or(0);
         let picker_state = PickerState::new("Pick Character", items.clone(), selected);
-        let session = PickerSession {
+        let session = ActivePicker {
             state: picker_state,
             data: PickerData::Character(CharacterPickerState {
                 search_filter: String::new(),
@@ -1021,7 +1021,7 @@ impl PickerController {
             }),
         };
 
-        self.start_picker_session(session, active_character_id);
+        self.start_active_picker(session, active_character_id);
 
         Ok(())
     }
@@ -1113,7 +1113,7 @@ impl PickerController {
             .and_then(|active_id| items.iter().position(|item| item.id == active_id))
             .unwrap_or(0);
         let picker_state = PickerState::new("Pick Persona", items.clone(), selected);
-        let session = PickerSession {
+        let session = ActivePicker {
             state: picker_state,
             data: PickerData::Persona(PersonaPickerState {
                 search_filter: String::new(),
@@ -1121,7 +1121,7 @@ impl PickerController {
             }),
         };
 
-        self.start_picker_session(session, active_persona_id);
+        self.start_active_picker(session, active_persona_id);
 
         Ok(())
     }
@@ -1214,7 +1214,7 @@ impl PickerController {
             .and_then(|active_id| items.iter().position(|item| item.id == active_id))
             .unwrap_or(0);
         let picker_state = PickerState::new("Pick Preset", items.clone(), selected);
-        let session = PickerSession {
+        let session = ActivePicker {
             state: picker_state,
             data: PickerData::Preset(PresetPickerState {
                 search_filter: String::new(),
@@ -1222,13 +1222,13 @@ impl PickerController {
             }),
         };
 
-        self.start_picker_session(session, active_preset_id);
+        self.start_active_picker(session, active_preset_id);
 
         Ok(())
     }
 
     fn prefers_alphabetical(&self) -> bool {
-        self.session()
+        self.active()
             .map(|session| session.prefers_alphabetical())
             .unwrap_or(false)
     }
@@ -1261,7 +1261,7 @@ mod tests {
         let mut picker_state = PickerState::new("Pick Model", items.clone(), 2);
         picker_state.sort_mode = SortMode::Name;
 
-        let mut session = PickerSession {
+        let mut session = ActivePicker {
             state: picker_state,
             data: PickerData::Model(Box::new(ModelPickerState {
                 search_filter: "GPT".to_string(),
@@ -1272,10 +1272,10 @@ mod tests {
         };
         session.state.sort_mode = session.default_sort_mode();
 
-        controller.picker_session = Some(session);
+        controller.active_picker = Some(session);
         controller.filter_models();
 
-        let session = controller.session().expect("model picker session");
+        let session = controller.active().expect("model picker session");
         assert_eq!(session.state.selected, 0);
         assert_eq!(session.state.items.len(), 2);
         let ids: Vec<&str> = session
@@ -1304,7 +1304,7 @@ mod tests {
         let mut picker_state = PickerState::new("Pick Character", items.clone(), 2);
         picker_state.sort_mode = SortMode::Name;
 
-        let mut session = PickerSession {
+        let mut session = ActivePicker {
             state: picker_state,
             data: PickerData::Character(CharacterPickerState {
                 search_filter: "GAMMA".to_string(),
@@ -1313,10 +1313,10 @@ mod tests {
         };
         session.state.sort_mode = session.default_sort_mode();
 
-        controller.picker_session = Some(session);
+        controller.active_picker = Some(session);
         controller.filter_characters();
 
-        let session = controller.session().expect("character picker session");
+        let session = controller.active().expect("character picker session");
         assert_eq!(session.state.selected, 0);
         assert_eq!(session.state.items.len(), 2);
         assert_eq!(session.state.items[0].id, TURN_OFF_CHARACTER_ID);
@@ -1339,7 +1339,7 @@ mod tests {
         let mut picker_state = PickerState::new("Pick Persona", items.clone(), 2);
         picker_state.sort_mode = SortMode::Name;
 
-        let mut session = PickerSession {
+        let mut session = ActivePicker {
             state: picker_state,
             data: PickerData::Persona(PersonaPickerState {
                 search_filter: "ADVISER".to_string(),
@@ -1348,10 +1348,10 @@ mod tests {
         };
         session.state.sort_mode = session.default_sort_mode();
 
-        controller.picker_session = Some(session);
+        controller.active_picker = Some(session);
         controller.filter_personas();
 
-        let session = controller.session().expect("persona picker session");
+        let session = controller.active().expect("persona picker session");
         assert_eq!(session.state.selected, 0);
         assert_eq!(session.state.items.len(), 2);
         assert_eq!(session.state.items[0].id, TURN_OFF_PERSONA_ID);
@@ -1374,7 +1374,7 @@ mod tests {
         let mut picker_state = PickerState::new("Pick Preset", items.clone(), 2);
         picker_state.sort_mode = SortMode::Name;
 
-        let mut session = PickerSession {
+        let mut session = ActivePicker {
             state: picker_state,
             data: PickerData::Preset(PresetPickerState {
                 search_filter: "FOCUS".to_string(),
@@ -1383,10 +1383,10 @@ mod tests {
         };
         session.state.sort_mode = session.default_sort_mode();
 
-        controller.picker_session = Some(session);
+        controller.active_picker = Some(session);
         controller.filter_presets();
 
-        let session = controller.session().expect("preset picker session");
+        let session = controller.active().expect("preset picker session");
         assert_eq!(session.state.selected, 0);
         assert_eq!(session.state.items.len(), 2);
         assert_eq!(session.state.items[0].id, TURN_OFF_PRESET_ID);
@@ -1405,9 +1405,9 @@ mod tests {
         let mut picker_state = PickerState::new("Load Session", items.clone(), 2);
         picker_state.sort_mode = SortMode::Name;
 
-        let mut session = PickerSession {
+        let mut session = ActivePicker {
             state: picker_state,
-            data: PickerData::SessionLoad(SessionPickerState {
+            data: PickerData::SavedSession(SavedSessionPickerState {
                 sessions: Vec::new(),
                 selected_index: 2,
                 search_filter: "claude".to_string(),
@@ -1416,24 +1416,24 @@ mod tests {
         };
         session.state.sort_mode = session.default_sort_mode();
 
-        controller.picker_session = Some(session);
-        controller.filter_sessions();
+        controller.active_picker = Some(session);
+        controller.filter_saved_sessions();
 
-        let session = controller.session().expect("session load picker");
+        let session = controller.active().expect("session load picker");
         assert_eq!(session.state.selected, 0);
         assert_eq!(session.state.items.len(), 1);
         assert_eq!(session.state.items[0].id, "sess-beta");
 
-        let session = controller.session_mut().expect("session load picker");
+        let session = controller.active_mut().expect("session load picker");
         session
-            .session_load_state_mut()
+            .saved_session_state_mut()
             .expect("session load state")
             .search_filter
             .clear();
 
-        controller.filter_sessions();
+        controller.filter_saved_sessions();
 
-        let session = controller.session().expect("session load picker");
+        let session = controller.active().expect("session load picker");
         assert_eq!(session.state.items.len(), 3);
     }
 
@@ -1584,7 +1584,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        let picker_items = &app.picker.session().unwrap().state.items;
+        let picker_items = &app.picker.active().unwrap().state.items;
         assert!(picker_items.len() >= 2);
         assert_eq!(picker_items[0].id, TURN_OFF_CHARACTER_ID);
         assert_eq!(picker_items[0].label, "[Turn off character mode]");
@@ -1634,7 +1634,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        let picker_items = &app.picker.session().unwrap().state.items;
+        let picker_items = &app.picker.active().unwrap().state.items;
         assert!(!picker_items
             .iter()
             .any(|item| item.id == TURN_OFF_CHARACTER_ID));
@@ -1708,12 +1708,12 @@ mod tests {
 
         assert!(result.is_ok());
 
-        let items_before_sort = app.picker.session().unwrap().state.items.len();
+        let items_before_sort = app.picker.active().unwrap().state.items.len();
         assert!(items_before_sort >= 4); // turn off + 3 characters
 
         app.picker.sort_items();
 
-        let picker_items = &app.picker.session().unwrap().state.items;
+        let picker_items = &app.picker.active().unwrap().state.items;
 
         // First item should always be the turn off entry, regardless of sort
         assert_eq!(picker_items[0].id, TURN_OFF_CHARACTER_ID);
@@ -1762,12 +1762,12 @@ mod tests {
 
         assert!(result.is_ok());
 
-        let items_before_sort = app.picker.session().unwrap().state.items.len();
+        let items_before_sort = app.picker.active().unwrap().state.items.len();
         assert!(items_before_sort >= 2);
 
         app.picker.sort_items();
 
-        let picker_items = &app.picker.session().unwrap().state.items;
+        let picker_items = &app.picker.active().unwrap().state.items;
 
         // First item should always be the turn off persona entry, regardless of sort
         assert_eq!(picker_items[0].id, TURN_OFF_PERSONA_ID);
@@ -1850,7 +1850,7 @@ mod tests {
             .open_character_picker(cards, &app.session)
             .unwrap();
 
-        let session = app.picker.session().expect("character picker session");
+        let session = app.picker.active().expect("character picker session");
         let selected_item = &session.state.items[session.state.selected];
         assert_eq!(selected_item.id, "Beta");
     }
@@ -1890,7 +1890,7 @@ mod tests {
             .open_persona_picker(&app.persona_manager, &app.session)
             .unwrap();
 
-        let session = app.picker.session().expect("persona picker session");
+        let session = app.picker.active().expect("persona picker session");
         let selected_item = &session.state.items[session.state.selected];
         assert_eq!(selected_item.id, "beta");
     }
@@ -1931,7 +1931,7 @@ mod tests {
             .open_preset_picker(&app.preset_manager, &app.session)
             .unwrap();
 
-        let session = app.picker.session().expect("preset picker session");
+        let session = app.picker.active().expect("preset picker session");
         let selected_item = &session.state.items[session.state.selected];
         assert_eq!(selected_item.id, "casual");
     }
@@ -1960,7 +1960,7 @@ mod tests {
             .open_persona_picker(&app.persona_manager, &app.session)
             .unwrap();
 
-        let picker_items = &app.picker.session().unwrap().state.items;
+        let picker_items = &app.picker.active().unwrap().state.items;
         let persona_item = picker_items
             .iter()
             .find(|item| item.id == "neat")
@@ -1996,7 +1996,7 @@ mod tests {
             .open_persona_picker(&app.persona_manager, &app.session)
             .unwrap();
 
-        let picker_items = &app.picker.session().unwrap().state.items;
+        let picker_items = &app.picker.active().unwrap().state.items;
         let persona_item = picker_items
             .iter()
             .find(|item| item.id == "blank")

--- a/src/core/app/pickers.rs
+++ b/src/core/app/pickers.rs
@@ -1,5 +1,5 @@
 use super::picker::{
-    self, CharacterPickerState, ModelPickerState, PersonaPickerState, PickerMode, PickerSession,
+    self, ActivePicker, CharacterPickerState, ModelPickerState, PersonaPickerState, PickerMode,
     PresetPickerState, ProviderPickerState, ThemePickerState,
 };
 use super::ui_state::ActivityKind;
@@ -19,13 +19,13 @@ pub struct ModelPickerRequest {
 }
 
 impl App {
-    pub fn picker_session(&self) -> Option<&PickerSession> {
-        self.picker.session()
+    pub fn active_picker(&self) -> Option<&ActivePicker> {
+        self.picker.active()
     }
 
     #[cfg(test)]
-    pub fn picker_session_mut(&mut self) -> Option<&mut PickerSession> {
-        self.picker.session_mut()
+    pub fn active_picker_mut(&mut self) -> Option<&mut ActivePicker> {
+        self.picker.active_mut()
     }
 
     pub fn current_picker_mode(&self) -> Option<PickerMode> {
@@ -41,35 +41,33 @@ impl App {
     }
 
     pub fn theme_picker_state(&self) -> Option<&ThemePickerState> {
-        self.picker.session().and_then(PickerSession::theme_state)
+        self.picker.active().and_then(ActivePicker::theme_state)
     }
 
     pub fn theme_picker_state_mut(&mut self) -> Option<&mut ThemePickerState> {
         self.picker
-            .session_mut()
-            .and_then(PickerSession::theme_state_mut)
+            .active_mut()
+            .and_then(ActivePicker::theme_state_mut)
     }
 
     pub fn model_picker_state(&self) -> Option<&ModelPickerState> {
-        self.picker.session().and_then(PickerSession::model_state)
+        self.picker.active().and_then(ActivePicker::model_state)
     }
 
     pub fn model_picker_state_mut(&mut self) -> Option<&mut ModelPickerState> {
         self.picker
-            .session_mut()
-            .and_then(PickerSession::model_state_mut)
+            .active_mut()
+            .and_then(ActivePicker::model_state_mut)
     }
 
     pub fn provider_picker_state(&self) -> Option<&ProviderPickerState> {
-        self.picker
-            .session()
-            .and_then(PickerSession::provider_state)
+        self.picker.active().and_then(ActivePicker::provider_state)
     }
 
     pub fn provider_picker_state_mut(&mut self) -> Option<&mut ProviderPickerState> {
         self.picker
-            .session_mut()
-            .and_then(PickerSession::provider_state_mut)
+            .active_mut()
+            .and_then(ActivePicker::provider_state_mut)
     }
 
     pub fn close_picker(&mut self) {
@@ -241,7 +239,7 @@ impl App {
     pub fn apply_selected_character(&mut self, set_as_default: bool) {
         let character_name = self
             .picker
-            .session()
+            .active()
             .and_then(|picker| picker.state.selected_id())
             .map(|s| s.to_string());
 
@@ -317,7 +315,7 @@ impl App {
     pub fn apply_selected_persona(&mut self, set_as_default: bool) {
         let persona_id = self
             .picker
-            .session()
+            .active()
             .and_then(|picker| picker.state.selected_id())
             .map(|s| s.to_string());
 
@@ -400,7 +398,7 @@ impl App {
     pub fn apply_selected_preset(&mut self, set_as_default: bool) {
         let preset_id = self
             .picker
-            .session()
+            .active()
             .and_then(|picker| picker.state.selected_id())
             .map(|s| s.to_string());
 
@@ -458,62 +456,60 @@ impl App {
 
     /// Get character picker state accessor
     pub fn character_picker_state(&self) -> Option<&CharacterPickerState> {
-        self.picker
-            .session()
-            .and_then(PickerSession::character_state)
+        self.picker.active().and_then(ActivePicker::character_state)
     }
 
     /// Get mutable character picker state accessor
     pub fn character_picker_state_mut(&mut self) -> Option<&mut CharacterPickerState> {
         self.picker
-            .session_mut()
-            .and_then(PickerSession::character_state_mut)
+            .active_mut()
+            .and_then(ActivePicker::character_state_mut)
     }
 
     /// Get persona picker state accessor
     pub fn persona_picker_state(&self) -> Option<&PersonaPickerState> {
-        self.picker.session().and_then(PickerSession::persona_state)
+        self.picker.active().and_then(ActivePicker::persona_state)
     }
 
     /// Get mutable persona picker state accessor
     pub fn persona_picker_state_mut(&mut self) -> Option<&mut PersonaPickerState> {
         self.picker
-            .session_mut()
-            .and_then(PickerSession::persona_state_mut)
+            .active_mut()
+            .and_then(ActivePicker::persona_state_mut)
     }
 
     /// Get preset picker state accessor
     pub fn preset_picker_state(&self) -> Option<&PresetPickerState> {
-        self.picker.session().and_then(PickerSession::preset_state)
+        self.picker.active().and_then(ActivePicker::preset_state)
     }
 
     /// Get mutable preset picker state accessor
     pub fn preset_picker_state_mut(&mut self) -> Option<&mut PresetPickerState> {
         self.picker
-            .session_mut()
-            .and_then(PickerSession::preset_state_mut)
+            .active_mut()
+            .and_then(ActivePicker::preset_state_mut)
     }
 
-    /// Get session load picker state accessor
-    pub fn session_load_picker_state(
+    /// Get saved-session picker state accessor
+    pub fn saved_session_picker_state(
         &self,
-    ) -> Option<&crate::core::app::picker::SessionPickerState> {
+    ) -> Option<&crate::core::app::picker::SavedSessionPickerState> {
         self.picker
-            .session()
-            .and_then(PickerSession::session_load_state)
+            .active()
+            .and_then(ActivePicker::saved_session_state)
     }
 
-    /// Get mutable session load picker state accessor
-    pub fn session_load_picker_state_mut(
+    /// Get mutable saved-session picker state accessor
+    pub fn saved_session_picker_state_mut(
         &mut self,
-    ) -> Option<&mut crate::core::app::picker::SessionPickerState> {
+    ) -> Option<&mut crate::core::app::picker::SavedSessionPickerState> {
         self.picker
-            .session_mut()
-            .and_then(PickerSession::session_load_state_mut)
+            .active_mut()
+            .and_then(ActivePicker::saved_session_state_mut)
     }
 
-    /// Filter sessions based on search term and update picker
-    pub fn filter_sessions(&mut self) {
-        self.picker.filter_sessions();
+    /// Filter saved sessions based on search term and update picker
+    pub fn filter_saved_sessions(&mut self) {
+        self.picker.filter_saved_sessions();
     }
 }

--- a/src/core/app/pickers.rs
+++ b/src/core/app/pickers.rs
@@ -493,4 +493,40 @@ impl App {
             .session_mut()
             .and_then(PickerSession::preset_state_mut)
     }
+
+    /// Get session load picker state accessor
+    pub fn session_load_picker_state(
+        &self,
+    ) -> Option<&crate::core::app::picker::SessionPickerState> {
+        self.picker
+            .session()
+            .and_then(PickerSession::session_load_state)
+    }
+
+    /// Get mutable session load picker state accessor
+    pub fn session_load_picker_state_mut(
+        &mut self,
+    ) -> Option<&mut crate::core::app::picker::SessionPickerState> {
+        self.picker
+            .session_mut()
+            .and_then(PickerSession::session_load_state_mut)
+    }
+
+    /// Filter sessions based on search term and update picker
+    pub fn filter_sessions(&mut self) {
+        if let Some(state) = self.session_load_picker_state_mut() {
+            let filter = state.search_filter.to_lowercase();
+            state.all_items.retain(|item| {
+                item.label.to_lowercase().contains(&filter)
+                    || item
+                        .metadata
+                        .as_ref()
+                        .map(|m| m.to_lowercase().contains(&filter))
+                        .unwrap_or(false)
+            });
+            if state.selected_index >= state.all_items.len() {
+                state.selected_index = state.all_items.len().saturating_sub(1);
+            }
+        }
+    }
 }

--- a/src/core/app/pickers.rs
+++ b/src/core/app/pickers.rs
@@ -514,19 +514,6 @@ impl App {
 
     /// Filter sessions based on search term and update picker
     pub fn filter_sessions(&mut self) {
-        if let Some(state) = self.session_load_picker_state_mut() {
-            let filter = state.search_filter.to_lowercase();
-            state.all_items.retain(|item| {
-                item.label.to_lowercase().contains(&filter)
-                    || item
-                        .metadata
-                        .as_ref()
-                        .map(|m| m.to_lowercase().contains(&filter))
-                        .unwrap_or(false)
-            });
-            if state.selected_index >= state.all_items.len() {
-                state.selected_index = state.all_items.len().saturating_sub(1);
-            }
-        }
+        self.picker.filter_sessions();
     }
 }

--- a/src/core/app/session.rs
+++ b/src/core/app/session.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 
 use reqwest::Client;
 use rust_mcp_schema::CreateMessageRequest;
+use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
 use crate::api::{ChatMessage, ChatToolCall};
@@ -31,6 +32,15 @@ use crate::ui::theme::Theme;
 use crate::utils::color::quantize_theme_for_current_terminal;
 use crate::utils::logging::LoggingState;
 use crate::utils::url::construct_api_url;
+
+/// Generate a new session ID using a hex-encoded random value.
+fn generate_session_id() -> String {
+    let mut bytes = [0u8; 16];
+    getrandom::fill(&mut bytes).unwrap_or_else(|_| {
+        bytes.copy_from_slice(b"0000000000000000");
+    });
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
 
 pub struct SessionContext {
     pub client: Client,
@@ -59,6 +69,8 @@ pub struct SessionContext {
     pub active_assistant_message_index: Option<usize>,
     pub mcp_tools_enabled: bool,
     pub mcp_tools_unsupported: bool,
+    /// UUID for the current conversation session. Used for save/load operations.
+    pub session_id: String,
 }
 
 #[derive(Default, Clone)]
@@ -81,7 +93,7 @@ pub struct StreamContinuation {
     pub api_messages_base: Vec<ChatMessage>,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct McpInitState {
     pub in_progress: bool,
     pub complete: bool,
@@ -95,7 +107,7 @@ pub struct PendingToolCall {
     pub arguments: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ToolResultStatus {
     Success,
     Error,
@@ -288,6 +300,7 @@ impl SessionContext {
             active_assistant_message_index: None,
             mcp_tools_enabled: false,
             mcp_tools_unsupported: false,
+            session_id: String::new(),
         }
     }
 }
@@ -606,6 +619,7 @@ pub(crate) async fn prepare_with_auth(
         active_assistant_message_index: None,
         mcp_tools_enabled: false,
         mcp_tools_unsupported: false,
+        session_id: generate_session_id(),
     };
 
     Ok(SessionBootstrap {
@@ -652,6 +666,7 @@ pub(crate) async fn prepare_uninitialized(
         active_assistant_message_index: None,
         mcp_tools_enabled: false,
         mcp_tools_unsupported: false,
+        session_id: generate_session_id(),
     };
 
     Ok(UninitializedSessionBootstrap {
@@ -941,6 +956,7 @@ mod tests {
             active_assistant_message_index: None,
             mcp_tools_enabled: false,
             mcp_tools_unsupported: false,
+            session_id: String::new(),
         };
 
         let card = CharacterCard {
@@ -1018,6 +1034,7 @@ mod tests {
             active_assistant_message_index: None,
             mcp_tools_enabled: false,
             mcp_tools_unsupported: false,
+            session_id: String::new(),
         };
 
         session.clear_character();
@@ -1074,6 +1091,7 @@ mod tests {
             active_assistant_message_index: None,
             mcp_tools_enabled: false,
             mcp_tools_unsupported: false,
+            session_id: String::new(),
         };
 
         // Should show greeting when character is active and greeting not shown
@@ -1133,6 +1151,7 @@ mod tests {
             active_assistant_message_index: None,
             mcp_tools_enabled: false,
             mcp_tools_unsupported: false,
+            session_id: String::new(),
         };
 
         // Should not show empty/whitespace greeting
@@ -1346,6 +1365,7 @@ mod tests {
             active_assistant_message_index: None,
             mcp_tools_enabled: false,
             mcp_tools_unsupported: false,
+            session_id: String::new(),
         };
 
         assert!(session.get_character().is_none());
@@ -1383,6 +1403,7 @@ mod tests {
             active_assistant_message_index: None,
             mcp_tools_enabled: false,
             mcp_tools_unsupported: false,
+            session_id: String::new(),
         };
 
         // Initially no greeting
@@ -1458,6 +1479,7 @@ mod tests {
             active_assistant_message_index: None,
             mcp_tools_enabled: false,
             mcp_tools_unsupported: false,
+            session_id: String::new(),
         };
 
         let card = CharacterCard {
@@ -1525,6 +1547,7 @@ mod tests {
             active_assistant_message_index: None,
             mcp_tools_enabled: false,
             mcp_tools_unsupported: false,
+            session_id: String::new(),
         };
 
         let card1 = CharacterCard {

--- a/src/core/app/settings.rs
+++ b/src/core/app/settings.rs
@@ -42,7 +42,7 @@ impl<'a> ThemeController<'a> {
         })
         .map_err(|e| e.to_string())?;
 
-        if let Some(session) = self.picker.session_mut() {
+        if let Some(session) = self.picker.active_mut() {
             if let Some(state) = session.theme_state_mut() {
                 state.before_theme = None;
                 state.before_theme_id = None;
@@ -58,7 +58,7 @@ impl<'a> ThemeController<'a> {
         self.apply_theme(theme);
         self.ui.current_theme_id = Some(id.to_string());
 
-        if let Some(session) = self.picker.session_mut() {
+        if let Some(session) = self.picker.active_mut() {
             if let Some(state) = session.theme_state_mut() {
                 state.before_theme = None;
                 state.before_theme_id = None;
@@ -79,11 +79,11 @@ impl<'a> ThemeController<'a> {
     pub fn revert_theme_preview(&mut self) {
         let previous_theme = self
             .picker
-            .session()
+            .active()
             .and_then(|session| session.theme_state())
             .and_then(|state| state.before_theme.clone());
 
-        if let Some(session) = self.picker.session_mut() {
+        if let Some(session) = self.picker.active_mut() {
             if let Some(state) = session.theme_state_mut() {
                 state.before_theme = None;
                 state.before_theme_id = None;
@@ -121,7 +121,7 @@ impl<'a> ProviderController<'a> {
         self.session.model = model_id.to_string();
         self.session.mcp_tools_unsupported = false;
         self.session.mcp_tools_enabled = false;
-        if let Some(session) = self.picker.session_mut() {
+        if let Some(session) = self.picker.active_mut() {
             if let Some(state) = session.model_state_mut() {
                 state.before_model = None;
             }
@@ -150,7 +150,7 @@ impl<'a> ProviderController<'a> {
             self.picker.in_provider_model_transition = false;
             self.picker.provider_model_transition_state = None;
 
-            if let Some(session) = self.picker.session_mut() {
+            if let Some(session) = self.picker.active_mut() {
                 if let Some(state) = session.provider_state_mut() {
                     state.before_provider = None;
                 }
@@ -197,7 +197,7 @@ impl<'a> ProviderController<'a> {
                         true
                     };
 
-                if let Some(session) = self.picker.session_mut() {
+                if let Some(session) = self.picker.active_mut() {
                     if let Some(state) = session.provider_state_mut() {
                         state.before_provider = None;
                     }
@@ -249,7 +249,7 @@ impl<'a> ProviderController<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::app::picker::{PickerData, PickerSession, ProviderPickerState};
+    use crate::core::app::picker::{ActivePicker, PickerData, ProviderPickerState};
     use crate::ui::picker::{PickerItem, PickerState};
     use crate::utils::test_utils::create_test_app;
 
@@ -317,7 +317,7 @@ mod tests {
             sort_key: None,
         }];
 
-        app.picker.picker_session = Some(PickerSession {
+        app.picker.active_picker = Some(ActivePicker {
             state: PickerState::new("Pick Provider", items.clone(), 0),
             data: PickerData::Provider(Box::new(ProviderPickerState {
                 search_filter: String::new(),
@@ -340,7 +340,7 @@ mod tests {
 
         let provider_state = app
             .picker
-            .session()
+            .active()
             .and_then(|session| session.provider_state())
             .expect("provider picker state should exist");
         assert!(provider_state.before_provider.is_none());

--- a/src/core/app/tests.rs
+++ b/src/core/app/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::api::{ChatMessage, ChatToolCall, ChatToolCallFunction};
 use crate::core::app::picker::{
-    ModelPickerState, PickerData, PickerSession, ProviderPickerState, ThemePickerState,
+    ActivePicker, ModelPickerState, PickerData, ProviderPickerState, ThemePickerState,
 };
 use crate::core::app::session::{
     PendingToolCall, StreamContinuation, ToolCallRequest, ToolPayloadHistoryEntry,
@@ -65,7 +65,7 @@ fn model_picker_title_uses_az_when_no_dates() {
     ];
     let mut picker_state = PickerState::new("Pick Model", items.clone(), 0);
     picker_state.sort_mode = crate::ui::picker::SortMode::Name;
-    app.picker.picker_session = Some(PickerSession {
+    app.picker.active_picker = Some(ActivePicker {
         state: picker_state,
         data: PickerData::Model(Box::new(ModelPickerState {
             search_filter: String::new(),
@@ -309,7 +309,7 @@ fn start_new_stream_preserves_tool_history_and_clears_transient_state() {
 fn default_sort_mode_helper_behaviour() {
     let mut app = create_test_app();
     // Theme picker prefers alphabetical → Name
-    app.picker.picker_session = Some(PickerSession {
+    app.picker.active_picker = Some(ActivePicker {
         state: PickerState::new("Pick Theme", vec![], 0),
         data: PickerData::Theme(Box::new(ThemePickerState {
             search_filter: String::new(),
@@ -319,11 +319,11 @@ fn default_sort_mode_helper_behaviour() {
         })),
     });
     assert!(matches!(
-        app.picker_session().unwrap().default_sort_mode(),
+        app.active_picker().unwrap().default_sort_mode(),
         crate::ui::picker::SortMode::Name
     ));
     // Provider picker prefers alphabetical → Name
-    app.picker.picker_session = Some(PickerSession {
+    app.picker.active_picker = Some(ActivePicker {
         state: PickerState::new("Pick Provider", vec![], 0),
         data: PickerData::Provider(Box::new(ProviderPickerState {
             search_filter: String::new(),
@@ -332,11 +332,11 @@ fn default_sort_mode_helper_behaviour() {
         })),
     });
     assert!(matches!(
-        app.picker_session().unwrap().default_sort_mode(),
+        app.active_picker().unwrap().default_sort_mode(),
         crate::ui::picker::SortMode::Name
     ));
     // Model picker with dates → Date
-    app.picker.picker_session = Some(PickerSession {
+    app.picker.active_picker = Some(ActivePicker {
         state: PickerState::new("Pick Model", vec![], 0),
         data: PickerData::Model(Box::new(ModelPickerState {
             search_filter: String::new(),
@@ -346,19 +346,19 @@ fn default_sort_mode_helper_behaviour() {
         })),
     });
     assert!(matches!(
-        app.picker_session().unwrap().default_sort_mode(),
+        app.active_picker().unwrap().default_sort_mode(),
         crate::ui::picker::SortMode::Date
     ));
     // Model picker without dates → Name
-    if let Some(PickerSession {
+    if let Some(ActivePicker {
         data: PickerData::Model(state),
         ..
-    }) = app.picker_session_mut()
+    }) = app.active_picker_mut()
     {
         state.has_dates = false;
     }
     assert!(matches!(
-        app.picker_session().unwrap().default_sort_mode(),
+        app.active_picker().unwrap().default_sort_mode(),
         crate::ui::picker::SortMode::Name
     ));
 }
@@ -1830,7 +1830,7 @@ fn test_turn_off_character_mode_from_picker() {
     app.session.set_character(character);
     assert!(app.session.active_character.is_some());
 
-    app.picker.picker_session = Some(picker::PickerSession {
+    app.picker.active_picker = Some(picker::ActivePicker {
         state: PickerState::new(
             "Pick Character",
             vec![PickerItem {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,5 +33,6 @@ pub mod persona;
 pub mod persona_integration_tests;
 pub mod preset;
 pub mod providers;
+pub mod session_store;
 mod shared_selection;
 pub mod text_wrapping;

--- a/src/core/session_store.rs
+++ b/src/core/session_store.rs
@@ -10,8 +10,7 @@
 use crate::api::ChatMessage;
 use crate::character::card::CharacterCard;
 use crate::core::app::session::{
-    McpInitState, ToolPayloadHistoryEntry, ToolPipelineState,
-    ToolResultStatus,
+    McpInitState, ToolPayloadHistoryEntry, ToolPipelineState, ToolResultStatus,
 };
 use crate::core::config::data::{Persona, Preset};
 use crate::core::message::Message;
@@ -354,7 +353,7 @@ fn session_dir() -> Result<PathBuf, SessionError> {
     } else {
         let proj_dirs = directories::BaseDirs::new().ok_or_else(|| SessionError::CreateDir {
             path: PathBuf::new(),
-            source: std::io::Error::new(std::io::ErrorKind::Other, "no user home directory"),
+            source: std::io::Error::other("no user home directory"),
         })?;
         proj_dirs.data_local_dir().join("chabeau").join("sessions")
     };
@@ -379,6 +378,7 @@ fn session_path(id: &str) -> Result<PathBuf, SessionError> {
 ///
 /// Captures the conversation transcript, tool results, and session context
 /// (provider, model, character, persona, preset). API keys are not included.
+#[allow(clippy::too_many_arguments)]
 pub fn save_session(
     session_id: &str,
     name: &str,
@@ -446,7 +446,7 @@ pub fn save_session(
         })?;
     temp.persist(&path).map_err(|source| SessionError::Write {
         path: path.clone(),
-        source: std::io::Error::new(std::io::ErrorKind::Other, source),
+        source: std::io::Error::other(source),
     })?;
 
     Ok(())
@@ -655,9 +655,18 @@ mod tests {
         assert_eq!(snapshot.provider, "test-provider");
         assert_eq!(snapshot.model, "test-model");
         assert_eq!(snapshot.base_url, "https://example.com/v1");
-        assert_eq!(snapshot.character.as_ref().map(|c| c.data.name.as_str()), Some("test-char"));
-        assert_eq!(snapshot.persona.as_ref().map(|p| p.id.as_str()), Some("test-persona"));
-        assert_eq!(snapshot.preset.as_ref().map(|p| p.id.as_str()), Some("test-preset"));
+        assert_eq!(
+            snapshot.character.as_ref().map(|c| c.data.name.as_str()),
+            Some("test-char")
+        );
+        assert_eq!(
+            snapshot.persona.as_ref().map(|p| p.id.as_str()),
+            Some("test-persona")
+        );
+        assert_eq!(
+            snapshot.preset.as_ref().map(|p| p.id.as_str()),
+            Some("test-preset")
+        );
         assert_eq!(snapshot.messages.len(), 3);
         assert_eq!(snapshot.messages[0].role, TranscriptRole::User);
         assert_eq!(snapshot.messages[0].content, "Hello, world!");

--- a/src/core/session_store.rs
+++ b/src/core/session_store.rs
@@ -1,0 +1,922 @@
+//! Session persistence — save and restore conversation state.
+//!
+//! Sessions are stored as JSON files under the XDG data directory
+//! (`~/.local/share/chabeau/sessions/` on Linux). Each session captures the
+//! full conversation transcript, tool results, and session context (provider,
+//! model, character, persona, preset) so the user can resume later.
+//!
+//! No authentication material (API keys) is stored in session files.
+
+use crate::api::ChatMessage;
+use crate::character::card::CharacterCard;
+use crate::core::app::session::{
+    McpInitState, ToolPayloadHistoryEntry, ToolPipelineState,
+    ToolResultStatus,
+};
+use crate::core::config::data::{Persona, Preset};
+use crate::core::message::Message;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Errors that can occur during session save/load operations.
+#[derive(Debug)]
+pub enum SessionError {
+    /// Failed to read the session directory.
+    ReadDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// Failed to read a session file.
+    ReadFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// Failed to parse a session file.
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    /// Failed to write a session file.
+    Write {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// The session directory could not be created.
+    CreateDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// The session file could not be deleted.
+    Delete {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for SessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionError::ReadDir { path, source } => {
+                write!(
+                    f,
+                    "Failed to read session dir {}: {}",
+                    path.display(),
+                    source
+                )
+            }
+            SessionError::ReadFile { path, source } => {
+                write!(
+                    f,
+                    "Failed to read session file {}: {}",
+                    path.display(),
+                    source
+                )
+            }
+            SessionError::Parse { path, source } => {
+                write!(
+                    f,
+                    "Failed to parse session file {}: {}",
+                    path.display(),
+                    source
+                )
+            }
+            SessionError::Write { path, source } => {
+                write!(
+                    f,
+                    "Failed to write session file {}: {}",
+                    path.display(),
+                    source
+                )
+            }
+            SessionError::CreateDir { path, source } => {
+                write!(
+                    f,
+                    "Failed to create session dir {}: {}",
+                    path.display(),
+                    source
+                )
+            }
+            SessionError::Delete { path, source } => {
+                write!(
+                    f,
+                    "Failed to delete session file {}: {}",
+                    path.display(),
+                    source
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SessionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SessionError::ReadDir { source, .. }
+            | SessionError::ReadFile { source, .. }
+            | SessionError::Write { source, .. }
+            | SessionError::CreateDir { source, .. }
+            | SessionError::Delete { source, .. } => Some(source),
+            SessionError::Parse { source, .. } => Some(source),
+        }
+    }
+}
+
+/// A summary of a saved session, returned by [`list_sessions`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSummary {
+    pub id: String,
+    pub name: String,
+    pub provider: String,
+    pub model: String,
+    pub character: Option<String>,
+    pub persona: Option<String>,
+    pub preset: Option<String>,
+    pub message_count: usize,
+    pub modified_at: chrono::DateTime<Utc>,
+}
+
+/// Full session snapshot — enough to reconstruct an App's conversation state.
+/// Stores full character/persona/preset data so sessions survive config changes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSnapshot {
+    pub id: String,
+    pub name: String,
+    pub provider: String,
+    pub model: String,
+    pub base_url: String,
+    pub character: Option<CharacterCard>,
+    pub persona: Option<Persona>,
+    pub preset: Option<Preset>,
+    pub messages: Vec<Message>,
+    pub tool_results: Vec<ChatMessage>,
+    pub tool_payloads: Vec<ToolPayload>,
+    pub mcp_init_complete: bool,
+    pub refine_instructions: String,
+    pub refine_prefix: String,
+    pub markdown_enabled: bool,
+    pub syntax_enabled: bool,
+    pub created_at: chrono::DateTime<Utc>,
+    pub modified_at: chrono::DateTime<Utc>,
+}
+
+/// Serializable wrapper for ToolPayloadHistoryEntry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolPayload {
+    pub server_id: Option<String>,
+    pub tool_call_id: Option<String>,
+    pub assistant_message: ChatMessage,
+    pub tool_message: ChatMessage,
+    pub assistant_message_index: Option<usize>,
+}
+
+impl From<&ToolPayloadHistoryEntry> for ToolPayload {
+    fn from(entry: &ToolPayloadHistoryEntry) -> Self {
+        Self {
+            server_id: entry.server_id.clone(),
+            tool_call_id: entry.tool_call_id.clone(),
+            assistant_message: entry.assistant_message.clone(),
+            tool_message: entry.tool_message.clone(),
+            assistant_message_index: entry.assistant_message_index,
+        }
+    }
+}
+
+/// Serializable wrapper for ToolResultRecord.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializableToolResultRecord {
+    pub tool_name: String,
+    pub server_name: Option<String>,
+    pub server_id: Option<String>,
+    pub status: ToolResultStatus,
+    pub content: String,
+    pub summary: String,
+    pub tool_call_id: Option<String>,
+    pub raw_arguments: Option<String>,
+    pub assistant_message_index: Option<usize>,
+}
+
+/// Serializable wrapper for McpSamplingRequest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializableMcpSamplingRequest {
+    pub server_id: String,
+    pub messages: Vec<ChatMessage>,
+}
+
+/// Serializable wrapper for ToolCallRequest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializableToolCallRequest {
+    pub server_id: String,
+    pub tool_name: String,
+    pub raw_arguments: String,
+}
+
+/// Serializable wrapper for PendingToolCall.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializablePendingToolCall {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub arguments: String,
+}
+
+/// Serializable wrapper for ToolPipelineState.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializableToolPipeline {
+    pub pending_tool_calls: Vec<(u32, SerializablePendingToolCall)>,
+    pub pending_tool_queue: Vec<SerializableToolCallRequest>,
+    pub active_tool_request: Option<SerializableToolCallRequest>,
+    pub pending_sampling_queue: Vec<SerializableMcpSamplingRequest>,
+    pub active_sampling_request: Option<SerializableMcpSamplingRequest>,
+    pub tool_call_records: Vec<crate::api::ChatToolCall>,
+    pub tool_results: Vec<ChatMessage>,
+    pub tool_result_history: Vec<SerializableToolResultRecord>,
+    pub tool_payload_history: Vec<ToolPayload>,
+    pub continuation_messages: Option<SerializableStreamContinuation>,
+}
+
+/// Serializable wrapper for StreamContinuation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializableStreamContinuation {
+    pub api_messages: Vec<ChatMessage>,
+    pub api_messages_base: Vec<ChatMessage>,
+}
+
+impl From<&ToolPipelineState> for SerializableToolPipeline {
+    fn from(state: &ToolPipelineState) -> Self {
+        Self {
+            pending_tool_calls: state
+                .pending_tool_calls
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        *k,
+                        SerializablePendingToolCall {
+                            id: v.id.clone(),
+                            name: v.name.clone(),
+                            arguments: v.arguments.clone(),
+                        },
+                    )
+                })
+                .collect(),
+            pending_tool_queue: state
+                .pending_tool_queue
+                .iter()
+                .map(|r| SerializableToolCallRequest {
+                    server_id: r.server_id.clone(),
+                    tool_name: r.tool_name.clone(),
+                    raw_arguments: r.raw_arguments.clone(),
+                })
+                .collect(),
+            active_tool_request: state.active_tool_request.as_ref().map(|r| {
+                SerializableToolCallRequest {
+                    server_id: r.server_id.clone(),
+                    tool_name: r.tool_name.clone(),
+                    raw_arguments: r.raw_arguments.clone(),
+                }
+            }),
+            pending_sampling_queue: state
+                .pending_sampling_queue
+                .iter()
+                .map(|r| SerializableMcpSamplingRequest {
+                    server_id: r.server_id.clone(),
+                    messages: r.messages.clone(),
+                })
+                .collect(),
+            active_sampling_request: state.active_sampling_request.as_ref().map(|r| {
+                SerializableMcpSamplingRequest {
+                    server_id: r.server_id.clone(),
+                    messages: r.messages.clone(),
+                }
+            }),
+            tool_call_records: state.tool_call_records.clone(),
+            tool_results: state.tool_results.clone(),
+            tool_result_history: state
+                .tool_result_history
+                .iter()
+                .map(|r| SerializableToolResultRecord {
+                    tool_name: r.tool_name.clone(),
+                    server_name: r.server_name.clone(),
+                    server_id: r.server_id.clone(),
+                    status: r.status,
+                    content: r.content.clone(),
+                    summary: r.summary.clone(),
+                    tool_call_id: r.tool_call_id.clone(),
+                    raw_arguments: r.raw_arguments.clone(),
+                    assistant_message_index: r.assistant_message_index,
+                })
+                .collect(),
+            tool_payload_history: state
+                .tool_payload_history
+                .iter()
+                .map(ToolPayload::from)
+                .collect(),
+            continuation_messages: state.continuation_messages.as_ref().map(|c| {
+                SerializableStreamContinuation {
+                    api_messages: c.api_messages.clone(),
+                    api_messages_base: c.api_messages_base.clone(),
+                }
+            }),
+        }
+    }
+}
+
+/// Serializable wrapper for McpInitState.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializableMcpInitState {
+    pub in_progress: bool,
+    pub complete: bool,
+    pub deferred_message: Option<String>,
+}
+
+impl From<&McpInitState> for SerializableMcpInitState {
+    fn from(state: &McpInitState) -> Self {
+        Self {
+            in_progress: state.in_progress,
+            complete: state.complete,
+            deferred_message: state.deferred_message.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Directory helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the directory where session files are stored.
+///
+/// Uses `~/.local/share/chabeau/sessions/` (XDG_DATA_HOME) on Linux, or the
+/// platform-equivalent data directory on other platforms.
+fn session_dir() -> Result<PathBuf, SessionError> {
+    let base = if let Some(override_dir) = std::env::var_os("CHABEAU_DATA_DIR") {
+        PathBuf::from(override_dir)
+    } else {
+        let proj_dirs = directories::BaseDirs::new().ok_or_else(|| SessionError::CreateDir {
+            path: PathBuf::new(),
+            source: std::io::Error::new(std::io::ErrorKind::Other, "no user home directory"),
+        })?;
+        proj_dirs.data_local_dir().join("chabeau").join("sessions")
+    };
+    let base_clone = base.clone();
+    fs::create_dir_all(&base).map_err(|source| SessionError::CreateDir {
+        path: base_clone,
+        source,
+    })?;
+    Ok(base)
+}
+
+/// Returns the full path for a session file given its ID.
+fn session_path(id: &str) -> Result<PathBuf, SessionError> {
+    Ok(session_dir()?.join(format!("{}.json", id)))
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Create a new session snapshot from the current App state.
+///
+/// Captures the conversation transcript, tool results, and session context
+/// (provider, model, character, persona, preset). API keys are not included.
+pub fn save_session(
+    session_id: &str,
+    name: &str,
+    provider: &str,
+    model: &str,
+    base_url: &str,
+    character: Option<CharacterCard>,
+    persona: Option<Persona>,
+    preset: Option<Preset>,
+    messages: &[Message],
+    tool_results: &[ChatMessage],
+    tool_payloads: &[ToolPayloadHistoryEntry],
+    mcp_init: &McpInitState,
+    refine_instructions: &str,
+    refine_prefix: &str,
+    markdown_enabled: bool,
+    syntax_enabled: bool,
+) -> Result<(), SessionError> {
+    let now = Utc::now();
+    let snapshot = SessionSnapshot {
+        id: session_id.to_string(),
+        name: name.to_string(),
+        provider: provider.to_string(),
+        model: model.to_string(),
+        base_url: base_url.to_string(),
+        character,
+        persona,
+        preset,
+        messages: messages.to_vec(),
+        tool_results: tool_results.to_vec(),
+        tool_payloads: tool_payloads.iter().map(ToolPayload::from).collect(),
+        mcp_init_complete: mcp_init.complete,
+        refine_instructions: refine_instructions.to_string(),
+        refine_prefix: refine_prefix.to_string(),
+        markdown_enabled,
+        syntax_enabled,
+        created_at: now,
+        modified_at: now,
+    };
+
+    let path = session_path(&snapshot.id)?;
+    let contents =
+        serde_json::to_string_pretty(&snapshot).map_err(|source| SessionError::Parse {
+            path: path.clone(),
+            source,
+        })?;
+
+    // Write atomically via temp file in the same directory
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let mut temp =
+        tempfile::NamedTempFile::new_in(parent).map_err(|source| SessionError::Write {
+            path: path.clone(),
+            source,
+        })?;
+    temp.write_all(contents.as_bytes())
+        .map_err(|source| SessionError::Write {
+            path: path.clone(),
+            source,
+        })?;
+    temp.as_file()
+        .sync_all()
+        .map_err(|source| SessionError::Write {
+            path: path.clone(),
+            source,
+        })?;
+    temp.persist(&path).map_err(|source| SessionError::Write {
+        path: path.clone(),
+        source: std::io::Error::new(std::io::ErrorKind::Other, source),
+    })?;
+
+    Ok(())
+}
+
+/// Load a session snapshot from disk by ID.
+pub fn load_session(id: &str) -> Result<SessionSnapshot, SessionError> {
+    let path = session_path(id)?;
+    let contents = fs::read_to_string(&path).map_err(|source| SessionError::ReadFile {
+        path: path.clone(),
+        source,
+    })?;
+    let snapshot: SessionSnapshot =
+        serde_json::from_str(&contents).map_err(|source| SessionError::Parse {
+            path: path.clone(),
+            source,
+        })?;
+    Ok(snapshot)
+}
+
+/// List all saved sessions, sorted by modified_at descending (newest first).
+pub fn list_sessions() -> Result<Vec<SessionSummary>, SessionError> {
+    let dir = session_dir()?;
+    let entries = dir.read_dir().map_err(|source| SessionError::ReadDir {
+        path: dir.clone(),
+        source,
+    })?;
+
+    let mut summaries = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| SessionError::ReadDir {
+            path: dir.clone(),
+            source,
+        })?;
+        let filename = entry.file_name().to_string_lossy().trim_end().to_string();
+        if !filename.ends_with(".json") {
+            continue;
+        }
+
+        // Try to load the summary without full validation
+        let path = entry.path();
+        let contents = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let snapshot: SessionSnapshot = match serde_json::from_str(&contents) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        summaries.push(SessionSummary {
+            id: snapshot.id,
+            name: snapshot.name,
+            provider: snapshot.provider,
+            model: snapshot.model,
+            character: snapshot.character.as_ref().map(|c| c.data.name.clone()),
+            persona: snapshot.persona.as_ref().map(|p| p.display_name.clone()),
+            preset: snapshot.preset.as_ref().map(|p| p.id.clone()),
+            message_count: snapshot.messages.len(),
+            modified_at: snapshot.modified_at,
+        });
+    }
+
+    summaries.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+    Ok(summaries)
+}
+
+/// Delete a session file by ID.
+pub fn delete_session(id: &str) -> Result<(), SessionError> {
+    let path = session_path(id)?;
+    fs::remove_file(&path).map_err(|source| SessionError::Delete { path, source })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::message::{Message, TranscriptRole};
+    use std::env;
+    use std::sync::{LazyLock, Mutex};
+
+    static TEST_ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn with_data_dir<F, R>(dir: &Path, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let _lock = TEST_ENV_MUTEX.lock().unwrap();
+        let old = env::var("CHABEAU_DATA_DIR").ok();
+        env::set_var("CHABEAU_DATA_DIR", dir);
+        let result = f();
+        if let Some(val) = old {
+            env::set_var("CHABEAU_DATA_DIR", val);
+        } else {
+            env::remove_var("CHABEAU_DATA_DIR");
+        }
+        result
+    }
+
+    fn make_test_messages() -> Vec<Message> {
+        vec![
+            Message::new(TranscriptRole::User, "Hello, world!"),
+            Message::new(TranscriptRole::Assistant, "Hi there!"),
+            Message::new(TranscriptRole::User, "How are you?"),
+        ]
+    }
+
+    fn make_test_tool_results() -> Vec<ChatMessage> {
+        vec![ChatMessage {
+            role: "tool".to_string(),
+            content: "tool output".to_string(),
+            name: None,
+            tool_call_id: Some("call-1".to_string()),
+            tool_calls: None,
+        }]
+    }
+
+    fn make_test_tool_payloads() -> Vec<ToolPayloadHistoryEntry> {
+        vec![ToolPayloadHistoryEntry {
+            server_id: Some("test-server".to_string()),
+            tool_call_id: Some("call-1".to_string()),
+            assistant_message: ChatMessage {
+                role: "assistant".to_string(),
+                content: "calling tool".to_string(),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            },
+            tool_message: ChatMessage {
+                role: "tool".to_string(),
+                content: "tool result".to_string(),
+                name: None,
+                tool_call_id: Some("call-1".to_string()),
+                tool_calls: None,
+            },
+            assistant_message_index: Some(1),
+        }]
+    }
+
+    fn save_test_session(session_id: &str, name: &str) {
+        let character = Some(CharacterCard {
+            spec: "chara_card_v2".to_string(),
+            spec_version: "2.0".to_string(),
+            data: crate::character::card::CharacterData {
+                name: "test-char".to_string(),
+                description: "Test character".to_string(),
+                personality: "Friendly".to_string(),
+                scenario: "Testing".to_string(),
+                first_mes: "Hello!".to_string(),
+                mes_example: String::new(),
+                creator_notes: None,
+                system_prompt: None,
+                post_history_instructions: None,
+                alternate_greetings: None,
+                tags: None,
+                creator: None,
+                character_version: None,
+            },
+        });
+        let persona = Some(Persona {
+            id: "test-persona".to_string(),
+            display_name: "Test Persona".to_string(),
+            bio: None,
+        });
+        let preset = Some(Preset {
+            id: "test-preset".to_string(),
+            pre: String::new(),
+            post: String::new(),
+        });
+
+        save_session(
+            session_id,
+            name,
+            "test-provider",
+            "test-model",
+            "https://example.com/v1",
+            character,
+            persona,
+            preset,
+            &make_test_messages(),
+            &make_test_tool_results(),
+            &make_test_tool_payloads(),
+            &McpInitState {
+                in_progress: false,
+                complete: true,
+                deferred_message: None,
+            },
+            "refine instructions",
+            "refine prefix",
+            true,
+            true,
+        )
+        .expect("save");
+    }
+
+    #[test]
+    fn session_save_load_roundtrip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let snapshot = with_data_dir(dir.path(), || {
+            save_test_session("test-001", "Roundtrip Test");
+            load_session("test-001").expect("load")
+        });
+
+        assert_eq!(snapshot.id, "test-001");
+        assert_eq!(snapshot.name, "Roundtrip Test");
+        assert_eq!(snapshot.provider, "test-provider");
+        assert_eq!(snapshot.model, "test-model");
+        assert_eq!(snapshot.base_url, "https://example.com/v1");
+        assert_eq!(snapshot.character.as_ref().map(|c| c.data.name.as_str()), Some("test-char"));
+        assert_eq!(snapshot.persona.as_ref().map(|p| p.id.as_str()), Some("test-persona"));
+        assert_eq!(snapshot.preset.as_ref().map(|p| p.id.as_str()), Some("test-preset"));
+        assert_eq!(snapshot.messages.len(), 3);
+        assert_eq!(snapshot.messages[0].role, TranscriptRole::User);
+        assert_eq!(snapshot.messages[0].content, "Hello, world!");
+        assert_eq!(snapshot.tool_results.len(), 1);
+        assert_eq!(snapshot.tool_payloads.len(), 1);
+        assert!(snapshot.mcp_init_complete);
+        assert_eq!(snapshot.refine_instructions, "refine instructions");
+        assert_eq!(snapshot.refine_prefix, "refine prefix");
+        assert!(snapshot.markdown_enabled);
+        assert!(snapshot.syntax_enabled);
+    }
+
+    #[test]
+    fn session_save_with_optional_none_fields() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let snapshot = with_data_dir(dir.path(), || {
+            save_session(
+                "test-none",
+                "No Optionals",
+                "prov",
+                "mod",
+                "https://example.com/v1",
+                None,
+                None,
+                None,
+                &[],
+                &[],
+                &[],
+                &McpInitState::default(),
+                "",
+                "",
+                false,
+                false,
+            )
+            .expect("save");
+            load_session("test-none").expect("load")
+        });
+        assert!(snapshot.character.is_none());
+        assert!(snapshot.persona.is_none());
+        assert!(snapshot.preset.is_none());
+        assert!(snapshot.messages.is_empty());
+        assert!(!snapshot.mcp_init_complete);
+        assert!(!snapshot.markdown_enabled);
+        assert!(!snapshot.syntax_enabled);
+    }
+
+    #[test]
+    fn session_save_creates_json_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        with_data_dir(dir.path(), || {
+            save_test_session("test-file", "File Test");
+        });
+
+        let path = dir.path().join("test-file.json");
+        assert!(path.exists(), "session file should exist");
+        let contents = fs::read_to_string(&path).expect("read file");
+        assert!(contents.contains("File Test"));
+    }
+
+    #[test]
+    fn session_save_overwrites_existing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let snapshot = with_data_dir(dir.path(), || {
+            save_test_session("test-overwrite", "Version 1");
+            save_test_session("test-overwrite", "Version 2");
+            load_session("test-overwrite").expect("load")
+        });
+        assert_eq!(snapshot.name, "Version 2");
+    }
+
+    #[test]
+    fn session_list_returns_summaries_sorted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let sessions = with_data_dir(dir.path(), || {
+            save_test_session("sess-a", "Session A");
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            save_test_session("sess-b", "Session B");
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            save_test_session("sess-c", "Session C");
+            list_sessions().expect("list")
+        });
+
+        assert_eq!(sessions.len(), 3);
+        assert_eq!(sessions[0].id, "sess-c");
+        assert_eq!(sessions[1].id, "sess-b");
+        assert_eq!(sessions[2].id, "sess-a");
+        assert_eq!(sessions[0].message_count, 3);
+        assert_eq!(sessions[0].provider, "test-provider");
+        assert_eq!(sessions[0].model, "test-model");
+    }
+
+    #[test]
+    fn session_list_skips_corrupt_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions = with_data_dir(dir.path(), || {
+            save_test_session("valid", "Valid Session");
+
+            fs::write(dir.path().join("corrupt.json"), "not json{{{").expect("write corrupt");
+            fs::write(dir.path().join("readme.txt"), "hello").expect("write txt");
+
+            list_sessions().expect("list")
+        });
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, "valid");
+    }
+
+    #[test]
+    fn session_delete_removes_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        with_data_dir(dir.path(), || {
+            save_test_session("test-delete", "To Delete");
+            let sess_path = dir.path().join("test-delete.json");
+            assert!(sess_path.exists());
+
+            delete_session("test-delete").expect("delete");
+            assert!(!sess_path.exists());
+        });
+    }
+
+    #[test]
+    fn session_delete_nonexistent_returns_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = with_data_dir(dir.path(), || delete_session("nonexistent"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_nonexistent_returns_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = with_data_dir(dir.path(), || load_session("does-not-exist"));
+        assert!(result.is_err());
+        match result {
+            Err(SessionError::ReadFile { .. }) => {}
+            other => panic!("expected ReadFile error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn load_corrupt_json_returns_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = with_data_dir(dir.path(), || {
+            fs::write(dir.path().join("bad.json"), "{{{invalid json}}}").expect("write corrupt");
+            load_session("bad")
+        });
+
+        assert!(result.is_err());
+        match result {
+            Err(SessionError::Parse { .. }) => {}
+            other => panic!("expected Parse error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn chabeau_data_dir_env_override() {
+        let custom_dir = tempfile::tempdir().expect("tempdir");
+        let sessions = with_data_dir(custom_dir.path(), || {
+            save_test_session("env-test", "Env Override");
+            list_sessions().expect("list")
+        });
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, "env-test");
+    }
+
+    #[test]
+    fn tool_payload_conversion_roundtrip() {
+        let entry = ToolPayloadHistoryEntry {
+            server_id: Some("srv-1".to_string()),
+            tool_call_id: Some("tc-42".to_string()),
+            assistant_message: ChatMessage {
+                role: "assistant".to_string(),
+                content: "calling weather".to_string(),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            },
+            tool_message: ChatMessage {
+                role: "tool".to_string(),
+                content: "sunny, 25C".to_string(),
+                name: None,
+                tool_call_id: Some("tc-42".to_string()),
+                tool_calls: None,
+            },
+            assistant_message_index: Some(3),
+        };
+
+        let payload = ToolPayload::from(&entry);
+
+        assert_eq!(payload.server_id, entry.server_id);
+        assert_eq!(payload.tool_call_id, entry.tool_call_id);
+        assert_eq!(
+            payload.assistant_message.content,
+            entry.assistant_message.content
+        );
+        assert_eq!(payload.tool_message.content, entry.tool_message.content);
+        assert_eq!(
+            payload.assistant_message_index,
+            entry.assistant_message_index
+        );
+    }
+
+    #[test]
+    fn serializable_tool_pipeline_conversion() {
+        let mut state = ToolPipelineState::default();
+        state.pending_tool_calls.insert(
+            1,
+            crate::core::app::session::PendingToolCall {
+                id: Some("id-1".to_string()),
+                name: Some("weather".to_string()),
+                arguments: "{}".to_string(),
+            },
+        );
+        state
+            .pending_tool_queue
+            .push_back(crate::core::app::session::ToolCallRequest {
+                server_id: "srv".to_string(),
+                tool_name: "lookup".to_string(),
+                arguments: None,
+                raw_arguments: "{}".to_string(),
+                tool_call_id: None,
+            });
+        state.set_continuation(
+            vec![ChatMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            }],
+            vec![],
+        );
+
+        let serializable = SerializableToolPipeline::from(&state);
+
+        assert_eq!(serializable.pending_tool_calls.len(), 1);
+        assert_eq!(serializable.pending_tool_queue.len(), 1);
+        assert!(serializable.continuation_messages.is_some());
+        assert_eq!(
+            serializable.continuation_messages.unwrap().api_messages[0].content,
+            "hi"
+        );
+    }
+
+    #[test]
+    fn serializable_mcp_init_conversion() {
+        let state = McpInitState {
+            in_progress: true,
+            complete: false,
+            deferred_message: Some("wait for init".to_string()),
+        };
+
+        let serializable = SerializableMcpInitState::from(&state);
+
+        assert!(serializable.in_progress);
+        assert!(!serializable.complete);
+        assert_eq!(
+            serializable.deferred_message,
+            Some("wait for init".to_string())
+        );
+    }
+}

--- a/src/ui/chat_loop/event_loop.rs
+++ b/src/ui/chat_loop/event_loop.rs
@@ -188,7 +188,7 @@ async fn route_keyboard_event(
 ) -> Result<KeyboardEventOutcome, Box<dyn Error>> {
     let context = app
         .read(|app| {
-            let picker_open = app.picker_session().is_some();
+            let picker_open = app.active_picker().is_some();
             KeyContext::from_ui_mode(&app.ui.mode, picker_open)
         })
         .await;

--- a/src/ui/chat_loop/event_loop.rs
+++ b/src/ui/chat_loop/event_loop.rs
@@ -63,6 +63,7 @@ pub struct RunChatOptions {
     pub preset: Option<String>,
     pub disable_mcp: bool,
     pub character_service: CharacterService,
+    pub session: Option<String>,
 }
 
 #[derive(Debug)]
@@ -772,6 +773,7 @@ pub async fn run_chat(options: RunChatOptions) -> Result<(), Box<dyn Error>> {
     };
 
     event_reader_handle.abort();
+
     restore_terminal(&terminal).await?;
 
     let (should_print, last_term_size) = app

--- a/src/ui/chat_loop/event_loop.rs
+++ b/src/ui/chat_loop/event_loop.rs
@@ -188,12 +188,7 @@ async fn route_keyboard_event(
 ) -> Result<KeyboardEventOutcome, Box<dyn Error>> {
     let context = app
         .read(|app| {
-            let picker_open = app.model_picker_state().is_some()
-                || app.theme_picker_state().is_some()
-                || app.provider_picker_state().is_some()
-                || app.character_picker_state().is_some()
-                || app.persona_picker_state().is_some()
-                || app.preset_picker_state().is_some();
+            let picker_open = app.picker_session().is_some();
             KeyContext::from_ui_mode(&app.ui.mode, picker_open)
         })
         .await;

--- a/src/ui/chat_loop/event_loop_tests.rs
+++ b/src/ui/chat_loop/event_loop_tests.rs
@@ -133,7 +133,7 @@ async fn session_picker_character_keys_do_not_fall_through_to_input() {
     app.update(|app| {
         app.ui.set_input_text(String::new());
         app.ui.focus_input();
-        app.picker.open_session_picker(
+        app.picker.open_saved_session_picker(
             Vec::new(),
             vec![PickerItem {
                 id: "sess-alpha".to_string(),
@@ -165,7 +165,7 @@ async fn session_picker_character_keys_do_not_fall_through_to_input() {
         .read(|app| {
             (
                 app.ui.get_input_text().to_string(),
-                app.picker_session().is_some(),
+                app.active_picker().is_some(),
             )
         })
         .await;

--- a/src/ui/chat_loop/event_loop_tests.rs
+++ b/src/ui/chat_loop/event_loop_tests.rs
@@ -6,6 +6,7 @@ use crate::core::app::actions::{
 use crate::core::app::ui_state::EditSelectTarget;
 use crate::core::app::App;
 use crate::core::message::{self, Message, TranscriptRole};
+use crate::ui::picker::PickerItem;
 use crate::ui::theme::Theme;
 use crate::utils::test_utils::create_test_app;
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -124,6 +125,52 @@ async fn tab_toggles_focus_without_slash_prefix() {
 
     assert!(outcome.request_redraw);
     assert!(app.read(|app| app.ui.is_transcript_focused()).await);
+}
+
+#[tokio::test]
+async fn session_picker_character_keys_do_not_fall_through_to_input() {
+    let app = new_app_handle();
+    app.update(|app| {
+        app.ui.set_input_text(String::new());
+        app.ui.focus_input();
+        app.picker.open_session_picker(
+            Vec::new(),
+            vec![PickerItem {
+                id: "sess-alpha".to_string(),
+                label: "Alpha Session".to_string(),
+                metadata: Some("openai | gpt-4".to_string()),
+                inspect_metadata: None,
+                sort_key: None,
+            }],
+        );
+    })
+    .await;
+
+    let dispatcher = new_dispatcher();
+    let mode_registry = ModeAwareRegistry::new();
+    let mut last_update = Instant::now();
+
+    let _outcome = route_keyboard_event(
+        &app,
+        &mode_registry,
+        &dispatcher,
+        KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+        Size::new(TERM_WIDTH, TERM_HEIGHT),
+        &mut last_update,
+    )
+    .await
+    .expect("session picker key routing should succeed");
+
+    let (input, picker_open) = app
+        .read(|app| {
+            (
+                app.ui.get_input_text().to_string(),
+                app.picker_session().is_some(),
+            )
+        })
+        .await;
+    assert_eq!(input, "");
+    assert!(picker_open);
 }
 
 #[tokio::test]

--- a/src/ui/chat_loop/keybindings/handlers.rs
+++ b/src/ui/chat_loop/keybindings/handlers.rs
@@ -1034,7 +1034,7 @@ impl KeyHandler for PickerHandler {
         _last_input_layout_update: Option<Instant>,
     ) -> KeyResult {
         // Check if there's a picker session before handling the key
-        let had_picker_before = app.read(|app| app.picker_session().is_some()).await;
+        let had_picker_before = app.read(|app| app.active_picker().is_some()).await;
 
         handle_picker_key_event(app, dispatcher, key, term_width, term_height).await;
 

--- a/src/ui/chat_loop/setup.rs
+++ b/src/ui/chat_loop/setup.rs
@@ -32,6 +32,7 @@ pub async fn bootstrap_app(
         preset,
         disable_mcp,
         character_service,
+        session,
     } = options;
     let config = Config::load()?;
     let auth_manager = AuthManager::new()?;
@@ -105,7 +106,7 @@ pub async fn bootstrap_app(
 
     let mut character_service = Some(character_service);
 
-    let app = if open_provider_picker {
+    let mut app = if open_provider_picker {
         let service = character_service
             .take()
             .expect("character service should be available");
@@ -182,6 +183,14 @@ pub async fn bootstrap_app(
 
         app
     };
+
+    // Load session if specified via --session CLI flag
+    if let Some(ref session_id) = session {
+        if let Err(e) = crate::commands::do_load_session(&mut app, session_id) {
+            eprintln!("Error: Failed to load session '{}': {}", session_id, e);
+            std::process::exit(1);
+        }
+    }
 
     let app = Arc::new(Mutex::new(app));
 

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -613,6 +613,9 @@ fn input_title_base(app: &App, input_width: u16) -> Cow<'_, str> {
             Some(crate::core::app::PickerMode::Preset) => {
                 Cow::Borrowed("Select a preset (Esc=cancel • Ctrl+C=quit)")
             }
+            Some(crate::core::app::PickerMode::SessionLoad) => {
+                Cow::Borrowed("Select a session (Esc=cancel • Ctrl+C=quit)")
+            }
             _ => Cow::Borrowed("Make a selection (Esc=cancel • Ctrl+C=quit)"),
         }
     } else if let Some(prompt) = app.ui.tool_prompt() {
@@ -844,6 +847,10 @@ fn generate_picker_help_text(app: &App) -> String {
             .unwrap_or(""),
         Some(crate::core::app::PickerMode::Preset) => app
             .preset_picker_state()
+            .map(|state| state.search_filter.as_str())
+            .unwrap_or(""),
+        Some(crate::core::app::PickerMode::SessionLoad) => app
+            .session_load_picker_state()
             .map(|state| state.search_filter.as_str())
             .unwrap_or(""),
         _ => "",

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -371,7 +371,7 @@ pub fn ui(f: &mut Frame, app: &mut App) {
 
         // Set cursor based on wrapped text and linear cursor position
         // Suppress cursor when picker is open (like Ctrl+B/Ctrl+P modes)
-        if app.ui.is_input_active() && app.ui.is_input_focused() && app.picker_session().is_none() {
+        if app.ui.is_input_active() && app.ui.is_input_focused() && app.active_picker().is_none() {
             let (line, col) = TextWrapper::calculate_cursor_position_in_wrapped_text(
                 app.ui.get_input_text(),
                 app.ui.get_input_cursor_position(),
@@ -446,7 +446,7 @@ pub fn ui(f: &mut Frame, app: &mut App) {
         let inspect_state = app.inspect_state();
         let inspect_mode = inspect_state.map(|state| state.mode);
         let decoded = inspect_state.map(|state| state.decoded).unwrap_or(false);
-        let in_picker = app.picker_session().is_some();
+        let in_picker = app.active_picker().is_some();
         let (line1, line2): (String, String) = match inspect_mode {
             Some(InspectMode::ToolCalls { view, kind, .. }) => {
                 let toggle_label = match (kind, view) {
@@ -592,7 +592,7 @@ fn input_title_base(app: &App, input_width: u16) -> Cow<'_, str> {
         }
     } else if app.ui.in_block_select_mode() {
         Cow::Borrowed("Select code block (↑/↓ • c=Copy • s=Save • Esc=Cancel)")
-    } else if app.picker_session().is_some() {
+    } else if app.active_picker().is_some() {
         // Show specific prompt for picker mode with global shortcuts
         match app.current_picker_mode() {
             Some(crate::core::app::PickerMode::Model) => {
@@ -613,7 +613,7 @@ fn input_title_base(app: &App, input_width: u16) -> Cow<'_, str> {
             Some(crate::core::app::PickerMode::Preset) => {
                 Cow::Borrowed("Select a preset (Esc=cancel • Ctrl+C=quit)")
             }
-            Some(crate::core::app::PickerMode::SessionLoad) => {
+            Some(crate::core::app::PickerMode::SavedSession) => {
                 Cow::Borrowed("Select a session (Esc=cancel • Ctrl+C=quit)")
             }
             _ => Cow::Borrowed("Make a selection (Esc=cancel • Ctrl+C=quit)"),
@@ -849,8 +849,8 @@ fn generate_picker_help_text(app: &App) -> String {
             .preset_picker_state()
             .map(|state| state.search_filter.as_str())
             .unwrap_or(""),
-        Some(crate::core::app::PickerMode::SessionLoad) => app
-            .session_load_picker_state()
+        Some(crate::core::app::PickerMode::SavedSession) => app
+            .saved_session_picker_state()
             .map(|state| state.search_filter.as_str())
             .unwrap_or(""),
         _ => "",
@@ -997,7 +997,7 @@ fn apply_code_block_highlight(
 mod tests {
     use super::*;
     use crate::core::app::picker::{
-        CharacterPickerState, ModelPickerState, PickerData, PickerSession, ProviderPickerState,
+        ActivePicker, CharacterPickerState, ModelPickerState, PickerData, ProviderPickerState,
         ThemePickerState,
     };
     use crate::core::app::{apply_actions, AppAction, AppActionContext, AppActionEnvelope};
@@ -1017,7 +1017,7 @@ mod tests {
         has_dates: bool,
     ) {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
-        app.picker.picker_session = Some(PickerSession {
+        app.picker.active_picker = Some(ActivePicker {
             state: picker_state,
             data: PickerData::Model(Box::new(ModelPickerState {
                 search_filter: search_filter.to_string(),
@@ -1035,7 +1035,7 @@ mod tests {
         selected: usize,
     ) {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
-        app.picker.picker_session = Some(PickerSession {
+        app.picker.active_picker = Some(ActivePicker {
             state: picker_state,
             data: PickerData::Theme(Box::new(ThemePickerState {
                 search_filter: search_filter.to_string(),
@@ -1053,7 +1053,7 @@ mod tests {
         selected: usize,
     ) {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
-        app.picker.picker_session = Some(PickerSession {
+        app.picker.active_picker = Some(ActivePicker {
             state: picker_state,
             data: PickerData::Provider(Box::new(ProviderPickerState {
                 search_filter: search_filter.to_string(),
@@ -1070,7 +1070,7 @@ mod tests {
         selected: usize,
     ) {
         let picker_state = PickerState::new("Test".to_string(), items.clone(), selected);
-        app.picker.picker_session = Some(PickerSession {
+        app.picker.active_picker = Some(ActivePicker {
             state: picker_state,
             data: PickerData::Character(CharacterPickerState {
                 search_filter: search_filter.to_string(),


### PR DESCRIPTION
Make it possible to save sessions and re-load them to continue.

- New `/save`, `/load`, `/sessions` commands for session management
- `--session` command line argument to start with a session
- Session files stored as JSON under `~/.local/share/chabeau/sessions/`
- SessionState captures: messages, tool results, MCP init state, persona, preset, character, provider/model, markdown/syntax settings
- Picker for browsing and loading saved sessions
- Add unit and handler tests for the new functionality